### PR TITLE
Close out V1 documentation status

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -42,12 +42,19 @@ Python in this repository is run with `uv`. Scripts, validation, and documentati
 Architecture, workflow, model definitions, and governance docs are part of the product. They are
 not disposable notes and must remain aligned with the implementation.
 
+### 8. Documentation Must Be Updated With The Change
+
+Every meaningful implementation change must include the documentation updates needed to keep the
+repository truthful. If code, workflow, issue status, or delivery state changes, the relevant docs
+must be updated in the same change rather than deferred indefinitely.
+
 ## Delivery Rules
 
 - V1 scope is software and system requirements discovery
 - one canonical model must drive requirements, use-case, and UCP outputs
 - UML and formal specification translation are future-facing and must not distort V1
 - GitHub issues are the work tracking source of truth for this repo
+- documentation and issue-status documents must be kept current as part of normal delivery work
 
 ## Amendment Process
 
@@ -59,4 +66,3 @@ Changes to this constitution require:
 
 If a proposed change conflicts with an existing principle, the constitution must be updated before
 the implementation is treated as valid.
-

--- a/README.md
+++ b/README.md
@@ -13,6 +13,21 @@ The interview step can be invoked directly as the `$specops-interview` skill.
 The repository is documentation-first and dogfood-oriented. The immediate goal is to use SpecOps to
 specify and improve SpecOps itself.
 
+## V1 Status
+
+SpecOps V1 is delivered.
+
+Delivered in V1:
+
+- first-class interview flow via `$specops-interview`
+- canonical `specops-model` workflow
+- generated `requirements-spec.md`, `use-case-model.md`, and `ucp-estimate.md`
+- deterministic UCP calculation and Markdown rendering utilities
+- dogfooding examples and replayable interview fixtures
+- interview UX and UCP guidance refinements from real usage
+
+Open roadmap work is now V2-oriented, especially UML/formalization and integrations.
+
 ## Repository Layout
 
 - `docs/`: implementation plan, architecture, dogfooding workflow, and GitHub issue map

--- a/docs/github-issue-map.md
+++ b/docs/github-issue-map.md
@@ -1,17 +1,14 @@
 # GitHub Issue Map
 
-This document defines the issue hierarchy to be created in GitHub with `gh`.
+This document records the issue hierarchy used in GitHub and the current delivery status.
 
-## Epics
+## V1 Status
+
+Closed V1 issues:
 
 - `#1` `EPIC: SpecOps V1 repository foundation`
 - `#10` `EPIC: SpecOps V1 interview-to-artifact workflow`
 - `#9` `EPIC: SpecOps V1 dogfooding and validation`
-- `#8` `EPIC: SpecOps V2 UML and formal specification translation`
-- `#7` `EPIC: SpecOps V2 integrations and productization`
-
-## V1 Delivery Issues
-
 - `#6` `Bootstrap SpecOps repository docs, constitution, and architecture`
 - `#5` `Define the canonical specops-model and skill pack scaffold`
 - `#4` `Implement deterministic UCP engine and artifact renderer`
@@ -20,7 +17,14 @@ This document defines the issue hierarchy to be created in GitHub with `gh`.
 - `#16` `Improve interview UX and reduce wall-of-text responses`
 - `#17` `Improve UCP scoring guidance in the interview flow`
 
-## V2 Decomposition for Epic #8
+V1 is complete. Remaining open work is V2.
+
+## Open Epics
+
+- `#8` `EPIC: SpecOps V2 UML and formal specification translation`
+- `#7` `EPIC: SpecOps V2 integrations and productization`
+
+## Open V2 Decomposition for Epic #8
 
 - `#11` `Implement V2 domain and class modeling`
 - `#14` `Implement V2 interaction diagram support`
@@ -33,7 +37,7 @@ This document defines the issue hierarchy to be created in GitHub with `gh`.
 - V1 foundation epic owns repo documentation, constitution, and branch conventions
 - V1 workflow epic owns the orchestrator, subskills, model, renderer, and UCP logic
 - V1 dogfooding epic owns the self-hosting spec, validation loop, and workflow adjustments
-- V2 epics are explicitly future-facing and should not block V1
+- V2 epics are explicitly future-facing and begin after the completed V1 baseline
 
 ## Labels To Use
 

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -1,5 +1,10 @@
 # SpecOps Implementation Plan
 
+## Status
+
+V1 is complete. This document now serves as the implementation record for what was delivered in V1
+and the shape that should be preserved while V2 expands UML/formalization and integration support.
+
 ## Objective
 
 Deliver a reusable Codex-native skill pack for software requirements discovery. The first release
@@ -10,41 +15,50 @@ requirements spec, use-case model, and UCP estimate from that shared model.
 
 ## 1. Repository Foundation
 
-- Create a documentation-first repo structure
-- Establish UV as the Python workflow
-- Add a SpecKit constitution and initial dogfooding spec
+- Delivered: documentation-first repo structure
+- Delivered: UV as the Python workflow
+- Delivered: SpecKit constitution and initial dogfooding spec
 
 ## 2. Skill Pack
 
-- `specops`: orchestrator skill
-- `specops-discovery`: interview and model normalization
-- `specops-use-cases`: actors, use cases, scenarios, complexity
-- `specops-ucp`: deterministic UCP calculation and estimate reporting
+- Delivered: `specops` orchestrator skill
+- Delivered: `specops-interview` first-class interview skill
+- Delivered: `specops-discovery` interview and model normalization skill
+- Delivered: `specops-use-cases` actor, use-case, scenario, and complexity skill
+- Delivered: `specops-ucp` deterministic UCP calculation and estimate reporting skill
 
 ## 3. Canonical Model and Artifacts
 
-- Define `specops-model.yaml` as the canonical project model
-- Keep artifact generation anchored to that model
-- Reserve space for future UML and formal specification outputs
+- Delivered: `specops-model.yaml` as the canonical project model
+- Delivered: artifact generation anchored to that model
+- Delivered: reserved space for future UML and formal specification outputs
 
 ## 4. Deterministic Utilities
 
-- Add a Python UCP engine
-- Add a renderer that turns a model into Markdown artifacts
-- Keep YAML support explicit through `uv sync --extra yaml`
+- Delivered: Python UCP engine
+- Delivered: renderer that turns a model into Markdown artifacts
+- Delivered: explicit YAML support through `uv sync --extra yaml`
+- Delivered: executable interview CLI and replay harness for automated regression testing
 
 ## 5. Dogfooding
 
-- Use SpecOps to spec and prioritize SpecOps itself
-- Keep one active dogfooding loop inside `.specify/specs/`
-- Drive ongoing work from GitHub issues rather than ad hoc notes
+- Delivered: SpecOps used to spec and prioritize SpecOps itself
+- Delivered: active dogfooding loop inside `.specify/specs/`
+- Delivered: work driven from GitHub issues rather than ad hoc notes
+- Delivered: example-feedback pattern to feed workflow friction back into the product
 
-## Immediate Deliverables
+## V1 Deliverables
 
 - Architecture documentation
 - SpecKit constitution
 - Skill pack scaffold
+- First-class interview entry skill
 - UCP engine and renderer
-- Example project model and generated outputs
+- Example project models and generated outputs
+- Executable interview replay fixtures and tests
 - GitHub issue hierarchy for V1 and V2
 
+## Remaining Roadmap
+
+- V2 UML and formal specification translation
+- V2 integrations and productization


### PR DESCRIPTION
## Summary
- update the top-level docs to reflect that SpecOps V1 is delivered
- convert the implementation plan and issue map from planning-only docs into current status docs
- strengthen the repo constitution so documentation updates are part of the change itself

Closes #21