### PR TITLE
Add V1.5 interview readiness planning and uncertainty metadata support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Delivered in V1:
 
 Open roadmap work is now V2-oriented, especially UML/formalization and integrations.
 
+An immediate bridge phase is now also defined as `V1.5`: improve the interview and canonical model
+so SpecOps can cover the relevant RUP-aligned specification views, manage ambiguity explicitly, and
+support targeted re-interview when new information appears later.
+
 ## Repository Layout
 
 - `docs/`: implementation plan, architecture, dogfooding workflow, and GitHub issue map
@@ -67,6 +71,7 @@ uv sync --extra yaml
 
 - [Implementation Plan](docs/implementation-plan.md)
 - [Solution Architecture](docs/solution-architecture.md)
+- [V1.5 Interview Readiness](docs/v1.5-interview-readiness.md)
 - [Dogfooding Workflow](docs/dogfooding.md)
 - [GitHub Issue Map](docs/github-issue-map.md)
 - [SpecKit Constitution](.specify/memory/constitution.md)

--- a/docs/github-issue-map.md
+++ b/docs/github-issue-map.md
@@ -17,7 +17,25 @@ Closed V1 issues:
 - `#16` `Improve interview UX and reduce wall-of-text responses`
 - `#17` `Improve UCP scoring guidance in the interview flow`
 
-V1 is complete. Remaining open work is V2.
+V1 is complete. A bridge phase now identified as V1.5 should happen before the existing V2 UML
+work is treated as implementation-ready.
+
+## Proposed V1.5 Focus
+
+- interview coverage for the relevant RUP-aligned specification views
+- explicit ambiguity and conflict handling
+- incremental re-interview and model patching
+- readiness, provenance, and staleness tracking
+
+These themes should shape the next issue set before broader UML rendering work proceeds.
+
+## Proposed V1.5 Issue Decomposition
+
+- `EPIC` `SpecOps V1.5 interview readiness`
+- `FEATURE` `Extend interview coverage for the relevant RUP-aligned views`
+- `FEATURE` `Make ambiguity and provenance first-class in the canonical model`
+- `FEATURE` `Support incremental re-interview and model patching`
+- `FEATURE` `Track per-view readiness and downstream staleness`
 
 ## Open Epics
 

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -2,8 +2,9 @@
 
 ## Status
 
-V1 is complete. This document now serves as the implementation record for what was delivered in V1
-and the shape that should be preserved while V2 expands UML/formalization and integration support.
+V1 is complete. This document now serves as the implementation record for what was delivered in V1,
+the bridge work now identified as V1.5, and the shape that should be preserved while later work
+expands UML/formalization and integration support.
 
 ## Objective
 
@@ -58,7 +59,21 @@ requirements spec, use-case model, and UCP estimate from that shared model.
 - Executable interview replay fixtures and tests
 - GitHub issue hierarchy for V1 and V2
 
-## Remaining Roadmap
+## V1.5 Bridge Work
+
+The next phase is not direct UML rendering. It is interview and model readiness for full
+specification work.
+
+V1.5 focuses on:
+
+- stronger interview coverage across the relevant RUP-aligned views
+- explicit ambiguity handling for unknowns, assumptions, conflicts, and stale answers
+- incremental re-interview so new information can update the model without restarting from scratch
+- readiness, provenance, and traceability needed before deterministic UML outputs are credible
+
+Reference: [V1.5 Interview Readiness](v1.5-interview-readiness.md)
+
+## Remaining Roadmap After V1.5
 
 - V2 UML and formal specification translation
 - V2 integrations and productization

--- a/docs/issue-drafts/epic-v1.5-interview-readiness.md
+++ b/docs/issue-drafts/epic-v1.5-interview-readiness.md
@@ -1,0 +1,20 @@
+## Summary
+
+Bridge SpecOps from V1 discovery readiness to V2 UML/formalization by making the interview and
+canonical model strong enough for full RUP-aligned specification work without assuming all answers
+are known up front.
+
+## Scope
+
+- richer interview coverage across the relevant specification views
+- explicit ambiguity, conflict, and assumption handling
+- incremental re-interview and model patching
+- readiness, provenance, and staleness tracking
+
+## Acceptance Criteria
+
+- the interview can deepen the relevant RUP-aligned views without forcing every project into a
+  maximal template
+- unresolved information remains explicit instead of being flattened into false certainty
+- existing interview sessions can be selectively revisited without restarting from round one
+- the canonical model can express readiness and dependency gaps needed before UML generation

--- a/docs/issue-drafts/feature-v1.5-ambiguity-and-provenance.md
+++ b/docs/issue-drafts/feature-v1.5-ambiguity-and-provenance.md
@@ -1,0 +1,20 @@
+## Summary
+
+Make ambiguity first-class in SpecOps so unknowns, assumptions, conflicts, and provenance survive
+interview and normalization instead of being collapsed into a flat best guess.
+
+Parent epic: V1.5 interview readiness
+
+## Scope
+
+- uncertainty status fields
+- source and last-updated metadata
+- conflict capture
+- explicit notes on assumptions and unresolved questions
+
+## Acceptance Criteria
+
+- important facts can be marked as confirmed, assumed, unknown, conflicting, or out of date
+- the canonical model preserves where an answer came from and when it changed
+- conflicting information is visible until resolved
+- generated outputs can surface uncertainty honestly instead of hiding it

--- a/docs/issue-drafts/feature-v1.5-incremental-reinterview.md
+++ b/docs/issue-drafts/feature-v1.5-incremental-reinterview.md
@@ -1,0 +1,20 @@
+## Summary
+
+Add incremental re-interview behavior so new information can update an existing interview/model
+state without forcing a complete restart.
+
+Parent epic: V1.5 interview readiness
+
+## Scope
+
+- stable identifiers for rounds, questions, and model entities
+- patch-oriented interview updates
+- rerun by view, round, or unresolved-question set
+- merge behavior for replayed or updated answers
+
+## Acceptance Criteria
+
+- an existing interview session can be replayed and selectively extended
+- the workflow can revisit one affected area without rerunning unrelated rounds
+- updated answers merge into the existing model instead of replacing it wholesale
+- the system can target unresolved or stale questions directly

--- a/docs/issue-drafts/feature-v1.5-readiness-and-staleness.md
+++ b/docs/issue-drafts/feature-v1.5-readiness-and-staleness.md
@@ -1,0 +1,20 @@
+## Summary
+
+Track per-view readiness and downstream staleness so SpecOps can tell the truth about which parts
+of a specification are complete, partial, blocked, or invalidated by later changes.
+
+Parent epic: V1.5 interview readiness
+
+## Scope
+
+- readiness state per view
+- dependency tracking between interview/model sections and outputs
+- stale markers after impactful changes
+- gating rules for specification outputs
+
+## Acceptance Criteria
+
+- the workflow can report readiness independently for the relevant specification views
+- downstream artifacts are marked stale when dependent answers change
+- requested outputs fail clearly or report blockers when prerequisite information is unresolved
+- traceability gaps are made visible before UML rendering is attempted

--- a/docs/issue-drafts/feature-v1.5-rup-view-coverage.md
+++ b/docs/issue-drafts/feature-v1.5-rup-view-coverage.md
@@ -1,0 +1,21 @@
+## Summary
+
+Extend the interview flow so SpecOps can gather the information needed for the relevant
+RUP-aligned specification views rather than stopping at discovery and UCP readiness.
+
+Parent epic: V1.5 interview readiness
+
+## Scope
+
+- use-case view deepening
+- logical/domain view prompts
+- process/state and workflow prompts
+- development and physical view prompts where relevant
+- supplementary specification prompts for constraints and business rules
+
+## Acceptance Criteria
+
+- the interview can determine which specification views are relevant for a project
+- each relevant view has enough structured prompt coverage to support downstream normalization
+- the workflow does not pretend all projects require the same depth in every view
+- missing view coverage is reported explicitly

--- a/docs/solution-architecture.md
+++ b/docs/solution-architecture.md
@@ -19,6 +19,10 @@ Responsibilities:
 - separate facts, assumptions, and open questions
 - stop clearly when the input is insufficient for normalization or UCP
 
+V1.5 extends this layer toward iterative interview management rather than one linear pass. The
+workflow should support targeted re-interview of affected views when new information appears later,
+instead of forcing a full restart.
+
 ## 2. Orchestrator Layer
 
 The `specops` skill is the entrypoint. It performs scope checks, runs the structured interview,
@@ -58,6 +62,10 @@ Required sections:
 - UCP inputs
 - reserved placeholders for future UML and formal specification translations
 
+The next model evolution must also represent ambiguity, provenance, readiness, and staleness so the
+system can preserve incomplete or conflicting information honestly and determine which downstream
+artifacts need regeneration.
+
 The canonical path is `specops-model.yaml`. A JSON mirror is included in examples so the offline
 tooling can run without the optional YAML extra.
 
@@ -74,6 +82,9 @@ Components:
 
 The tooling does not invent heuristic fallbacks. If YAML support is requested without the optional
 dependency, the command fails clearly and tells the user to run `uv sync --extra yaml`.
+
+The same rule should apply to richer specification outputs: if a view is not ready, SpecOps should
+fail clearly or mark that view as partial rather than silently inventing structure.
 
 ## 6. Dogfooding Loop
 

--- a/docs/v1.5-interview-readiness.md
+++ b/docs/v1.5-interview-readiness.md
@@ -1,0 +1,190 @@
+# SpecOps V1.5 Interview Readiness
+
+## Purpose
+
+V1 proved that SpecOps can interview a stakeholder, normalize the result into a canonical model,
+and generate requirements, use-case, and UCP artifacts from that model.
+
+V1.5 is the bridge between that discovery-ready baseline and the existing V2 UML/formalization
+work. Its job is to make the interview and model strong enough to support a full RUP-aligned
+specification workflow without pretending that all answers are known up front.
+
+## Problem Statement
+
+The current V1 interview is strong enough for discovery, use-case modeling, and UCP scoring. It is
+not strong enough for full specification work across the relevant RUP views.
+
+Two gaps must be closed before deterministic UML and richer formal outputs become credible:
+
+- the interview does not yet cover all relevant specification views deeply enough
+- the workflow assumes a mostly linear interview, even though real projects learn important facts
+  incrementally and often revisit earlier assumptions
+
+V1.5 focuses on interview completeness, ambiguity management, and targeted re-interview.
+
+## Design Goals
+
+- cover the relevant RUP views needed for a full specification
+- treat ambiguity, unknowns, and conflicts as first-class model state
+- support incremental re-interview without restarting from round one
+- preserve traceability from interview answers to downstream artifacts
+- make readiness and staleness visible instead of silently inventing missing structure
+
+## Relevant RUP Views
+
+V1.5 should make the interview and model ready for the views that commonly matter in software
+specification work:
+
+- use-case view: actors, goals, scenarios, preconditions, postconditions, alternate flows
+- logical view: domain concepts, relationships, responsibilities, business rules
+- process view: lifecycle behavior, approvals, concurrency, asynchronous events, long-running flows
+- development view: subsystems, components, services, interfaces, ownership boundaries
+- physical view: runtime nodes, environments, integrations, deployment topology
+- supplementary specification: constraints, quality attributes, business rules, data policies
+- traceability across the views above
+
+Not every project needs the same depth in every view. The workflow should identify which views are
+relevant, then deepen only those views instead of forcing every project into a maximal template.
+
+## Core Design Decisions
+
+## 1. Replace the linear interview with an iterative interview state machine
+
+The workflow should move from a single pass toward three layers:
+
+1. core discovery
+2. view-deepening passes
+3. gap and ambiguity review
+
+The user must be able to revisit one view or one question cluster without rerunning the entire
+interview.
+
+Examples:
+
+- revisit lifecycle and approval states
+- clarify domain entities and relationships
+- refine integration boundaries and API ownership
+- update deployment assumptions
+- re-score UCP after use cases are refined
+
+## 2. Model uncertainty explicitly
+
+The canonical model must represent more than a flat current value. Important facts should carry
+uncertainty metadata such as:
+
+- `value`
+- `status`: `confirmed`, `assumed`, `unknown`, `conflicting`, `out_of_date`
+- `source`
+- `last_updated`
+- `notes`
+- `affects`
+
+This allows SpecOps to preserve reality instead of flattening incomplete or conflicting answers into
+false certainty.
+
+## 3. Introduce targeted re-interview
+
+Re-interview should be patch-based, not restart-based.
+
+The workflow should support:
+
+- rerunning a specific round
+- rerunning a specific view
+- asking only unresolved questions
+- asking only questions made stale by a changed answer
+
+This requires stable identifiers for rounds, questions, model entities, and trace links so updated
+answers can merge into an existing model instead of replacing it wholesale.
+
+## 4. Track readiness by view
+
+SpecOps should not claim that a project is fully specification-ready just because one pass of the
+interview completed.
+
+Each view should expose a readiness state such as:
+
+- `ready`
+- `partial`
+- `blocked`
+- `stale`
+
+Example:
+
+- use-case view: ready
+- logical view: partial
+- process view: ready
+- development view: blocked by unresolved subsystem ownership
+- physical view: stale after integration topology changed
+
+## 5. Preserve impact and provenance
+
+When one answer changes, downstream artifacts should be marked as stale if they depend on that
+answer.
+
+Examples:
+
+- a changed lifecycle model should mark state-related outputs stale
+- a changed integration boundary should mark interaction and deployment views stale
+- a changed actor or use-case decomposition should mark UCP outputs stale
+
+This is the minimum traceability needed before full UML generation is reliable.
+
+## Interview Changes
+
+The current V1 interview rounds should remain the foundation, but V1.5 needs additional
+view-oriented prompts and review loops.
+
+New or expanded interview areas:
+
+- domain concepts and relationships
+- lifecycle and state transitions
+- approval and exception workflows
+- interaction and integration responsibilities
+- component and subsystem boundaries
+- deployment/runtime topology
+- ambiguity review and conflict resolution
+- traceability review for key requirements and architectural decisions
+
+The interview should prefer smaller grouped prompts over large walls of inline text.
+
+## Canonical Model Changes
+
+V1.5 should extend the model so it can carry specification-ready structures, including:
+
+- domain entities, relationships, and core business rules
+- stateful entities and allowed transitions
+- interaction realizations for important use cases
+- components, services, interfaces, and deployment nodes
+- traceability links between goals, requirements, use cases, domain objects, states, and components
+- readiness and staleness metadata
+- provenance and ambiguity metadata
+
+The model should allow partial completion without forcing placeholder certainty.
+
+## Output Rules
+
+V1.5 should enforce these workflow rules:
+
+- do not invent missing information just to complete a diagram or specification section
+- show unknowns, assumptions, and conflicts explicitly
+- allow per-view readiness instead of a single binary completion flag
+- allow artifacts to be regenerated selectively when a dependent view changes
+- stop clearly when a requested artifact requires information that is still unresolved
+
+## Non-Goals
+
+V1.5 is not the phase for polished UML rendering or broad integrations.
+
+It is specifically the phase that makes those later outputs trustworthy by improving interview
+coverage, model structure, and iterative workflow behavior.
+
+## Acceptance Criteria
+
+V1.5 is successful when:
+
+- an existing interview session can be replayed and selectively extended without restarting
+- the canonical model can preserve ambiguity and provenance instead of flattening them away
+- the workflow can identify which RUP-aligned views are ready, partial, blocked, or stale
+- the interview can gather the information needed for full specification work across the relevant
+  views without pretending every project needs every view equally
+- downstream specification outputs can declare dependency gaps honestly instead of hiding them

--- a/skills/specops/references/specops-model.md
+++ b/skills/specops/references/specops-model.md
@@ -29,7 +29,21 @@ The canonical project model is `specops-model.yaml`.
   - `functional`
   - `non_functional`
 - `assumptions`
+  - supports plain strings
+  - may also use structured items with:
+    - `text`
+    - `status`
+    - `source`
+    - `last_updated`
+    - `notes`
 - `open_questions`
+  - supports plain strings
+  - may also use structured items with:
+    - `text`
+    - `status`
+    - `source`
+    - `last_updated`
+    - `notes`
 - `ucp`
   - `technical_factors`
   - `environmental_factors`
@@ -47,4 +61,3 @@ The model should be rich enough to generate:
 - `ucp-estimate.md`
 
 If any artifact would require invented inputs, stop and surface the missing fields.
-

--- a/src/specops_tools/model_metadata.py
+++ b/src/specops_tools/model_metadata.py
@@ -1,0 +1,55 @@
+"""Helpers for metadata-aware SpecOps model fields."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def normalize_uncertainty_item(item: Any) -> dict[str, str]:
+    """Normalize one assumption or open-question item.
+
+    Args:
+        item: Raw item from the model.
+
+    Returns:
+        Normalized item with stable keys.
+
+    Raises:
+        TypeError: If the item shape is unsupported.
+        ValueError: If a mapping item is missing required text.
+    """
+    if isinstance(item, str):
+        return {
+            "text": item,
+            "status": "",
+            "source": "",
+            "last_updated": "",
+            "notes": "",
+        }
+
+    if not isinstance(item, dict):
+        raise TypeError("Uncertainty items must be strings or mappings.")
+
+    text = str(item.get("text", "")).strip()
+    if not text:
+        raise ValueError("Structured uncertainty items must include non-empty `text`.")
+
+    return {
+        "text": text,
+        "status": str(item.get("status", "")).strip(),
+        "source": str(item.get("source", "")).strip(),
+        "last_updated": str(item.get("last_updated", "")).strip(),
+        "notes": str(item.get("notes", "")).strip(),
+    }
+
+
+def normalize_uncertainty_list(items: list[Any]) -> list[dict[str, str]]:
+    """Normalize a list of assumptions or open questions.
+
+    Args:
+        items: Raw list from the model.
+
+    Returns:
+        Normalized items.
+    """
+    return [normalize_uncertainty_item(item) for item in items]

--- a/src/specops_tools/render.py
+++ b/src/specops_tools/render.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from .model_metadata import normalize_uncertainty_list
 from .ucp import calculate_ucp, render_ucp_markdown
 
 
@@ -17,6 +18,38 @@ def _bullet_list(items: list[str]) -> str:
         Markdown text.
     """
     return "\n".join(f"- {item}" for item in items) or "- None"
+
+
+def _uncertainty_list(items: list[Any]) -> str:
+    """Render assumptions or open questions with optional metadata.
+
+    Args:
+        items: Raw uncertainty items.
+
+    Returns:
+        Markdown text.
+    """
+    normalized_items = normalize_uncertainty_list(items)
+    if not normalized_items:
+        return "- None"
+
+    rendered = []
+    for item in normalized_items:
+        details = []
+        if item["status"]:
+            details.append(f"status: {item['status']}")
+        if item["source"]:
+            details.append(f"source: {item['source']}")
+        if item["last_updated"]:
+            details.append(f"last updated: {item['last_updated']}")
+        if item["notes"]:
+            details.append(f"notes: {item['notes']}")
+
+        if details:
+            rendered.append(f"- {item['text']} ({'; '.join(details)})")
+        else:
+            rendered.append(f"- {item['text']}")
+    return "\n".join(rendered)
 
 
 def render_requirements_spec(model: dict[str, Any]) -> str:
@@ -60,11 +93,11 @@ def render_requirements_spec(model: dict[str, Any]) -> str:
 
 ## Assumptions
 
-{_bullet_list(model.get("assumptions", []))}
+{_uncertainty_list(model.get("assumptions", []))}
 
 ## Open Questions
 
-{_bullet_list(model.get("open_questions", []))}
+{_uncertainty_list(model.get("open_questions", []))}
 """
 
 
@@ -139,4 +172,3 @@ def render_all(model: dict[str, Any]) -> dict[str, str]:
         "use-case-model.md": render_use_case_model(model),
         "ucp-estimate.md": render_ucp_markdown(model, ucp_results),
     }
-

--- a/src/specops_tools/ucp.py
+++ b/src/specops_tools/ucp.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from .model_metadata import normalize_uncertainty_list
+
 ACTOR_WEIGHTS = {
     "simple": 1,
     "average": 2,
@@ -191,8 +193,13 @@ def render_ucp_markdown(model: dict[str, Any], results: dict[str, Any]) -> str:
         Markdown report content.
     """
     project_name = model.get("project", {}).get("name", "Unnamed Project")
-    assumptions = "\n".join(f"- {item}" for item in results["assumptions"]) or "- None"
-    open_questions = "\n".join(f"- {item}" for item in results["open_questions"]) or "- None"
+    assumptions = "\n".join(
+        _render_uncertainty_item(item) for item in normalize_uncertainty_list(results["assumptions"])
+    ) or "- None"
+    open_questions = "\n".join(
+        _render_uncertainty_item(item)
+        for item in normalize_uncertainty_list(results["open_questions"])
+    ) or "- None"
 
     return f"""# UCP Estimate
 
@@ -225,3 +232,19 @@ def render_ucp_markdown(model: dict[str, Any], results: dict[str, Any]) -> str:
 {open_questions}
 """
 
+
+def _render_uncertainty_item(item: dict[str, str]) -> str:
+    """Render a normalized uncertainty item into one Markdown bullet."""
+    details = []
+    if item["status"]:
+        details.append(f"status: {item['status']}")
+    if item["source"]:
+        details.append(f"source: {item['source']}")
+    if item["last_updated"]:
+        details.append(f"last updated: {item['last_updated']}")
+    if item["notes"]:
+        details.append(f"notes: {item['notes']}")
+
+    if details:
+        return f"- {item['text']} ({'; '.join(details)})"
+    return f"- {item['text']}"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test package for default unittest discovery."""

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -7,7 +7,10 @@ import unittest
 from specops_tools.render import render_requirements_spec
 from specops_tools.ucp import calculate_ucp, render_ucp_markdown
 
-from test_ucp import build_model
+try:
+    from tests.test_ucp import build_model
+except ModuleNotFoundError:
+    from test_ucp import build_model
 
 
 class RenderTests(unittest.TestCase):

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,0 +1,67 @@
+"""Tests for rendering SpecOps artifacts."""
+
+from __future__ import annotations
+
+import unittest
+
+from specops_tools.render import render_requirements_spec
+from specops_tools.ucp import calculate_ucp, render_ucp_markdown
+
+from test_ucp import build_model
+
+
+class RenderTests(unittest.TestCase):
+    """Coverage for rendering helpers."""
+
+    def test_requirements_render_supports_structured_uncertainty_items(self) -> None:
+        """Requirements rendering should preserve uncertainty metadata when present."""
+        model = build_model()
+        model["assumptions"] = [
+            {
+                "text": "Initial estimate assumes one delivery team.",
+                "status": "assumed",
+                "source": "interview round 2",
+                "last_updated": "2026-04-13",
+                "notes": "Team topology still needs confirmation.",
+            }
+        ]
+        model["open_questions"] = [
+            {
+                "text": "Should partner merchants count as actors in V1?",
+                "status": "unknown",
+                "source": "portfolio workshop",
+            }
+        ]
+
+        rendered = render_requirements_spec(model)
+
+        self.assertIn("status: assumed", rendered)
+        self.assertIn("source: interview round 2", rendered)
+        self.assertIn("last updated: 2026-04-13", rendered)
+        self.assertIn("notes: Team topology still needs confirmation.", rendered)
+        self.assertIn("status: unknown", rendered)
+
+    def test_ucp_render_supports_structured_uncertainty_items(self) -> None:
+        """UCP rendering should preserve uncertainty metadata when present."""
+        model = build_model()
+        model["assumptions"] = [
+            {
+                "text": "Initial estimate assumes one delivery team.",
+                "status": "assumed",
+                "source": "interview round 2",
+            }
+        ]
+        model["open_questions"] = [
+            {
+                "text": "Should partner merchants count as actors in V1?",
+                "status": "unknown",
+                "notes": "Could affect actor count and UCP.",
+            }
+        ]
+
+        rendered = render_ucp_markdown(model, calculate_ucp(model))
+
+        self.assertIn("status: assumed", rendered)
+        self.assertIn("source: interview round 2", rendered)
+        self.assertIn("status: unknown", rendered)
+        self.assertIn("notes: Could affect actor count and UCP.", rendered)


### PR DESCRIPTION
## Summary
- add V1.5 interview-readiness design docs and issue drafts as the bridge between V1 and V2 UML work
- implement the first slice of #24 by supporting structured uncertainty metadata for assumptions and open questions
- fix default unittest discovery so `uv run python -m unittest` works out of the box

## Testing
- `uv run python -m unittest`
- `uv run python -m unittest discover -s tests`

## Related Issues
- closes #24
- refs #27
- refs #23
- refs #25
- refs #26