### PR TITLE
Add structured normalization for new views

### DIFF
--- a/src/specops_tools/discovery.py
+++ b/src/specops_tools/discovery.py
@@ -5,6 +5,20 @@ from __future__ import annotations
 from typing import Any
 
 
+def _slugify(value: str) -> str:
+    """Create a stable slug-like identifier."""
+    cleaned = []
+    for char in value.strip().lower():
+        if char.isalnum():
+            cleaned.append(char)
+        else:
+            cleaned.append("-")
+    result = "".join(cleaned).strip("-")
+    while "--" in result:
+        result = result.replace("--", "-")
+    return result or "item"
+
+
 def _ensure_list(value: Any) -> list[str]:
     """Normalize a scalar or list answer into a clean string list."""
     def _clean(item: Any) -> str:
@@ -19,6 +33,28 @@ def _ensure_list(value: Any) -> list[str]:
         return [_clean(item) for item in value if _clean(item)]
     text = _clean(value)
     return [text] if text else []
+
+
+def _string_items_to_named_items(items: list[str], kind: str) -> list[dict[str, str]]:
+    """Convert string items into simple structured objects."""
+    return [
+        {
+            "id": f"{kind}-{_slugify(item)}",
+            "name": item,
+        }
+        for item in items
+    ]
+
+
+def _string_items_to_described_items(items: list[str], kind: str) -> list[dict[str, str]]:
+    """Convert string items into structured objects with text descriptions."""
+    return [
+        {
+            "id": f"{kind}-{index}",
+            "text": item,
+        }
+        for index, item in enumerate(items, 1)
+    ]
 
 
 def _text_or_empty(value: Any) -> str:
@@ -47,6 +83,7 @@ def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
     round_4 = merged_answers.get("round_4", {})
     round_5 = merged_answers.get("round_5", {})
     round_6 = merged_answers.get("round_6", {})
+    round_7 = merged_answers.get("round_7", {})
 
     functional_requirements = []
     if workflow_scope := _text_or_empty(round_4.get("workflow_scope")):
@@ -58,6 +95,16 @@ def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
     non_functional = _ensure_list(round_4.get("non_functional_requirements"))
     if constraints:
         non_functional = constraints + non_functional
+
+    domain_entities = _ensure_list(round_5.get("domain_entities"))
+    relationships = _ensure_list(round_5.get("relationships"))
+    business_rules = _ensure_list(round_5.get("business_rules"))
+    state_entities = _ensure_list(round_6.get("state_entities"))
+    states_and_transitions = _ensure_list(round_6.get("states_and_transitions"))
+    triggers_and_approvals = _ensure_list(round_6.get("triggers_and_approvals"))
+    components_and_services = _ensure_list(round_7.get("components_and_services"))
+    interfaces_and_integrations = _ensure_list(round_7.get("interfaces_and_integrations"))
+    runtime_boundaries = _ensure_list(round_7.get("runtime_boundaries"))
 
     return {
         "project": {
@@ -75,24 +122,45 @@ def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
             "non_functional": non_functional,
         },
         "logical_view": {
-            "domain_entities": _ensure_list(round_5.get("domain_entities")),
-            "relationships": _ensure_list(round_5.get("relationships")),
-            "business_rules": _ensure_list(round_5.get("business_rules")),
+            "domain_entities": domain_entities,
+            "domain_entity_objects": _string_items_to_named_items(domain_entities, "entity"),
+            "relationships": relationships,
+            "relationship_objects": _string_items_to_described_items(relationships, "relationship"),
+            "business_rules": business_rules,
+            "business_rule_objects": _string_items_to_described_items(
+                business_rules,
+                "business-rule",
+            ),
         },
         "process_view": {
-            "state_entities": _ensure_list(round_6.get("state_entities")),
-            "states_and_transitions": _ensure_list(round_6.get("states_and_transitions")),
-            "triggers_and_approvals": _ensure_list(round_6.get("triggers_and_approvals")),
+            "state_entities": state_entities,
+            "state_entity_objects": _string_items_to_named_items(state_entities, "state-entity"),
+            "states_and_transitions": states_and_transitions,
+            "state_transition_objects": _string_items_to_described_items(
+                states_and_transitions,
+                "state-transition",
+            ),
+            "triggers_and_approvals": triggers_and_approvals,
+            "trigger_objects": _string_items_to_described_items(
+                triggers_and_approvals,
+                "trigger",
+            ),
         },
         "architecture_view": {
-            "components_and_services": _ensure_list(
-                merged_answers.get("round_7", {}).get("components_and_services")
+            "components_and_services": components_and_services,
+            "component_objects": _string_items_to_named_items(
+                components_and_services,
+                "component",
             ),
-            "interfaces_and_integrations": _ensure_list(
-                merged_answers.get("round_7", {}).get("interfaces_and_integrations")
+            "interfaces_and_integrations": interfaces_and_integrations,
+            "interface_objects": _string_items_to_described_items(
+                interfaces_and_integrations,
+                "interface",
             ),
-            "runtime_boundaries": _ensure_list(
-                merged_answers.get("round_7", {}).get("runtime_boundaries")
+            "runtime_boundaries": runtime_boundaries,
+            "runtime_boundary_objects": _string_items_to_described_items(
+                runtime_boundaries,
+                "runtime-boundary",
             ),
         },
         "metadata_fields": _ensure_list(round_4.get("metadata_fields")),

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -85,11 +85,23 @@ class DiscoveryTests(unittest.TestCase):
         self.assertIn("Clearer specs", model["business_goals"])
         self.assertIn("Web based", model["requirements"]["non_functional"])
         self.assertIn("System", model["logical_view"]["domain_entities"])
+        self.assertEqual(
+            model["logical_view"]["domain_entity_objects"][0]["id"],
+            "entity-system",
+        )
         self.assertIn(
             "Draft -> Submitted -> Approved",
             model["process_view"]["states_and_transitions"],
         )
+        self.assertEqual(
+            model["process_view"]["state_entity_objects"][0]["id"],
+            "state-entity-approval-request",
+        )
         self.assertIn("Web app", model["architecture_view"]["components_and_services"])
+        self.assertEqual(
+            model["architecture_view"]["component_objects"][0]["id"],
+            "component-web-app",
+        )
 
     def test_normalize_replay_to_model_keeps_empty_sections_explicit(self) -> None:
         """Missing optional view rounds should still produce stable empty sections."""
@@ -108,8 +120,11 @@ class DiscoveryTests(unittest.TestCase):
         model = normalize_replay_to_model(replay)
 
         self.assertEqual(model["logical_view"]["domain_entities"], [])
+        self.assertEqual(model["logical_view"]["domain_entity_objects"], [])
         self.assertEqual(model["process_view"]["state_entities"], [])
+        self.assertEqual(model["process_view"]["state_entity_objects"], [])
         self.assertEqual(model["architecture_view"]["components_and_services"], [])
+        self.assertEqual(model["architecture_view"]["component_objects"], [])
 
     def test_normalize_replay_to_model_with_real_fixture(self) -> None:
         """The checked-in interview fixture should normalize into the canonical V1.5 shape."""
@@ -127,4 +142,6 @@ class DiscoveryTests(unittest.TestCase):
         self.assertIn("UI must be web based", model["requirements"]["non_functional"])
         self.assertIn("System name", model["metadata_fields"])
         self.assertEqual(model["logical_view"]["domain_entities"], [])
+        self.assertEqual(model["logical_view"]["relationship_objects"], [])
         self.assertEqual(model["process_view"]["state_entities"], [])
+        self.assertEqual(model["architecture_view"]["runtime_boundary_objects"], [])


### PR DESCRIPTION
## Summary
- extend deterministic normalization so the new interview views produce structured objects as well as string lists
- generate stable ids for normalized domain entities, relationships, state entities, transitions, components, interfaces, and runtime boundaries
- keep the existing string-list fields for compatibility with the current renderers

## Testing
- `uv run python -m unittest`

## Related Issues
- refs #23
- refs #27