### PR TITLE
Add logical view interview round

### DIFF
--- a/skills/specops-interview/references/interview-rounds.md
+++ b/skills/specops-interview/references/interview-rounds.md
@@ -81,7 +81,28 @@ Collect:
 - core metadata fields
 - non-functional requirements
 
-## Round 5: UCP Actor Complexity
+## Round 5: Domain Model
+
+Ask at most 3 prompts.
+
+Preferred answer shape:
+
+```text
+Domain entities:
+Relationships:
+Business rules:
+```
+
+Collect:
+
+- core domain concepts
+- important business relationships
+- rules that govern validity, ownership, lifecycle, and approvals
+
+This round is for the logical view. Do not force technical design language if the stakeholder is
+still speaking in business concepts.
+
+## Round 6: UCP Actor Complexity
 
 Do not ask for all UCP inputs in one block.
 
@@ -104,7 +125,7 @@ Actor complexity:
 - Actor B: simple/average/complex
 ```
 
-## Round 6: UCP Use-Case Complexity
+## Round 7: UCP Use-Case Complexity
 
 Explain the scale first:
 
@@ -124,7 +145,7 @@ Use-case complexity:
 - Use case B: simple/average/complex
 ```
 
-## Round 7: UCP Technical Factors
+## Round 8: UCP Technical Factors
 
 Explain the influence scale briefly:
 
@@ -151,7 +172,7 @@ complex internal processing:
 ...
 ```
 
-## Round 8: UCP Environmental Factors
+## Round 9: UCP Environmental Factors
 
 Use the same `0-5` influence explanation, but state clearly that:
 

--- a/src/specops_tools/interview.py
+++ b/src/specops_tools/interview.py
@@ -79,6 +79,14 @@ def _parse_block_answer(text: str) -> dict[str, Any]:
     return parsed
 
 
+LEGACY_ROUND_KEY_MAP = {
+    5: "actor_complexity",
+    6: "use_case_complexity",
+    7: "technical",
+    8: "environmental",
+}
+
+
 @dataclass(frozen=True)
 class InterviewQuestion:
     """Definition of one question within an interview round."""
@@ -195,6 +203,49 @@ ROUND_DEFINITIONS: list[InterviewRound] = [
     ),
     InterviewRound(
         number=5,
+        title="Domain Model",
+        prompt=(
+            "Capture the core domain concepts, important relationships, and key business rules that "
+            "shape the logical view."
+        ),
+        template="Domain entities:\nRelationships:\nBusiness rules:\n",
+        guidance=(
+            "Focus on the important nouns, relationships, and rules, not implementation classes.",
+            "If a relationship or rule is unclear, record the ambiguity instead of inventing detail.",
+        ),
+        questions=(
+            InterviewQuestion(
+                "domain_entities",
+                "Domain entities",
+                "What are the core business entities or concepts?",
+                guidance=(
+                    "Prefer domain concepts such as System, Lifecycle, Approval, Contract, or Risk.",
+                    "Avoid technical table or API naming unless it already matters to the business.",
+                ),
+                example="- System\n- Capability\n- Contract\n- Lifecycle state",
+            ),
+            InterviewQuestion(
+                "relationships",
+                "Relationships",
+                "How do the important entities relate to each other?",
+                guidance=(
+                    "Capture business relationships such as ownership, dependency, approval, or containment.",
+                ),
+                example="- A System has one Business Owner\n- A System supports many Capabilities",
+            ),
+            InterviewQuestion(
+                "business_rules",
+                "Business rules",
+                "What key rules or constraints govern these entities?",
+                guidance=(
+                    "Include rules that shape lifecycle transitions, approvals, ownership, or data validity.",
+                ),
+                example="- A deprecation request requires at least one approver\n- Contract end date cannot precede go-live date",
+            ),
+        ),
+    ),
+    InterviewRound(
+        number=6,
         title="UCP Actor Complexity",
         prompt=(
             "Capture actor complexity using simple/average/complex after discovery is stable."
@@ -221,7 +272,7 @@ ROUND_DEFINITIONS: list[InterviewRound] = [
         ),
     ),
     InterviewRound(
-        number=6,
+        number=7,
         title="UCP Use-Case Complexity",
         prompt="Capture use-case complexity using simple/average/complex.",
         template="Use-case complexity:\n- Use case A: simple/average/complex\n",
@@ -244,7 +295,7 @@ ROUND_DEFINITIONS: list[InterviewRound] = [
         ),
     ),
     InterviewRound(
-        number=7,
+        number=8,
         title="UCP Technical Factors",
         prompt="Capture the technical 0-5 influence scores in a compact block.",
         template=(
@@ -271,7 +322,7 @@ ROUND_DEFINITIONS: list[InterviewRound] = [
         ),
     ),
     InterviewRound(
-        number=8,
+        number=9,
         title="UCP Environmental Factors",
         prompt="Capture the environmental 0-5 influence scores in a compact block.",
         template=(
@@ -324,6 +375,29 @@ def next_round(number: int) -> InterviewRound | None:
     return get_round(number + 1)
 
 
+def _resolve_round_number(number: int, item: dict[str, Any]) -> int:
+    """Resolve a round number, including compatibility with legacy replay fixtures."""
+    if number not in LEGACY_ROUND_KEY_MAP:
+        return number
+
+    expected_key = LEGACY_ROUND_KEY_MAP[number]
+    candidate_keys: set[str] = set()
+
+    if "responses" in item:
+        for response in item["responses"]:
+            key = response.get("key")
+            label = response.get("label")
+            if key is None and label is None:
+                continue
+            candidate_keys.add(key or _normalize_key(str(label)))
+    else:
+        candidate_keys.update(_parse_block_answer(str(item.get("answer", ""))).keys())
+
+    if expected_key in candidate_keys:
+        return number + 1
+    return number
+
+
 def _round_payload(round_definition: InterviewRound) -> dict[str, Any]:
     """Serialize a round definition for CLI output."""
     return {
@@ -354,6 +428,7 @@ def _stringify_response_value(value: Any) -> str:
 
 def _coerce_round_answer(number: int, item: dict[str, Any]) -> tuple[str, list[dict[str, str]]]:
     """Convert replay input into canonical answer text and response items."""
+    number = _resolve_round_number(number, item)
     if "responses" in item:
         round_definition = get_round(number)
         keyed_values: dict[str, Any] = {}
@@ -414,7 +489,7 @@ def _normalize_round_item(item: dict[str, Any]) -> dict[str, Any]:
     Returns:
         Normalized round item with canonical response entries.
     """
-    round_number = int(item["round"])
+    round_number = _resolve_round_number(int(item["round"]), item)
     answer_text, response_items = _coerce_round_answer(round_number, item)
     normalized_item: dict[str, Any] = {
         "round": round_number,
@@ -485,6 +560,7 @@ def process_round(number: int, answer_text: str) -> dict[str, Any]:
     Returns:
         Structured round result.
     """
+    number = _resolve_round_number(number, {"round": number, "answer": answer_text})
     round_definition = get_round(number)
     parsed_answers = _parse_block_answer(answer_text)
     following_round = next_round(number)
@@ -522,22 +598,23 @@ def replay_session(round_inputs: list[dict[str, Any]]) -> dict[str, Any]:
     """
     transcript = []
     merged_answers: dict[str, Any] = {}
+    normalized_round_inputs = [_normalize_round_item(item) for item in round_inputs]
 
-    for item in round_inputs:
-        round_number = int(item["round"])
+    for item in normalized_round_inputs:
+        round_number = _resolve_round_number(int(item["round"]), item)
         answer_text, response_items = _coerce_round_answer(round_number, item)
         result = process_round(round_number, answer_text)
         if response_items:
             result["responses"] = response_items
         transcript.append(result)
-        merged_answers[f"round_{round_number}"] = result["parsed_answers"]
+        merged_answers[f"round_{result['round']['number']}"] = result["parsed_answers"]
 
     return {
         "transcript": transcript,
         "merged_answers": merged_answers,
         "last_round": transcript[-1]["round"]["number"] if transcript else None,
         "next_round": transcript[-1]["next_round"] if transcript else None,
-        "readiness": evaluate_readiness(round_inputs),
+        "readiness": evaluate_readiness(normalized_round_inputs),
         "stale_artifacts": [],
     }
 

--- a/src/specops_tools/readiness.py
+++ b/src/specops_tools/readiness.py
@@ -8,12 +8,14 @@ from typing import Any
 VIEW_REQUIREMENTS = {
     "discovery": {1, 2},
     "use_case": {3, 4},
-    "ucp": {5, 6, 7, 8},
+    "logical": {5},
+    "ucp": {6, 7, 8, 9},
 }
 
 VIEW_ARTIFACTS = {
     "discovery": ["requirements-spec.md"],
     "use_case": ["requirements-spec.md", "use-case-model.md"],
+    "logical": ["requirements-spec.md"],
     "ucp": ["ucp-estimate.md"],
 }
 

--- a/tests/test_interview.py
+++ b/tests/test_interview.py
@@ -68,6 +68,7 @@ class InterviewHarnessTests(unittest.TestCase):
         self.assertEqual(replay["next_round"]["number"], 3)
         self.assertEqual(replay["readiness"]["discovery"], "ready")
         self.assertEqual(replay["readiness"]["use_case"], "blocked")
+        self.assertEqual(replay["readiness"]["logical"], "blocked")
         self.assertEqual(replay["stale_artifacts"], [])
 
     def test_replay_session_accepts_individual_question_responses(self) -> None:
@@ -181,9 +182,22 @@ class InterviewHarnessTests(unittest.TestCase):
         self.assertEqual(payload["parsed_answers"]["idea"], "IT systems inventory")
         self.assertEqual(payload["next_round"]["number"], 2)
 
-    def test_ucp_actor_round_exposes_inversion_guidance(self) -> None:
-        """Round 5 should explain the common actor complexity intuition mismatch."""
+    def test_domain_round_exposes_logical_view_guidance(self) -> None:
+        """Round 5 should gather logical-view concepts without forcing technical design language."""
         round_definition = get_round(5)
+
+        self.assertIn(
+            "Focus on the important nouns, relationships, and rules, not implementation classes.",
+            round_definition.guidance,
+        )
+        self.assertEqual(round_definition.questions[0].key, "domain_entities")
+        self.assertIn("Capability", round_definition.questions[0].example)
+        self.assertEqual(round_definition.questions[1].key, "relationships")
+        self.assertEqual(round_definition.questions[2].key, "business_rules")
+
+    def test_ucp_actor_round_exposes_inversion_guidance(self) -> None:
+        """Round 6 should explain the common actor complexity intuition mismatch."""
+        round_definition = get_round(6)
 
         self.assertIn(
             "System or API actors are usually simpler than humans using a rich UI.",
@@ -194,9 +208,9 @@ class InterviewHarnessTests(unittest.TestCase):
         self.assertIn("Enterprise architect: complex", question.example)
 
     def test_technical_factor_round_exposes_0_to_5_guidance(self) -> None:
-        """Round 7 should clarify that the factor scale is about influence, not quality."""
+        """Round 8 should clarify that the factor scale is about influence, not quality."""
         result = process_round(
-            7,
+            8,
             (
                 "Technical:\n"
                 "security: 5\n"
@@ -285,8 +299,8 @@ class InterviewHarnessTests(unittest.TestCase):
         )
 
         payload = json.loads(completed.stdout)
-        self.assertEqual(payload["last_round"], 6)
-        self.assertEqual(payload["next_round"]["number"], 7)
+        self.assertEqual(payload["last_round"], 7)
+        self.assertEqual(payload["next_round"]["number"], 8)
         self.assertEqual(
             payload["transcript"][0]["responses"][0]["label"],
             "Idea",
@@ -313,12 +327,13 @@ class InterviewHarnessTests(unittest.TestCase):
         )
         self.assertIn(
             "IT Business Owner: Simple",
-            payload["merged_answers"]["round_5"]["actor_complexity"],
+            payload["merged_answers"]["round_6"]["actor_complexity"],
         )
         self.assertIn(
             "expose/export data by API: Complex",
-            payload["merged_answers"]["round_6"]["use_case_complexity"],
+            payload["merged_answers"]["round_7"]["use_case_complexity"],
         )
+        self.assertEqual(payload["readiness"]["logical"], "blocked")
 
     def test_replay_cli_applies_updates_fixture(self) -> None:
         """The replay CLI should support targeted updates without replay restarts."""

--- a/tests/test_readiness.py
+++ b/tests/test_readiness.py
@@ -18,11 +18,13 @@ class ReadinessTests(unittest.TestCase):
                 {"round": 3, "responses": []},
                 {"round": 4, "responses": []},
                 {"round": 5, "responses": []},
+                {"round": 6, "responses": []},
             ]
         )
 
         self.assertEqual(readiness["discovery"], "partial")
         self.assertEqual(readiness["use_case"], "ready")
+        self.assertEqual(readiness["logical"], "ready")
         self.assertEqual(readiness["ucp"], "partial")
 
     def test_identify_stale_artifacts_maps_round_updates_to_outputs(self) -> None:
@@ -30,7 +32,7 @@ class ReadinessTests(unittest.TestCase):
         stale = identify_stale_artifacts(
             [
                 {"round": 2, "responses": []},
-                {"round": 6, "responses": []},
+                {"round": 7, "responses": []},
             ]
         )
 


### PR DESCRIPTION
## Summary
- insert a `Domain Model` interview round before UCP capture to cover the logical view
- capture `domain_entities`, `relationships`, and `business_rules` as the first RUP-aligned view expansion
- extend readiness reporting with a `logical` view and preserve compatibility for older replay fixtures

## Testing
- `uv run python -m unittest`

## Related Issues
- closes #23
- refs #27