### PR TITLE
Clarify UCP interview guidance

### DIFF
--- a/skills/specops-interview/SKILL.md
+++ b/skills/specops-interview/SKILL.md
@@ -49,11 +49,16 @@ entrypoint for discovery before the canonical model or generated artifacts exist
 - Do not open with raw UCP scoring.
 - Only ask for actor and use-case complexity after the discovery baseline is stable.
 - Explain the UCP scale briefly before asking for scores.
+- Correct the most common intuition mismatch explicitly:
+  - system/API actors are often `simple`
+  - human actors using a richer UI are often `complex`
+- Explain that `0-5` factor inputs are influence scores, not quality grades.
 - Ask for UCP values in small groups:
   - actor complexity
   - use-case complexity
   - technical factors
   - environmental factors
+- For environmental factors, state clearly which higher values are positive and which indicate drag.
 - When helpful, apply a reasonable provisional value and label it clearly as an assumption instead
   of forcing the user through an awkward scoring wall.
 

--- a/skills/specops-interview/references/interview-rounds.md
+++ b/skills/specops-interview/references/interview-rounds.md
@@ -90,6 +90,9 @@ Explain the scale first:
 - `simple`: system/API actor
 - `average`: human with simpler interaction
 - `complex`: human with richer interactive UI
+- remind the user that UCP actor complexity is often the opposite of product importance intuition
+- explicitly say that a downstream API consumer is often `simple` while a human using a richer web UI
+  is often `complex`
 
 Ask for actor complexity in a short list only.
 
@@ -108,6 +111,8 @@ Explain the scale first:
 - `simple`: few transactions
 - `average`: moderate flow
 - `complex`: longer flow, more rules, more branching or approvals
+- rate the interaction flow itself, not how strategically important the business topic feels
+- if needed, give one example before asking for the classifications
 
 Ask only for the main use cases already identified.
 
@@ -124,8 +129,14 @@ Use-case complexity:
 Explain the influence scale briefly:
 
 - `0`: not relevant
+- `1`: very low influence
+- `2`: low influence
 - `3`: moderate influence
+- `4`: high influence
 - `5`: very high influence
+- state clearly that this is an influence scale, not a quality score
+- if helpful, give one or two starting defaults for a typical internal enterprise system instead of
+  forcing the user to reason from a blank page
 
 Ask the technical factors in 2 smaller groups if needed instead of one giant block.
 
@@ -146,6 +157,9 @@ Use the same `0-5` influence explanation, but state clearly that:
 
 - higher is better for familiarity, capability, motivation, and stability
 - higher is worse for part-time staffing and platform difficulty
+- call out these reversed-sign factors explicitly when asking, because they are easy to answer
+  backwards
+- if the user does not know, prefer a provisional assumption labeled as such over a fake precise score
 
 Preferred answer shape:
 

--- a/src/specops_tools/interview.py
+++ b/src/specops_tools/interview.py
@@ -84,6 +84,8 @@ class InterviewQuestion:
     key: str
     label: str
     prompt: str
+    guidance: tuple[str, ...] = ()
+    example: str | None = None
 
 
 @dataclass(frozen=True)
@@ -95,6 +97,7 @@ class InterviewRound:
     prompt: str
     template: str
     questions: tuple[InterviewQuestion, ...]
+    guidance: tuple[str, ...] = ()
 
 
 ROUND_DEFINITIONS: list[InterviewRound] = [
@@ -195,11 +198,23 @@ ROUND_DEFINITIONS: list[InterviewRound] = [
             "Capture actor complexity using simple/average/complex after discovery is stable."
         ),
         template="Actor complexity:\n- Actor A: simple/average/complex\n",
+        guidance=(
+            "Use standard UCP semantics, not general product complexity intuition.",
+            "System or API actors are usually simpler than humans using a rich UI.",
+            "If a classification is uncertain, state the assumption instead of forcing false precision.",
+        ),
         questions=(
             InterviewQuestion(
                 "actor_complexity",
                 "Actor complexity",
                 "How should each actor be classified for UCP?",
+                guidance=(
+                    "`simple` usually means a system or API actor.",
+                    "`average` usually means a human with a simpler interaction pattern.",
+                    "`complex` usually means a human using a richer interactive UI.",
+                    "A human actor is often more complex than an API actor in UCP.",
+                ),
+                example="- Downstream reporting API: simple\n- Enterprise architect: complex",
             ),
         ),
     ),
@@ -208,11 +223,21 @@ ROUND_DEFINITIONS: list[InterviewRound] = [
         title="UCP Use-Case Complexity",
         prompt="Capture use-case complexity using simple/average/complex.",
         template="Use-case complexity:\n- Use case A: simple/average/complex\n",
+        guidance=(
+            "Classify the use case based on transaction count, branching, rules, and approvals.",
+            "Do not rate a use case as complex just because the business topic feels important.",
+        ),
         questions=(
             InterviewQuestion(
                 "use_case_complexity",
                 "Use-case complexity",
                 "How should each use case be classified for UCP?",
+                guidance=(
+                    "`simple` means few transactions and little branching.",
+                    "`average` means a moderate flow.",
+                    "`complex` means longer flows, more branching, more rules, or approvals.",
+                ),
+                example="- Edit metadata: average\n- Approve deprecation: complex",
             ),
         ),
     ),
@@ -225,11 +250,21 @@ ROUND_DEFINITIONS: list[InterviewRound] = [
             "distributed system:\nresponse time:\nend-user efficiency:\n"
             "complex internal processing:\nreusability:\nease of installation:\n"
         ),
+        guidance=(
+            "Use a 0-5 influence scale, not a good-versus-bad scale.",
+            "`0` means not relevant, `3` means moderate influence, and `5` means very high influence.",
+            "Score how strongly the factor shapes the system, not whether the team is performing well.",
+        ),
         questions=(
             InterviewQuestion(
                 "technical",
                 "Technical",
                 "What technical 0-5 influence scores apply?",
+                guidance=(
+                    "Security and third-party access are often high for internal enterprise systems.",
+                    "Response time should reflect business importance, not an arbitrary SLA guess.",
+                ),
+                example="security: 5\nthird-party access: 4\nease of change: 4",
             ),
         ),
     ),
@@ -241,11 +276,21 @@ ROUND_DEFINITIONS: list[InterviewRound] = [
             "Environmental:\nteam familiarity:\napplication experience:\n"
             "architecture experience:\nanalyst capability:\nmotivation:\n"
         ),
+        guidance=(
+            "Use the same 0-5 influence scale, but note that some factors are positive and some are drag.",
+            "Higher is better for familiarity, experience, capability, motivation, and stability.",
+            "Higher is worse for part-time staffing and platform difficulty.",
+        ),
         questions=(
             InterviewQuestion(
                 "environmental",
                 "Environmental",
                 "What environmental 0-5 scores apply?",
+                guidance=(
+                    "If requirements are volatile, keep requirements stability low.",
+                    "If the team is split or part-time, part-time staffing should be scored higher.",
+                ),
+                example="team familiarity: 3\nteam motivation: 4\npart-time staffing: 2",
             ),
         ),
     ),
@@ -284,11 +329,14 @@ def _round_payload(round_definition: InterviewRound) -> dict[str, Any]:
         "title": round_definition.title,
         "prompt": round_definition.prompt,
         "template": round_definition.template,
+        "guidance": list(round_definition.guidance),
         "questions": [
             {
                 "key": question.key,
                 "label": question.label,
                 "prompt": question.prompt,
+                "guidance": list(question.guidance),
+                "example": question.example,
             }
             for question in round_definition.questions
         ],

--- a/tests/test_interview.py
+++ b/tests/test_interview.py
@@ -8,7 +8,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from specops_tools.interview import process_round, replay_session
+from specops_tools.interview import get_round, process_round, replay_session
 
 
 class InterviewHarnessTests(unittest.TestCase):
@@ -107,6 +107,44 @@ class InterviewHarnessTests(unittest.TestCase):
         payload = json.loads(completed.stdout)
         self.assertEqual(payload["parsed_answers"]["idea"], "IT systems inventory")
         self.assertEqual(payload["next_round"]["number"], 2)
+
+    def test_ucp_actor_round_exposes_inversion_guidance(self) -> None:
+        """Round 5 should explain the common actor complexity intuition mismatch."""
+        round_definition = get_round(5)
+
+        self.assertIn(
+            "System or API actors are usually simpler than humans using a rich UI.",
+            round_definition.guidance,
+        )
+        question = round_definition.questions[0]
+        self.assertIn("`simple` usually means a system or API actor.", question.guidance)
+        self.assertIn("Enterprise architect: complex", question.example)
+
+    def test_technical_factor_round_exposes_0_to_5_guidance(self) -> None:
+        """Round 7 should clarify that the factor scale is about influence, not quality."""
+        result = process_round(
+            7,
+            (
+                "Technical:\n"
+                "security: 5\n"
+                "third-party access: 4\n"
+                "ease of change: 4\n"
+            ),
+        )
+
+        self.assertIn(
+            "Use a 0-5 influence scale, not a good-versus-bad scale.",
+            result["round"]["guidance"],
+        )
+        self.assertIn(
+            "Score how strongly the factor shapes the system, not whether the team is performing well.",
+            result["round"]["guidance"],
+        )
+        self.assertIn(
+            "Security and third-party access are often high for internal enterprise systems.",
+            result["round"]["questions"][0]["guidance"],
+        )
+        self.assertIn("security: 5", result["round"]["questions"][0]["example"])
 
     def test_replay_cli_reads_fixture(self) -> None:
         """The replay CLI should process a fixture file."""


### PR DESCRIPTION
## Summary
- add explicit guidance for the common UCP actor complexity inversion
- explain the use-case and factor scales more compactly and more accurately
- expose that guidance through the executable interview harness and regression tests

Closes #17