### PR TITLE
Add process view interview round

### DIFF
--- a/skills/specops-interview/references/interview-rounds.md
+++ b/skills/specops-interview/references/interview-rounds.md
@@ -102,7 +102,28 @@ Collect:
 This round is for the logical view. Do not force technical design language if the stakeholder is
 still speaking in business concepts.
 
-## Round 6: UCP Actor Complexity
+## Round 6: State and Workflow Model
+
+Ask at most 3 prompts.
+
+Preferred answer shape:
+
+```text
+State entities:
+States and transitions:
+Triggers and approvals:
+```
+
+Collect:
+
+- entities or workflows with meaningful lifecycle behavior
+- key states and allowed transitions
+- approvals, validations, time-based triggers, and exception paths
+
+This round is for the process view. Focus on business lifecycle behavior instead of implementation
+events or internal code hooks.
+
+## Round 7: UCP Actor Complexity
 
 Do not ask for all UCP inputs in one block.
 
@@ -125,7 +146,7 @@ Actor complexity:
 - Actor B: simple/average/complex
 ```
 
-## Round 7: UCP Use-Case Complexity
+## Round 8: UCP Use-Case Complexity
 
 Explain the scale first:
 
@@ -145,7 +166,7 @@ Use-case complexity:
 - Use case B: simple/average/complex
 ```
 
-## Round 8: UCP Technical Factors
+## Round 9: UCP Technical Factors
 
 Explain the influence scale briefly:
 
@@ -172,7 +193,7 @@ complex internal processing:
 ...
 ```
 
-## Round 9: UCP Environmental Factors
+## Round 10: UCP Environmental Factors
 
 Use the same `0-5` influence explanation, but state clearly that:
 

--- a/src/specops_tools/interview.py
+++ b/src/specops_tools/interview.py
@@ -79,14 +79,6 @@ def _parse_block_answer(text: str) -> dict[str, Any]:
     return parsed
 
 
-LEGACY_ROUND_KEY_MAP = {
-    5: "actor_complexity",
-    6: "use_case_complexity",
-    7: "technical",
-    8: "environmental",
-}
-
-
 @dataclass(frozen=True)
 class InterviewQuestion:
     """Definition of one question within an interview round."""
@@ -246,6 +238,48 @@ ROUND_DEFINITIONS: list[InterviewRound] = [
     ),
     InterviewRound(
         number=6,
+        title="State and Workflow Model",
+        prompt=(
+            "Capture the important lifecycle states, transitions, and triggers that shape the "
+            "process view."
+        ),
+        template="State entities:\nStates and transitions:\nTriggers and approvals:\n",
+        guidance=(
+            "Focus on business lifecycle behavior, approvals, and transitions, not implementation events.",
+            "If a process is unclear, capture the uncertainty instead of forcing a complete state machine.",
+        ),
+        questions=(
+            InterviewQuestion(
+                "state_entities",
+                "State entities",
+                "Which entities or workflows have meaningful states or lifecycle behavior?",
+                guidance=(
+                    "Typical examples are System, Approval Request, Contract, Case, or Application Lifecycle.",
+                ),
+                example="- System lifecycle\n- Deprecation request\n- Approval request",
+            ),
+            InterviewQuestion(
+                "states_and_transitions",
+                "States and transitions",
+                "What are the key states and allowed transitions?",
+                guidance=(
+                    "Capture the main states and the transitions stakeholders care about.",
+                ),
+                example="- Proposed -> Active -> Sunset -> Decommissioned\n- Submitted -> Approved or Rejected",
+            ),
+            InterviewQuestion(
+                "triggers_and_approvals",
+                "Triggers and approvals",
+                "What triggers transitions, and where are approvals or exceptions required?",
+                guidance=(
+                    "Include approvals, validations, time-based triggers, and exception paths where relevant.",
+                ),
+                example="- Deprecation requires governance approval\n- Missing metadata blocks promotion to Active",
+            ),
+        ),
+    ),
+    InterviewRound(
+        number=7,
         title="UCP Actor Complexity",
         prompt=(
             "Capture actor complexity using simple/average/complex after discovery is stable."
@@ -272,7 +306,7 @@ ROUND_DEFINITIONS: list[InterviewRound] = [
         ),
     ),
     InterviewRound(
-        number=7,
+        number=8,
         title="UCP Use-Case Complexity",
         prompt="Capture use-case complexity using simple/average/complex.",
         template="Use-case complexity:\n- Use case A: simple/average/complex\n",
@@ -295,7 +329,7 @@ ROUND_DEFINITIONS: list[InterviewRound] = [
         ),
     ),
     InterviewRound(
-        number=8,
+        number=9,
         title="UCP Technical Factors",
         prompt="Capture the technical 0-5 influence scores in a compact block.",
         template=(
@@ -322,7 +356,7 @@ ROUND_DEFINITIONS: list[InterviewRound] = [
         ),
     ),
     InterviewRound(
-        number=9,
+        number=10,
         title="UCP Environmental Factors",
         prompt="Capture the environmental 0-5 influence scores in a compact block.",
         template=(
@@ -377,10 +411,6 @@ def next_round(number: int) -> InterviewRound | None:
 
 def _resolve_round_number(number: int, item: dict[str, Any]) -> int:
     """Resolve a round number, including compatibility with legacy replay fixtures."""
-    if number not in LEGACY_ROUND_KEY_MAP:
-        return number
-
-    expected_key = LEGACY_ROUND_KEY_MAP[number]
     candidate_keys: set[str] = set()
 
     if "responses" in item:
@@ -393,8 +423,18 @@ def _resolve_round_number(number: int, item: dict[str, Any]) -> int:
     else:
         candidate_keys.update(_parse_block_answer(str(item.get("answer", ""))).keys())
 
-    if expected_key in candidate_keys:
-        return number + 1
+    if candidate_keys:
+        matching_rounds = []
+        for round_definition in ROUND_DEFINITIONS:
+            round_keys = {question.key for question in round_definition.questions}
+            if candidate_keys <= round_keys:
+                matching_rounds.append(round_definition.number)
+
+        if len(matching_rounds) == 1:
+            return matching_rounds[0]
+        if number in matching_rounds:
+            return number
+
     return number
 
 

--- a/src/specops_tools/readiness.py
+++ b/src/specops_tools/readiness.py
@@ -9,13 +9,15 @@ VIEW_REQUIREMENTS = {
     "discovery": {1, 2},
     "use_case": {3, 4},
     "logical": {5},
-    "ucp": {6, 7, 8, 9},
+    "process": {6},
+    "ucp": {7, 8, 9, 10},
 }
 
 VIEW_ARTIFACTS = {
     "discovery": ["requirements-spec.md"],
     "use_case": ["requirements-spec.md", "use-case-model.md"],
     "logical": ["requirements-spec.md"],
+    "process": ["requirements-spec.md", "use-case-model.md"],
     "ucp": ["ucp-estimate.md"],
 }
 

--- a/tests/test_interview.py
+++ b/tests/test_interview.py
@@ -69,6 +69,7 @@ class InterviewHarnessTests(unittest.TestCase):
         self.assertEqual(replay["readiness"]["discovery"], "ready")
         self.assertEqual(replay["readiness"]["use_case"], "blocked")
         self.assertEqual(replay["readiness"]["logical"], "blocked")
+        self.assertEqual(replay["readiness"]["process"], "blocked")
         self.assertEqual(replay["stale_artifacts"], [])
 
     def test_replay_session_accepts_individual_question_responses(self) -> None:
@@ -195,9 +196,22 @@ class InterviewHarnessTests(unittest.TestCase):
         self.assertEqual(round_definition.questions[1].key, "relationships")
         self.assertEqual(round_definition.questions[2].key, "business_rules")
 
-    def test_ucp_actor_round_exposes_inversion_guidance(self) -> None:
-        """Round 6 should explain the common actor complexity intuition mismatch."""
+    def test_state_round_exposes_process_view_guidance(self) -> None:
+        """Round 6 should gather process-view behavior without forcing implementation events."""
         round_definition = get_round(6)
+
+        self.assertIn(
+            "Focus on business lifecycle behavior, approvals, and transitions, not implementation events.",
+            round_definition.guidance,
+        )
+        self.assertEqual(round_definition.questions[0].key, "state_entities")
+        self.assertIn("Approval request", round_definition.questions[0].example)
+        self.assertEqual(round_definition.questions[1].key, "states_and_transitions")
+        self.assertEqual(round_definition.questions[2].key, "triggers_and_approvals")
+
+    def test_ucp_actor_round_exposes_inversion_guidance(self) -> None:
+        """Round 7 should explain the common actor complexity intuition mismatch."""
+        round_definition = get_round(7)
 
         self.assertIn(
             "System or API actors are usually simpler than humans using a rich UI.",
@@ -208,9 +222,9 @@ class InterviewHarnessTests(unittest.TestCase):
         self.assertIn("Enterprise architect: complex", question.example)
 
     def test_technical_factor_round_exposes_0_to_5_guidance(self) -> None:
-        """Round 8 should clarify that the factor scale is about influence, not quality."""
+        """Round 9 should clarify that the factor scale is about influence, not quality."""
         result = process_round(
-            8,
+            9,
             (
                 "Technical:\n"
                 "security: 5\n"
@@ -299,8 +313,8 @@ class InterviewHarnessTests(unittest.TestCase):
         )
 
         payload = json.loads(completed.stdout)
-        self.assertEqual(payload["last_round"], 7)
-        self.assertEqual(payload["next_round"]["number"], 8)
+        self.assertEqual(payload["last_round"], 8)
+        self.assertEqual(payload["next_round"]["number"], 9)
         self.assertEqual(
             payload["transcript"][0]["responses"][0]["label"],
             "Idea",
@@ -327,13 +341,14 @@ class InterviewHarnessTests(unittest.TestCase):
         )
         self.assertIn(
             "IT Business Owner: Simple",
-            payload["merged_answers"]["round_6"]["actor_complexity"],
+            payload["merged_answers"]["round_7"]["actor_complexity"],
         )
         self.assertIn(
             "expose/export data by API: Complex",
-            payload["merged_answers"]["round_7"]["use_case_complexity"],
+            payload["merged_answers"]["round_8"]["use_case_complexity"],
         )
         self.assertEqual(payload["readiness"]["logical"], "blocked")
+        self.assertEqual(payload["readiness"]["process"], "blocked")
 
     def test_replay_cli_applies_updates_fixture(self) -> None:
         """The replay CLI should support targeted updates without replay restarts."""

--- a/tests/test_readiness.py
+++ b/tests/test_readiness.py
@@ -19,12 +19,14 @@ class ReadinessTests(unittest.TestCase):
                 {"round": 4, "responses": []},
                 {"round": 5, "responses": []},
                 {"round": 6, "responses": []},
+                {"round": 7, "responses": []},
             ]
         )
 
         self.assertEqual(readiness["discovery"], "partial")
         self.assertEqual(readiness["use_case"], "ready")
         self.assertEqual(readiness["logical"], "ready")
+        self.assertEqual(readiness["process"], "ready")
         self.assertEqual(readiness["ucp"], "partial")
 
     def test_identify_stale_artifacts_maps_round_updates_to_outputs(self) -> None:
@@ -32,7 +34,7 @@ class ReadinessTests(unittest.TestCase):
         stale = identify_stale_artifacts(
             [
                 {"round": 2, "responses": []},
-                {"round": 7, "responses": []},
+                {"round": 8, "responses": []},
             ]
         )
 


### PR DESCRIPTION
## Summary
- add a `State and Workflow Model` interview round after the logical view
- capture `state_entities`, `states_and_transitions`, and `triggers_and_approvals` for the process view
- extend readiness reporting with a `process` view and preserve replay compatibility across older round-numbering schemes

## Testing
- `uv run python -m unittest`

## Related Issues
- refs #23
- refs #27