### PR TITLE
Add interview readiness and staleness reporting

### DIFF
--- a/src/specops_tools/interview.py
+++ b/src/specops_tools/interview.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass
 import json
 from typing import Any
 
+from .readiness import evaluate_readiness, identify_stale_artifacts
+
 
 def _normalize_key(value: str) -> str:
     """Normalize a human label into a snake_case key.
@@ -535,6 +537,8 @@ def replay_session(round_inputs: list[dict[str, Any]]) -> dict[str, Any]:
         "merged_answers": merged_answers,
         "last_round": transcript[-1]["round"]["number"] if transcript else None,
         "next_round": transcript[-1]["next_round"] if transcript else None,
+        "readiness": evaluate_readiness(round_inputs),
+        "stale_artifacts": [],
     }
 
 
@@ -554,6 +558,7 @@ def replay_session_with_updates(
     merged_rounds = merge_round_inputs(round_inputs, updates)
     replay = replay_session(merged_rounds)
     replay["merged_round_inputs"] = merged_rounds
+    replay["stale_artifacts"] = identify_stale_artifacts(updates)
     return replay
 
 

--- a/src/specops_tools/readiness.py
+++ b/src/specops_tools/readiness.py
@@ -1,0 +1,61 @@
+"""Readiness and staleness reporting for SpecOps interview state."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+VIEW_REQUIREMENTS = {
+    "discovery": {1, 2},
+    "use_case": {3, 4},
+    "ucp": {5, 6, 7, 8},
+}
+
+VIEW_ARTIFACTS = {
+    "discovery": ["requirements-spec.md"],
+    "use_case": ["requirements-spec.md", "use-case-model.md"],
+    "ucp": ["ucp-estimate.md"],
+}
+
+
+def _view_status(required_rounds: set[int], answered_rounds: set[int]) -> str:
+    """Return the readiness state for one view."""
+    answered_required = required_rounds & answered_rounds
+    if answered_required == required_rounds:
+        return "ready"
+    if answered_required:
+        return "partial"
+    return "blocked"
+
+
+def evaluate_readiness(round_inputs: list[dict[str, Any]]) -> dict[str, str]:
+    """Evaluate readiness by view from replay rounds.
+
+    Args:
+        round_inputs: Canonical replay round inputs.
+
+    Returns:
+        Mapping of view name to readiness status.
+    """
+    answered_rounds = {int(item["round"]) for item in round_inputs}
+    return {
+        view_name: _view_status(required_rounds, answered_rounds)
+        for view_name, required_rounds in VIEW_REQUIREMENTS.items()
+    }
+
+
+def identify_stale_artifacts(updates: list[dict[str, Any]]) -> list[str]:
+    """Identify downstream artifacts impacted by updated interview rounds.
+
+    Args:
+        updates: Round update items.
+
+    Returns:
+        Sorted stale artifact names.
+    """
+    updated_rounds = {int(item["round"]) for item in updates}
+    stale_artifacts: set[str] = set()
+    for view_name, required_rounds in VIEW_REQUIREMENTS.items():
+        if updated_rounds & required_rounds:
+            stale_artifacts.update(VIEW_ARTIFACTS[view_name])
+    return sorted(stale_artifacts)

--- a/tests/test_interview.py
+++ b/tests/test_interview.py
@@ -66,6 +66,9 @@ class InterviewHarnessTests(unittest.TestCase):
         self.assertEqual(replay["last_round"], 2)
         self.assertEqual(replay["merged_answers"]["round_1"]["users"], "Architects")
         self.assertEqual(replay["next_round"]["number"], 3)
+        self.assertEqual(replay["readiness"]["discovery"], "ready")
+        self.assertEqual(replay["readiness"]["use_case"], "blocked")
+        self.assertEqual(replay["stale_artifacts"], [])
 
     def test_replay_session_accepts_individual_question_responses(self) -> None:
         """Replay should support storing answers per question instead of per round block."""
@@ -153,6 +156,8 @@ class InterviewHarnessTests(unittest.TestCase):
         self.assertEqual(replay["merged_answers"]["round_2"]["outcomes"], "Better planning")
         self.assertEqual(replay["next_round"]["number"], 3)
         self.assertEqual(len(replay["merged_round_inputs"]), 2)
+        self.assertEqual(replay["readiness"]["discovery"], "ready")
+        self.assertEqual(replay["stale_artifacts"], ["requirements-spec.md"])
 
     def test_cli_accepts_piped_round_answer(self) -> None:
         """The CLI should accept answer text from stdin."""
@@ -385,6 +390,8 @@ class InterviewHarnessTests(unittest.TestCase):
         self.assertEqual(payload["merged_answers"]["round_1"]["problem"], "Poor visibility across regions")
         self.assertEqual(payload["merged_answers"]["round_2"]["outcomes"], "Better planning")
         self.assertEqual(payload["next_round"]["number"], 3)
+        self.assertEqual(payload["readiness"]["discovery"], "ready")
+        self.assertEqual(payload["stale_artifacts"], ["requirements-spec.md"])
 
 
 if __name__ == "__main__":

--- a/tests/test_readiness.py
+++ b/tests/test_readiness.py
@@ -1,0 +1,40 @@
+"""Tests for readiness and staleness reporting."""
+
+from __future__ import annotations
+
+import unittest
+
+from specops_tools.readiness import evaluate_readiness, identify_stale_artifacts
+
+
+class ReadinessTests(unittest.TestCase):
+    """Coverage for interview-state readiness helpers."""
+
+    def test_evaluate_readiness_reports_partial_and_ready_views(self) -> None:
+        """Readiness should distinguish complete, partial, and blocked views."""
+        readiness = evaluate_readiness(
+            [
+                {"round": 1, "responses": []},
+                {"round": 3, "responses": []},
+                {"round": 4, "responses": []},
+                {"round": 5, "responses": []},
+            ]
+        )
+
+        self.assertEqual(readiness["discovery"], "partial")
+        self.assertEqual(readiness["use_case"], "ready")
+        self.assertEqual(readiness["ucp"], "partial")
+
+    def test_identify_stale_artifacts_maps_round_updates_to_outputs(self) -> None:
+        """Updated rounds should mark only dependent artifacts stale."""
+        stale = identify_stale_artifacts(
+            [
+                {"round": 2, "responses": []},
+                {"round": 6, "responses": []},
+            ]
+        )
+
+        self.assertEqual(
+            stale,
+            ["requirements-spec.md", "ucp-estimate.md"],
+        )


### PR DESCRIPTION
## Summary
- add interview-state readiness evaluation for the `discovery`, `use_case`, and `ucp` views
- add stale artifact detection for targeted interview updates
- include `readiness` and `stale_artifacts` in replay results and cover them with tests

## Testing
- `uv run python -m unittest`

## Related Issues
- closes #26
- refs #27