### PR TITLE
Add architecture view interview round

### DIFF
--- a/skills/specops-interview/references/interview-rounds.md
+++ b/skills/specops-interview/references/interview-rounds.md
@@ -123,7 +123,28 @@ Collect:
 This round is for the process view. Focus on business lifecycle behavior instead of implementation
 events or internal code hooks.
 
-## Round 7: UCP Actor Complexity
+## Round 7: Architecture and Deployment View
+
+Ask at most 3 prompts.
+
+Preferred answer shape:
+
+```text
+Components and services:
+Interfaces and integrations:
+Runtime boundaries:
+```
+
+Collect:
+
+- major components, subsystems, or services
+- interfaces and integrations between internal and external parts
+- runtime and deployment boundaries that matter for responsibility or hosting
+
+This round is for the first architectural view. Keep it at the level of major responsibilities and
+boundaries, not low-level implementation details.
+
+## Round 8: UCP Actor Complexity
 
 Do not ask for all UCP inputs in one block.
 
@@ -146,7 +167,7 @@ Actor complexity:
 - Actor B: simple/average/complex
 ```
 
-## Round 8: UCP Use-Case Complexity
+## Round 9: UCP Use-Case Complexity
 
 Explain the scale first:
 
@@ -166,7 +187,7 @@ Use-case complexity:
 - Use case B: simple/average/complex
 ```
 
-## Round 9: UCP Technical Factors
+## Round 10: UCP Technical Factors
 
 Explain the influence scale briefly:
 
@@ -193,7 +214,7 @@ complex internal processing:
 ...
 ```
 
-## Round 10: UCP Environmental Factors
+## Round 11: UCP Environmental Factors
 
 Use the same `0-5` influence explanation, but state clearly that:
 

--- a/src/specops_tools/interview.py
+++ b/src/specops_tools/interview.py
@@ -280,6 +280,48 @@ ROUND_DEFINITIONS: list[InterviewRound] = [
     ),
     InterviewRound(
         number=7,
+        title="Architecture and Deployment View",
+        prompt=(
+            "Capture the major components, interfaces, and runtime boundaries that shape the "
+            "architectural view."
+        ),
+        template="Components and services:\nInterfaces and integrations:\nRuntime boundaries:\n",
+        guidance=(
+            "Focus on business-relevant components and boundaries, not low-level implementation classes.",
+            "Capture only the architectural structure that materially affects responsibilities, deployment, or integration.",
+        ),
+        questions=(
+            InterviewQuestion(
+                "components_and_services",
+                "Components and services",
+                "What major components, subsystems, or services are needed?",
+                guidance=(
+                    "Examples include web app, workflow engine, reporting service, API, or integration adapter.",
+                ),
+                example="- Web application\n- Inventory API\n- Workflow service\n- Reporting adapter",
+            ),
+            InterviewQuestion(
+                "interfaces_and_integrations",
+                "Interfaces and integrations",
+                "What interfaces or integrations connect these parts?",
+                guidance=(
+                    "Include APIs, message flows, data feeds, and external system boundaries where they matter.",
+                ),
+                example="- Web application calls Inventory API\n- Reporting adapter exports data to BI platform",
+            ),
+            InterviewQuestion(
+                "runtime_boundaries",
+                "Runtime boundaries",
+                "What runtime, environment, or deployment boundaries matter?",
+                guidance=(
+                    "Capture distinctions such as internal service vs external platform, cloud vs on-prem, or batch vs interactive runtime.",
+                ),
+                example="- Internal web app and API run in the same platform\n- Reporting export runs on a scheduled job",
+            ),
+        ),
+    ),
+    InterviewRound(
+        number=8,
         title="UCP Actor Complexity",
         prompt=(
             "Capture actor complexity using simple/average/complex after discovery is stable."
@@ -306,7 +348,7 @@ ROUND_DEFINITIONS: list[InterviewRound] = [
         ),
     ),
     InterviewRound(
-        number=8,
+        number=9,
         title="UCP Use-Case Complexity",
         prompt="Capture use-case complexity using simple/average/complex.",
         template="Use-case complexity:\n- Use case A: simple/average/complex\n",
@@ -329,7 +371,7 @@ ROUND_DEFINITIONS: list[InterviewRound] = [
         ),
     ),
     InterviewRound(
-        number=9,
+        number=10,
         title="UCP Technical Factors",
         prompt="Capture the technical 0-5 influence scores in a compact block.",
         template=(
@@ -356,7 +398,7 @@ ROUND_DEFINITIONS: list[InterviewRound] = [
         ),
     ),
     InterviewRound(
-        number=10,
+        number=11,
         title="UCP Environmental Factors",
         prompt="Capture the environmental 0-5 influence scores in a compact block.",
         template=(

--- a/src/specops_tools/readiness.py
+++ b/src/specops_tools/readiness.py
@@ -10,7 +10,8 @@ VIEW_REQUIREMENTS = {
     "use_case": {3, 4},
     "logical": {5},
     "process": {6},
-    "ucp": {7, 8, 9, 10},
+    "architecture": {7},
+    "ucp": {8, 9, 10, 11},
 }
 
 VIEW_ARTIFACTS = {
@@ -18,6 +19,7 @@ VIEW_ARTIFACTS = {
     "use_case": ["requirements-spec.md", "use-case-model.md"],
     "logical": ["requirements-spec.md"],
     "process": ["requirements-spec.md", "use-case-model.md"],
+    "architecture": ["requirements-spec.md", "use-case-model.md"],
     "ucp": ["ucp-estimate.md"],
 }
 

--- a/tests/test_interview.py
+++ b/tests/test_interview.py
@@ -70,6 +70,7 @@ class InterviewHarnessTests(unittest.TestCase):
         self.assertEqual(replay["readiness"]["use_case"], "blocked")
         self.assertEqual(replay["readiness"]["logical"], "blocked")
         self.assertEqual(replay["readiness"]["process"], "blocked")
+        self.assertEqual(replay["readiness"]["architecture"], "blocked")
         self.assertEqual(replay["stale_artifacts"], [])
 
     def test_replay_session_accepts_individual_question_responses(self) -> None:
@@ -209,9 +210,22 @@ class InterviewHarnessTests(unittest.TestCase):
         self.assertEqual(round_definition.questions[1].key, "states_and_transitions")
         self.assertEqual(round_definition.questions[2].key, "triggers_and_approvals")
 
-    def test_ucp_actor_round_exposes_inversion_guidance(self) -> None:
-        """Round 7 should explain the common actor complexity intuition mismatch."""
+    def test_architecture_round_exposes_view_guidance(self) -> None:
+        """Round 7 should gather architectural structure without collapsing into implementation detail."""
         round_definition = get_round(7)
+
+        self.assertIn(
+            "Focus on business-relevant components and boundaries, not low-level implementation classes.",
+            round_definition.guidance,
+        )
+        self.assertEqual(round_definition.questions[0].key, "components_and_services")
+        self.assertIn("Workflow service", round_definition.questions[0].example)
+        self.assertEqual(round_definition.questions[1].key, "interfaces_and_integrations")
+        self.assertEqual(round_definition.questions[2].key, "runtime_boundaries")
+
+    def test_ucp_actor_round_exposes_inversion_guidance(self) -> None:
+        """Round 8 should explain the common actor complexity intuition mismatch."""
+        round_definition = get_round(8)
 
         self.assertIn(
             "System or API actors are usually simpler than humans using a rich UI.",
@@ -222,9 +236,9 @@ class InterviewHarnessTests(unittest.TestCase):
         self.assertIn("Enterprise architect: complex", question.example)
 
     def test_technical_factor_round_exposes_0_to_5_guidance(self) -> None:
-        """Round 9 should clarify that the factor scale is about influence, not quality."""
+        """Round 10 should clarify that the factor scale is about influence, not quality."""
         result = process_round(
-            9,
+            10,
             (
                 "Technical:\n"
                 "security: 5\n"
@@ -313,8 +327,8 @@ class InterviewHarnessTests(unittest.TestCase):
         )
 
         payload = json.loads(completed.stdout)
-        self.assertEqual(payload["last_round"], 8)
-        self.assertEqual(payload["next_round"]["number"], 9)
+        self.assertEqual(payload["last_round"], 9)
+        self.assertEqual(payload["next_round"]["number"], 10)
         self.assertEqual(
             payload["transcript"][0]["responses"][0]["label"],
             "Idea",
@@ -341,14 +355,15 @@ class InterviewHarnessTests(unittest.TestCase):
         )
         self.assertIn(
             "IT Business Owner: Simple",
-            payload["merged_answers"]["round_7"]["actor_complexity"],
+            payload["merged_answers"]["round_8"]["actor_complexity"],
         )
         self.assertIn(
             "expose/export data by API: Complex",
-            payload["merged_answers"]["round_8"]["use_case_complexity"],
+            payload["merged_answers"]["round_9"]["use_case_complexity"],
         )
         self.assertEqual(payload["readiness"]["logical"], "blocked")
         self.assertEqual(payload["readiness"]["process"], "blocked")
+        self.assertEqual(payload["readiness"]["architecture"], "blocked")
 
     def test_replay_cli_applies_updates_fixture(self) -> None:
         """The replay CLI should support targeted updates without replay restarts."""

--- a/tests/test_readiness.py
+++ b/tests/test_readiness.py
@@ -20,6 +20,7 @@ class ReadinessTests(unittest.TestCase):
                 {"round": 5, "responses": []},
                 {"round": 6, "responses": []},
                 {"round": 7, "responses": []},
+                {"round": 8, "responses": []},
             ]
         )
 
@@ -27,6 +28,7 @@ class ReadinessTests(unittest.TestCase):
         self.assertEqual(readiness["use_case"], "ready")
         self.assertEqual(readiness["logical"], "ready")
         self.assertEqual(readiness["process"], "ready")
+        self.assertEqual(readiness["architecture"], "ready")
         self.assertEqual(readiness["ucp"], "partial")
 
     def test_identify_stale_artifacts_maps_round_updates_to_outputs(self) -> None:
@@ -34,7 +36,7 @@ class ReadinessTests(unittest.TestCase):
         stale = identify_stale_artifacts(
             [
                 {"round": 2, "responses": []},
-                {"round": 8, "responses": []},
+                {"round": 9, "responses": []},
             ]
         )
 


### PR DESCRIPTION
## Summary
- add an `Architecture and Deployment View` interview round after the process view
- capture `components_and_services`, `interfaces_and_integrations`, and `runtime_boundaries` for the first architectural/deployment pass
- extend readiness reporting with an `architecture` view while preserving replay compatibility across older round-numbering schemes

## Testing
- `uv run python -m unittest`

## Related Issues
- refs #23
- refs #27