### PR TITLE
Add incremental interview replay updates

### DIFF
--- a/src/specops_tools/interview.py
+++ b/src/specops_tools/interview.py
@@ -403,6 +403,76 @@ def _coerce_round_answer(number: int, item: dict[str, Any]) -> tuple[str, list[d
     return answer_text, response_items
 
 
+def _normalize_round_item(item: dict[str, Any]) -> dict[str, Any]:
+    """Normalize one round input into a response-based shape.
+
+    Args:
+        item: Raw round input.
+
+    Returns:
+        Normalized round item with canonical response entries.
+    """
+    round_number = int(item["round"])
+    answer_text, response_items = _coerce_round_answer(round_number, item)
+    normalized_item: dict[str, Any] = {
+        "round": round_number,
+        "responses": response_items,
+    }
+    if answer_text.strip():
+        normalized_item["answer"] = answer_text
+    return normalized_item
+
+
+def merge_round_inputs(
+    round_inputs: list[dict[str, Any]],
+    updates: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Merge targeted updates into an existing replay session.
+
+    Round number acts as the stable round identifier. Within a round, question key acts as the
+    stable response identifier when responses are provided.
+
+    Args:
+        round_inputs: Existing replay rounds.
+        updates: Update items to apply.
+
+    Returns:
+        Merged round inputs ordered by round number.
+    """
+    merged_by_round: dict[int, dict[str, Any]] = {
+        int(item["round"]): _normalize_round_item(item)
+        for item in round_inputs
+    }
+
+    for update in updates:
+        round_number = int(update["round"])
+        normalized_update = _normalize_round_item(update)
+
+        if "responses" in update:
+            existing = merged_by_round.get(round_number, {"round": round_number, "responses": []})
+            existing_by_key = {
+                response["key"]: response
+                for response in existing.get("responses", [])
+            }
+            for response in normalized_update["responses"]:
+                existing_by_key[response["key"]] = response
+
+            merged_responses = []
+            for question in get_round(round_number).questions:
+                if question.key in existing_by_key:
+                    merged_responses.append(existing_by_key[question.key])
+
+            merged_by_round[round_number] = {
+                "round": round_number,
+                "responses": merged_responses,
+            }
+            continue
+
+        merged_by_round[round_number] = normalized_update
+
+    return [merged_by_round[number] for number in sorted(merged_by_round)]
+
+
 def process_round(number: int, answer_text: str) -> dict[str, Any]:
     """Process one round answer and prepare the next prompt.
 
@@ -466,6 +536,25 @@ def replay_session(round_inputs: list[dict[str, Any]]) -> dict[str, Any]:
         "last_round": transcript[-1]["round"]["number"] if transcript else None,
         "next_round": transcript[-1]["next_round"] if transcript else None,
     }
+
+
+def replay_session_with_updates(
+    round_inputs: list[dict[str, Any]],
+    updates: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Replay a session after applying targeted updates.
+
+    Args:
+        round_inputs: Existing replay rounds.
+        updates: Round updates to merge into the existing session.
+
+    Returns:
+        Structured replay summary including the merged session input.
+    """
+    merged_rounds = merge_round_inputs(round_inputs, updates)
+    replay = replay_session(merged_rounds)
+    replay["merged_round_inputs"] = merged_rounds
+    return replay
 
 
 def to_json(data: dict[str, Any]) -> str:

--- a/src/specops_tools/interview_replay.py
+++ b/src/specops_tools/interview_replay.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 
-from .interview import replay_session, to_json
+from .interview import replay_session, replay_session_with_updates, to_json
 
 
 def main() -> int:
@@ -16,16 +16,25 @@ def main() -> int:
     """
     parser = argparse.ArgumentParser(description="Replay a SpecOps interview session.")
     parser.add_argument("--input", required=True, help="Path to the replay fixture JSON file.")
+    parser.add_argument(
+        "--updates",
+        help="Optional path to a JSON file containing targeted round updates.",
+    )
     args = parser.parse_args()
 
     with open(args.input, "r", encoding="utf-8") as handle:
         fixture = json.load(handle)
 
     rounds = fixture.get("rounds", [])
-    print(to_json(replay_session(rounds)))
+    if args.updates:
+        with open(args.updates, "r", encoding="utf-8") as handle:
+            update_fixture = json.load(handle)
+        updates = update_fixture.get("rounds", [])
+        print(to_json(replay_session_with_updates(rounds, updates)))
+    else:
+        print(to_json(replay_session(rounds)))
     return 0
 
 
 if __name__ == "__main__":
     raise SystemExit(main())
-

--- a/tests/test_interview.py
+++ b/tests/test_interview.py
@@ -8,7 +8,13 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from specops_tools.interview import get_round, process_round, replay_session
+from specops_tools.interview import (
+    get_round,
+    merge_round_inputs,
+    process_round,
+    replay_session,
+    replay_session_with_updates,
+)
 
 
 class InterviewHarnessTests(unittest.TestCase):
@@ -85,6 +91,68 @@ class InterviewHarnessTests(unittest.TestCase):
         )
         self.assertEqual(replay["merged_answers"]["round_1"]["problem"], "Poor visibility")
         self.assertEqual(replay["next_round"]["number"], 2)
+
+    def test_merge_round_inputs_updates_only_targeted_response(self) -> None:
+        """A targeted response update should merge into one round without dropping siblings."""
+        merged = merge_round_inputs(
+            [
+                {
+                    "round": 1,
+                    "responses": [
+                        {"key": "idea", "answer": "Inventory system"},
+                        {"key": "problem", "answer": "Poor visibility"},
+                        {"key": "users", "answer": "Architects"},
+                    ],
+                }
+            ],
+            [
+                {
+                    "round": 1,
+                    "responses": [
+                        {"key": "problem", "answer": "Poor visibility across regions"},
+                    ],
+                }
+            ],
+        )
+
+        self.assertEqual(len(merged), 1)
+        self.assertEqual(merged[0]["round"], 1)
+        responses = {item["key"]: item["answer"] for item in merged[0]["responses"]}
+        self.assertEqual(responses["idea"], "Inventory system")
+        self.assertEqual(responses["users"], "Architects")
+        self.assertEqual(responses["problem"], "Poor visibility across regions")
+
+    def test_replay_session_with_updates_can_extend_existing_session(self) -> None:
+        """Replaying with updates should preserve prior rounds and add the new answers."""
+        replay = replay_session_with_updates(
+            [
+                {
+                    "round": 1,
+                    "responses": [
+                        {"key": "idea", "answer": "Inventory system"},
+                        {"key": "problem", "answer": "Poor visibility"},
+                        {"key": "users", "answer": "Architects"},
+                        {"key": "in_scope", "answer": "Non-OT"},
+                        {"key": "out_of_scope", "answer": "OT"},
+                    ],
+                }
+            ],
+            [
+                {
+                    "round": 2,
+                    "responses": [
+                        {"key": "outcomes", "answer": "Better planning"},
+                        {"key": "success_criteria", "answer": "One inventory source"},
+                    ],
+                }
+            ],
+        )
+
+        self.assertEqual(replay["last_round"], 2)
+        self.assertEqual(replay["merged_answers"]["round_1"]["idea"], "Inventory system")
+        self.assertEqual(replay["merged_answers"]["round_2"]["outcomes"], "Better planning")
+        self.assertEqual(replay["next_round"]["number"], 3)
+        self.assertEqual(len(replay["merged_round_inputs"]), 2)
 
     def test_cli_accepts_piped_round_answer(self) -> None:
         """The CLI should accept answer text from stdin."""
@@ -246,6 +314,77 @@ class InterviewHarnessTests(unittest.TestCase):
             "expose/export data by API: Complex",
             payload["merged_answers"]["round_6"]["use_case_complexity"],
         )
+
+    def test_replay_cli_applies_updates_fixture(self) -> None:
+        """The replay CLI should support targeted updates without replay restarts."""
+        repo_root = Path(__file__).resolve().parents[1]
+        with tempfile.TemporaryDirectory() as temp_dir:
+            fixture_path = Path(temp_dir) / "session.json"
+            updates_path = Path(temp_dir) / "updates.json"
+            fixture_path.write_text(
+                json.dumps(
+                    {
+                        "rounds": [
+                            {
+                                "round": 1,
+                                "responses": [
+                                    {"key": "idea", "answer": "Inventory system"},
+                                    {"key": "problem", "answer": "Poor visibility"},
+                                    {"key": "users", "answer": "Architects"},
+                                    {"key": "in_scope", "answer": "Non-OT"},
+                                    {"key": "out_of_scope", "answer": "OT"},
+                                ],
+                            }
+                        ]
+                    }
+                )
+            )
+            updates_path.write_text(
+                json.dumps(
+                    {
+                        "rounds": [
+                            {
+                                "round": 1,
+                                "responses": [
+                                    {
+                                        "key": "problem",
+                                        "answer": "Poor visibility across regions",
+                                    }
+                                ],
+                            },
+                            {
+                                "round": 2,
+                                "responses": [
+                                    {"key": "outcomes", "answer": "Better planning"},
+                                ],
+                            },
+                        ]
+                    }
+                )
+            )
+
+            completed = subprocess.run(
+                [
+                    "uv",
+                    "run",
+                    "python",
+                    "-m",
+                    "specops_tools.interview_replay",
+                    "--input",
+                    str(fixture_path),
+                    "--updates",
+                    str(updates_path),
+                ],
+                text=True,
+                capture_output=True,
+                check=True,
+                cwd=repo_root,
+            )
+
+        payload = json.loads(completed.stdout)
+        self.assertEqual(payload["merged_answers"]["round_1"]["problem"], "Poor visibility across regions")
+        self.assertEqual(payload["merged_answers"]["round_2"]["outcomes"], "Better planning")
+        self.assertEqual(payload["next_round"]["number"], 3)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a patch-style merge path for interview replay inputs using round number and question key as stable identifiers
- add `replay_session_with_updates()` and CLI support for `specops_tools.interview_replay --updates`
- add tests covering targeted response replacement, session extension, and CLI update replay

## Testing
- `uv run python -m unittest`

## Related Issues
- closes #25
- refs #27