### PR TITLE
Extend canonical model for new interview views

### DIFF
--- a/examples/it-systems-inventory/specops-model.yaml
+++ b/examples/it-systems-inventory/specops-model.yaml
@@ -176,6 +176,54 @@ requirements:
     - The system must support search and filtering.
     - The system must provide availability of at least 99%.
     - The system must provide acceptable web performance for normal page rendering.
+logical_view:
+  domain_entities:
+    - System
+    - Capability
+    - Business Owner
+    - Technical Owner
+    - Contract
+    - Lifecycle State
+    - Approval Request
+    - Risk Assessment
+  relationships:
+    - A System has one Business Owner and one Technical Owner.
+    - A System may support multiple Capabilities.
+    - A System may have one or more Contracts over time.
+    - A System has one current Lifecycle State.
+    - An Approval Request belongs to a System lifecycle or deprecation workflow.
+    - A Risk Assessment is recorded against a System or portfolio slice.
+  business_rules:
+    - A System cannot move to an active lifecycle state without required metadata.
+    - A deprecation-related approval request must reference a valid System record.
+    - Contract end date and ownership data must remain available for lifecycle planning.
+process_view:
+  state_entities:
+    - System lifecycle
+    - Deprecation request
+    - Approval workflow
+  states_and_transitions:
+    - System lifecycle: Proposed -> Active -> Tolerated -> Sunset -> Decommissioned.
+    - Deprecation request: Draft -> Submitted -> Approved or Rejected.
+    - Approval workflow: Pending -> Approved or Rejected.
+  triggers_and_approvals:
+    - Moving from a requested lifecycle transition to completion may require governance approval.
+    - Missing required metadata blocks promotion into an active lifecycle state.
+    - A rejected approval returns the request to rework instead of completing the transition.
+architecture_view:
+  components_and_services:
+    - Web application for inventory, workflow, and review actions.
+    - Inventory API for downstream reporting and automation access.
+    - Workflow service for lifecycle transitions and approvals.
+    - Reporting/export adapter for downstream portfolio reporting.
+  interfaces_and_integrations:
+    - Web application uses the Inventory API and Workflow service.
+    - Reporting/export adapter publishes inventory and lifecycle data to downstream reporting systems.
+    - Downstream API consumers read inventory and lifecycle data through authenticated API calls.
+  runtime_boundaries:
+    - Interactive user workflows run through the web application and backing services.
+    - Reporting/export flows may run as scheduled integration jobs.
+    - Downstream systems consume data across an API boundary rather than direct database access.
 metadata_fields:
   - system name
   - description

--- a/skills/specops/references/specops-model.md
+++ b/skills/specops/references/specops-model.md
@@ -28,6 +28,18 @@ The canonical project model is `specops-model.yaml`.
 - `requirements`
   - `functional`
   - `non_functional`
+- `logical_view` (optional in V1, expected for V1.5+ full-spec work)
+  - `domain_entities`
+  - `relationships`
+  - `business_rules`
+- `process_view` (optional in V1, expected for V1.5+ full-spec work)
+  - `state_entities`
+  - `states_and_transitions`
+  - `triggers_and_approvals`
+- `architecture_view` (optional in V1, expected for V1.5+ full-spec work)
+  - `components_and_services`
+  - `interfaces_and_integrations`
+  - `runtime_boundaries`
 - `assumptions`
   - supports plain strings
   - may also use structured items with:
@@ -59,5 +71,11 @@ The model should be rich enough to generate:
 - `requirements-spec.md`
 - `use-case-model.md`
 - `ucp-estimate.md`
+
+For V1.5+ work, the same model should also have stable places to hold:
+
+- logical-view discovery
+- process/state-view discovery
+- architecture/deployment-view discovery
 
 If any artifact would require invented inputs, stop and surface the missing fields.

--- a/src/specops_tools/render.py
+++ b/src/specops_tools/render.py
@@ -52,6 +52,17 @@ def _uncertainty_list(items: list[Any]) -> str:
     return "\n".join(rendered)
 
 
+def _named_section(title: str, items: list[str]) -> str:
+    """Render a markdown section only when items exist."""
+    if not items:
+        return ""
+    return f"""
+## {title}
+
+{_bullet_list(items)}
+"""
+
+
 def render_requirements_spec(model: dict[str, Any]) -> str:
     """Render the requirements specification artifact.
 
@@ -63,6 +74,9 @@ def render_requirements_spec(model: dict[str, Any]) -> str:
     """
     project = model.get("project", {})
     requirements = model.get("requirements", {})
+    logical_view = model.get("logical_view", {})
+    process_view = model.get("process_view", {})
+    architecture_view = model.get("architecture_view", {})
     return f"""# Requirements Specification
 
 ## Project
@@ -90,6 +104,15 @@ def render_requirements_spec(model: dict[str, Any]) -> str:
 ## Non-Functional Requirements
 
 {_bullet_list(requirements.get("non_functional", []))}
+{_named_section("Logical View", logical_view.get("domain_entities", []))}
+{_named_section("Relationships", logical_view.get("relationships", []))}
+{_named_section("Business Rules", logical_view.get("business_rules", []))}
+{_named_section("Process View", process_view.get("state_entities", []))}
+{_named_section("States and Transitions", process_view.get("states_and_transitions", []))}
+{_named_section("Triggers and Approvals", process_view.get("triggers_and_approvals", []))}
+{_named_section("Architecture View", architecture_view.get("components_and_services", []))}
+{_named_section("Interfaces and Integrations", architecture_view.get("interfaces_and_integrations", []))}
+{_named_section("Runtime Boundaries", architecture_view.get("runtime_boundaries", []))}
 
 ## Assumptions
 
@@ -144,6 +167,8 @@ def render_use_case_model(model: dict[str, Any]) -> str:
 
     actor_block = "\n".join(actor_lines) or "- None"
     use_case_block = "\n".join(use_case_sections) or "No use cases documented."
+    process_view = model.get("process_view", {})
+    architecture_view = model.get("architecture_view", {})
 
     return f"""# Use-Case Model
 
@@ -154,6 +179,9 @@ def render_use_case_model(model: dict[str, Any]) -> str:
 ## Use Cases
 
 {use_case_block}
+{_named_section("States and Transitions", process_view.get("states_and_transitions", []))}
+{_named_section("Triggers and Approvals", process_view.get("triggers_and_approvals", []))}
+{_named_section("Interfaces and Integrations", architecture_view.get("interfaces_and_integrations", []))}
 """
 
 

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -44,6 +44,54 @@ class RenderTests(unittest.TestCase):
         self.assertIn("notes: Team topology still needs confirmation.", rendered)
         self.assertIn("status: unknown", rendered)
 
+    def test_requirements_render_includes_extended_view_sections(self) -> None:
+        """Requirements rendering should include logical, process, and architecture sections when present."""
+        model = build_model()
+        model["logical_view"] = {
+            "domain_entities": ["Member", "Reward"],
+            "relationships": ["A Member can redeem many Rewards."],
+            "business_rules": ["A Reward requires sufficient points."],
+        }
+        model["process_view"] = {
+            "state_entities": ["Redemption request"],
+            "states_and_transitions": ["Requested -> Approved -> Fulfilled"],
+            "triggers_and_approvals": ["Approval is required for manual fulfillment."],
+        }
+        model["architecture_view"] = {
+            "components_and_services": ["Member app", "Rewards API"],
+            "interfaces_and_integrations": ["Member app calls Rewards API."],
+            "runtime_boundaries": ["Rewards API runs as a separate service."],
+        }
+
+        rendered = render_requirements_spec(model)
+
+        self.assertIn("## Logical View", rendered)
+        self.assertIn("Member", rendered)
+        self.assertIn("## Process View", rendered)
+        self.assertIn("Requested -> Approved -> Fulfilled", rendered)
+        self.assertIn("## Architecture View", rendered)
+        self.assertIn("Rewards API runs as a separate service.", rendered)
+
+    def test_use_case_render_includes_process_and_architecture_sections(self) -> None:
+        """Use-case rendering should include relevant process and architecture sections when present."""
+        from specops_tools.render import render_use_case_model
+
+        model = build_model()
+        model["process_view"] = {
+            "states_and_transitions": ["Requested -> Approved -> Fulfilled"],
+            "triggers_and_approvals": ["Approval is required for manual fulfillment."],
+        }
+        model["architecture_view"] = {
+            "interfaces_and_integrations": ["Member app calls Rewards API."],
+        }
+
+        rendered = render_use_case_model(model)
+
+        self.assertIn("## States and Transitions", rendered)
+        self.assertIn("Requested -> Approved -> Fulfilled", rendered)
+        self.assertIn("## Interfaces and Integrations", rendered)
+        self.assertIn("Member app calls Rewards API.", rendered)
+
     def test_ucp_render_supports_structured_uncertainty_items(self) -> None:
         """UCP rendering should preserve uncertainty metadata when present."""
         model = build_model()


### PR DESCRIPTION
## Summary
- extend the canonical model contract with `logical_view`, `process_view`, and `architecture_view`
- render those sections in the requirements and use-case outputs when present
- enrich the IT systems inventory example with representative logical/process/architecture data

## Testing
- `uv run python -m unittest`

## Related Issues
- refs #23
- refs #27