### PR TITLE
Normalize actors and use cases into model

### DIFF
--- a/src/specops_tools/discovery.py
+++ b/src/specops_tools/discovery.py
@@ -57,6 +57,54 @@ def _string_items_to_described_items(items: list[str], kind: str) -> list[dict[s
     ]
 
 
+def _normalize_actors(items: list[str]) -> list[dict[str, str]]:
+    """Convert actor strings into simple canonical actor objects."""
+    actors = []
+    for item in items:
+        normalized_name = item.strip()
+        actor_type = "system" if any(
+            marker in normalized_name.lower()
+            for marker in (
+                "system",
+                "api",
+                "service",
+                "integration",
+                "consumer",
+                "gateway",
+                "platform",
+            )
+        ) else "human"
+        actors.append(
+            {
+                "id": _slugify(normalized_name),
+                "name": normalized_name,
+                "type": actor_type,
+                "description": "",
+                "complexity": "unclassified",
+            }
+        )
+    return actors
+
+
+def _normalize_use_cases(items: list[str]) -> list[dict[str, Any]]:
+    """Convert use-case strings into simple canonical use-case objects."""
+    use_cases = []
+    for item in items:
+        normalized_name = item.strip()
+        use_cases.append(
+            {
+                "id": _slugify(normalized_name),
+                "name": normalized_name,
+                "primary_actor": "Unspecified",
+                "goal": normalized_name,
+                "complexity": "unclassified",
+                "main_success_scenario": [],
+                "extensions": [],
+            }
+        )
+    return use_cases
+
+
 def _text_or_empty(value: Any) -> str:
     """Normalize a scalar answer into a string."""
     if value is None:
@@ -84,6 +132,8 @@ def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
     round_5 = merged_answers.get("round_5", {})
     round_6 = merged_answers.get("round_6", {})
     round_7 = merged_answers.get("round_7", {})
+    actors = _ensure_list(round_3.get("actors"))
+    use_cases = _ensure_list(round_3.get("use_cases"))
 
     functional_requirements = []
     if workflow_scope := _text_or_empty(round_4.get("workflow_scope")):
@@ -115,8 +165,8 @@ def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
         },
         "business_goals": _ensure_list(round_2.get("outcomes")),
         "success_criteria": _ensure_list(round_2.get("success_criteria")),
-        "actors": [],
-        "use_cases": [],
+        "actors": _normalize_actors(actors),
+        "use_cases": _normalize_use_cases(use_cases),
         "requirements": {
             "functional": functional_requirements,
             "non_functional": non_functional,

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -84,6 +84,8 @@ class DiscoveryTests(unittest.TestCase):
         self.assertEqual(model["project"]["name"], "SpecOps Test")
         self.assertIn("Clearer specs", model["business_goals"])
         self.assertIn("Web based", model["requirements"]["non_functional"])
+        self.assertEqual(model["actors"], [])
+        self.assertEqual(model["use_cases"], [])
         self.assertIn("System", model["logical_view"]["domain_entities"])
         self.assertEqual(
             model["logical_view"]["domain_entity_objects"][0]["id"],
@@ -125,6 +127,38 @@ class DiscoveryTests(unittest.TestCase):
         self.assertEqual(model["process_view"]["state_entity_objects"], [])
         self.assertEqual(model["architecture_view"]["components_and_services"], [])
         self.assertEqual(model["architecture_view"]["component_objects"], [])
+        self.assertEqual(model["actors"], [])
+        self.assertEqual(model["use_cases"], [])
+
+    def test_normalize_replay_to_model_maps_actors_and_use_cases(self) -> None:
+        """Round-3 actor and use-case discovery should produce structured canonical objects."""
+        replay = replay_session(
+            [
+                {
+                    "round": 3,
+                    "responses": [
+                        {
+                            "key": "actors",
+                            "answer": ["Operations Manager", "Payment Gateway", "Reporting API"],
+                        },
+                        {
+                            "key": "use_cases",
+                            "answer": ["Browse Rewards", "Redeem Reward"],
+                        },
+                    ],
+                }
+            ]
+        )
+
+        model = normalize_replay_to_model(replay)
+
+        self.assertEqual(model["actors"][0]["id"], "operations-manager")
+        self.assertEqual(model["actors"][0]["type"], "human")
+        self.assertEqual(model["actors"][1]["type"], "system")
+        self.assertEqual(model["actors"][2]["type"], "system")
+        self.assertEqual(model["use_cases"][0]["id"], "browse-rewards")
+        self.assertEqual(model["use_cases"][0]["goal"], "Browse Rewards")
+        self.assertEqual(model["use_cases"][1]["complexity"], "unclassified")
 
     def test_normalize_replay_to_model_with_real_fixture(self) -> None:
         """The checked-in interview fixture should normalize into the canonical V1.5 shape."""
@@ -141,6 +175,9 @@ class DiscoveryTests(unittest.TestCase):
         )
         self.assertIn("UI must be web based", model["requirements"]["non_functional"])
         self.assertIn("System name", model["metadata_fields"])
+        self.assertEqual(model["actors"][0]["name"], "Business owners")
+        self.assertEqual(model["actors"][0]["type"], "human")
+        self.assertEqual(model["use_cases"][0]["name"], "Register a system")
         self.assertEqual(model["logical_view"]["domain_entities"], [])
         self.assertEqual(model["logical_view"]["relationship_objects"], [])
         self.assertEqual(model["process_view"]["state_entities"], [])


### PR DESCRIPTION
## Summary
- extend deterministic normalization so round-3 discovery produces canonical actor and use-case objects
- generate stable ids for normalized actors and use cases
- apply a conservative human-vs-system heuristic for obvious external/system actors

## Testing
- `uv run python -m unittest`

## Related Issues
- refs #23
- refs #27