### PR TITLE
Normalize interview replay into extended model

### DIFF
--- a/src/specops_tools/discovery.py
+++ b/src/specops_tools/discovery.py
@@ -1,0 +1,110 @@
+"""Deterministic normalization from interview replay data into a SpecOps model."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _ensure_list(value: Any) -> list[str]:
+    """Normalize a scalar or list answer into a clean string list."""
+    def _clean(item: Any) -> str:
+        text = str(item).strip()
+        if text.startswith("- "):
+            text = text[2:].strip()
+        return text
+
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [_clean(item) for item in value if _clean(item)]
+    text = _clean(value)
+    return [text] if text else []
+
+
+def _text_or_empty(value: Any) -> str:
+    """Normalize a scalar answer into a string."""
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
+    """Normalize replay output into a canonical SpecOps model shape.
+
+    This keeps the transformation deterministic and conservative. It maps interview answers into
+    stable model sections without inventing actors, use cases, or requirements that were not stated.
+
+    Args:
+        replay: Output from `replay_session()` or `replay_session_with_updates()`.
+
+    Returns:
+        Canonical model dictionary.
+    """
+    merged_answers = replay.get("merged_answers", {})
+    round_1 = merged_answers.get("round_1", {})
+    round_2 = merged_answers.get("round_2", {})
+    round_3 = merged_answers.get("round_3", {})
+    round_4 = merged_answers.get("round_4", {})
+    round_5 = merged_answers.get("round_5", {})
+    round_6 = merged_answers.get("round_6", {})
+
+    functional_requirements = []
+    if workflow_scope := _text_or_empty(round_4.get("workflow_scope")):
+        functional_requirements.append(workflow_scope)
+    if integrations := _text_or_empty(round_3.get("integrations")):
+        functional_requirements.append(integrations)
+
+    constraints = _ensure_list(round_2.get("constraints"))
+    non_functional = _ensure_list(round_4.get("non_functional_requirements"))
+    if constraints:
+        non_functional = constraints + non_functional
+
+    return {
+        "project": {
+            "name": _text_or_empty(round_1.get("idea")) or "Unnamed Project",
+            "domain": "Unspecified",
+            "problem_statement": _text_or_empty(round_1.get("problem")) or "Unspecified",
+            "system_scope": _text_or_empty(round_1.get("in_scope")) or "Unspecified",
+        },
+        "business_goals": _ensure_list(round_2.get("outcomes")),
+        "success_criteria": _ensure_list(round_2.get("success_criteria")),
+        "actors": [],
+        "use_cases": [],
+        "requirements": {
+            "functional": functional_requirements,
+            "non_functional": non_functional,
+        },
+        "logical_view": {
+            "domain_entities": _ensure_list(round_5.get("domain_entities")),
+            "relationships": _ensure_list(round_5.get("relationships")),
+            "business_rules": _ensure_list(round_5.get("business_rules")),
+        },
+        "process_view": {
+            "state_entities": _ensure_list(round_6.get("state_entities")),
+            "states_and_transitions": _ensure_list(round_6.get("states_and_transitions")),
+            "triggers_and_approvals": _ensure_list(round_6.get("triggers_and_approvals")),
+        },
+        "architecture_view": {
+            "components_and_services": _ensure_list(
+                merged_answers.get("round_7", {}).get("components_and_services")
+            ),
+            "interfaces_and_integrations": _ensure_list(
+                merged_answers.get("round_7", {}).get("interfaces_and_integrations")
+            ),
+            "runtime_boundaries": _ensure_list(
+                merged_answers.get("round_7", {}).get("runtime_boundaries")
+            ),
+        },
+        "metadata_fields": _ensure_list(round_4.get("metadata_fields")),
+        "assumptions": [],
+        "open_questions": [],
+        "ucp": {
+            "technical_factors": {},
+            "environmental_factors": {},
+            "productivity_hours_per_ucp": 20,
+        },
+        "future_placeholders": {
+            "uml": [],
+            "formal_specification": [],
+        },
+    }

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,0 +1,130 @@
+"""Tests for deterministic interview-to-model normalization."""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+from specops_tools.discovery import normalize_replay_to_model
+from specops_tools.interview import replay_session
+
+
+class DiscoveryTests(unittest.TestCase):
+    """Coverage for interview normalization."""
+
+    def test_normalize_replay_to_model_maps_new_view_sections(self) -> None:
+        """Replay answers for the new rounds should land in the matching model sections."""
+        replay = replay_session(
+            [
+                {
+                    "round": 1,
+                    "responses": [
+                        {"key": "idea", "answer": "SpecOps Test"},
+                        {"key": "problem", "answer": "Fragmented requirements"},
+                        {"key": "in_scope", "answer": "V1.5 interview flow"},
+                    ],
+                },
+                {
+                    "round": 2,
+                    "responses": [
+                        {"key": "outcomes", "answer": ["Clearer specs"]},
+                        {"key": "constraints", "answer": ["Web based"]},
+                    ],
+                },
+                {
+                    "round": 4,
+                    "responses": [
+                        {"key": "workflow_scope", "answer": "Support approvals and reviews"},
+                        {"key": "metadata_fields", "answer": ["name", "owner"]},
+                        {"key": "non_functional_requirements", "answer": ["SSO"]},
+                    ],
+                },
+                {
+                    "round": 5,
+                    "responses": [
+                        {"key": "domain_entities", "answer": ["System", "Approval Request"]},
+                        {"key": "relationships", "answer": ["A System has many Approval Requests"]},
+                        {"key": "business_rules", "answer": ["Approval requires an owner"]},
+                    ],
+                },
+                {
+                    "round": 6,
+                    "responses": [
+                        {"key": "state_entities", "answer": ["Approval request"]},
+                        {
+                            "key": "states_and_transitions",
+                            "answer": ["Draft -> Submitted -> Approved"],
+                        },
+                        {
+                            "key": "triggers_and_approvals",
+                            "answer": ["Submission triggers review"],
+                        },
+                    ],
+                },
+                {
+                    "round": 7,
+                    "responses": [
+                        {"key": "components_and_services", "answer": ["Web app", "API"]},
+                        {
+                            "key": "interfaces_and_integrations",
+                            "answer": ["Web app calls API"],
+                        },
+                        {
+                            "key": "runtime_boundaries",
+                            "answer": ["API runs separately from the UI"],
+                        },
+                    ],
+                },
+            ]
+        )
+
+        model = normalize_replay_to_model(replay)
+
+        self.assertEqual(model["project"]["name"], "SpecOps Test")
+        self.assertIn("Clearer specs", model["business_goals"])
+        self.assertIn("Web based", model["requirements"]["non_functional"])
+        self.assertIn("System", model["logical_view"]["domain_entities"])
+        self.assertIn(
+            "Draft -> Submitted -> Approved",
+            model["process_view"]["states_and_transitions"],
+        )
+        self.assertIn("Web app", model["architecture_view"]["components_and_services"])
+
+    def test_normalize_replay_to_model_keeps_empty_sections_explicit(self) -> None:
+        """Missing optional view rounds should still produce stable empty sections."""
+        replay = replay_session(
+            [
+                {
+                    "round": 1,
+                    "responses": [
+                        {"key": "idea", "answer": "SpecOps Test"},
+                        {"key": "problem", "answer": "Fragmented requirements"},
+                    ],
+                }
+            ]
+        )
+
+        model = normalize_replay_to_model(replay)
+
+        self.assertEqual(model["logical_view"]["domain_entities"], [])
+        self.assertEqual(model["process_view"]["state_entities"], [])
+        self.assertEqual(model["architecture_view"]["components_and_services"], [])
+
+    def test_normalize_replay_to_model_with_real_fixture(self) -> None:
+        """The checked-in interview fixture should normalize into the canonical V1.5 shape."""
+        repo_root = Path(__file__).resolve().parents[1]
+        fixture_path = repo_root / "tests" / "fixtures" / "it_systems_inventory_session.json"
+        fixture = json.loads(fixture_path.read_text())
+
+        replay = replay_session(fixture["rounds"])
+        model = normalize_replay_to_model(replay)
+
+        self.assertEqual(
+            model["project"]["name"],
+            "A system to manage inventory of IT Systems themselves.",
+        )
+        self.assertIn("UI must be web based", model["requirements"]["non_functional"])
+        self.assertIn("System name", model["metadata_fields"])
+        self.assertEqual(model["logical_view"]["domain_entities"], [])
+        self.assertEqual(model["process_view"]["state_entities"], [])


### PR DESCRIPTION
## Summary
- add a deterministic normalization bridge from replayed interview output into the canonical model
- map replay answers into the extended `logical_view`, `process_view`, and `architecture_view` sections
- keep missing newer view rounds explicit as empty sections instead of inventing data

## Testing
- `uv run python -m unittest`

## Related Issues
- refs #23
- refs #27