### PR TITLE
Render structured canonical model objects

### DIFF
--- a/src/specops_tools/render.py
+++ b/src/specops_tools/render.py
@@ -63,6 +63,43 @@ def _named_section(title: str, items: list[str]) -> str:
 """
 
 
+def _object_name_section(
+    title: str,
+    items: list[dict[str, Any]],
+    fallback: list[str],
+) -> str:
+    """Render a section from named objects, falling back to strings."""
+    if items:
+        rendered = []
+        for item in items:
+            line = f"- `{item.get('id', 'item')}` {item.get('name', 'Unnamed')}"
+            if item.get("description"):
+                line = f"{line}: {item['description']}"
+            rendered.append(line)
+        return f"""
+## {title}
+
+{"\n".join(rendered)}
+"""
+    return _named_section(title, fallback)
+
+
+def _object_text_section(
+    title: str,
+    items: list[dict[str, Any]],
+    fallback: list[str],
+) -> str:
+    """Render a section from text objects, falling back to strings."""
+    if items:
+        rendered = "\n".join(f"- `{item.get('id', 'item')}` {item.get('text', '')}" for item in items)
+        return f"""
+## {title}
+
+{rendered}
+"""
+    return _named_section(title, fallback)
+
+
 def render_requirements_spec(model: dict[str, Any]) -> str:
     """Render the requirements specification artifact.
 
@@ -104,15 +141,51 @@ def render_requirements_spec(model: dict[str, Any]) -> str:
 ## Non-Functional Requirements
 
 {_bullet_list(requirements.get("non_functional", []))}
-{_named_section("Logical View", logical_view.get("domain_entities", []))}
-{_named_section("Relationships", logical_view.get("relationships", []))}
-{_named_section("Business Rules", logical_view.get("business_rules", []))}
-{_named_section("Process View", process_view.get("state_entities", []))}
-{_named_section("States and Transitions", process_view.get("states_and_transitions", []))}
-{_named_section("Triggers and Approvals", process_view.get("triggers_and_approvals", []))}
-{_named_section("Architecture View", architecture_view.get("components_and_services", []))}
-{_named_section("Interfaces and Integrations", architecture_view.get("interfaces_and_integrations", []))}
-{_named_section("Runtime Boundaries", architecture_view.get("runtime_boundaries", []))}
+{_object_name_section(
+    "Logical View",
+    logical_view.get("domain_entity_objects", []),
+    logical_view.get("domain_entities", []),
+)}
+{_object_text_section(
+    "Relationships",
+    logical_view.get("relationship_objects", []),
+    logical_view.get("relationships", []),
+)}
+{_object_text_section(
+    "Business Rules",
+    logical_view.get("business_rule_objects", []),
+    logical_view.get("business_rules", []),
+)}
+{_object_name_section(
+    "Process View",
+    process_view.get("state_entity_objects", []),
+    process_view.get("state_entities", []),
+)}
+{_object_text_section(
+    "States and Transitions",
+    process_view.get("state_transition_objects", []),
+    process_view.get("states_and_transitions", []),
+)}
+{_object_text_section(
+    "Triggers and Approvals",
+    process_view.get("trigger_objects", []),
+    process_view.get("triggers_and_approvals", []),
+)}
+{_object_name_section(
+    "Architecture View",
+    architecture_view.get("component_objects", []),
+    architecture_view.get("components_and_services", []),
+)}
+{_object_text_section(
+    "Interfaces and Integrations",
+    architecture_view.get("interface_objects", []),
+    architecture_view.get("interfaces_and_integrations", []),
+)}
+{_object_text_section(
+    "Runtime Boundaries",
+    architecture_view.get("runtime_boundary_objects", []),
+    architecture_view.get("runtime_boundaries", []),
+)}
 
 ## Assumptions
 
@@ -179,9 +252,21 @@ def render_use_case_model(model: dict[str, Any]) -> str:
 ## Use Cases
 
 {use_case_block}
-{_named_section("States and Transitions", process_view.get("states_and_transitions", []))}
-{_named_section("Triggers and Approvals", process_view.get("triggers_and_approvals", []))}
-{_named_section("Interfaces and Integrations", architecture_view.get("interfaces_and_integrations", []))}
+{_object_text_section(
+    "States and Transitions",
+    process_view.get("state_transition_objects", []),
+    process_view.get("states_and_transitions", []),
+)}
+{_object_text_section(
+    "Triggers and Approvals",
+    process_view.get("trigger_objects", []),
+    process_view.get("triggers_and_approvals", []),
+)}
+{_object_text_section(
+    "Interfaces and Integrations",
+    architecture_view.get("interface_objects", []),
+    architecture_view.get("interfaces_and_integrations", []),
+)}
 """
 
 

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -49,28 +49,57 @@ class RenderTests(unittest.TestCase):
         model = build_model()
         model["logical_view"] = {
             "domain_entities": ["Member", "Reward"],
+            "domain_entity_objects": [
+                {"id": "entity-member", "name": "Member"},
+                {"id": "entity-reward", "name": "Reward"},
+            ],
             "relationships": ["A Member can redeem many Rewards."],
+            "relationship_objects": [
+                {"id": "relationship-1", "text": "A Member can redeem many Rewards."},
+            ],
             "business_rules": ["A Reward requires sufficient points."],
+            "business_rule_objects": [
+                {"id": "business-rule-1", "text": "A Reward requires sufficient points."},
+            ],
         }
         model["process_view"] = {
             "state_entities": ["Redemption request"],
+            "state_entity_objects": [
+                {"id": "state-entity-redemption-request", "name": "Redemption request"},
+            ],
             "states_and_transitions": ["Requested -> Approved -> Fulfilled"],
+            "state_transition_objects": [
+                {"id": "state-transition-1", "text": "Requested -> Approved -> Fulfilled"},
+            ],
             "triggers_and_approvals": ["Approval is required for manual fulfillment."],
+            "trigger_objects": [
+                {"id": "trigger-1", "text": "Approval is required for manual fulfillment."},
+            ],
         }
         model["architecture_view"] = {
             "components_and_services": ["Member app", "Rewards API"],
+            "component_objects": [
+                {"id": "component-member-app", "name": "Member app"},
+                {"id": "component-rewards-api", "name": "Rewards API"},
+            ],
             "interfaces_and_integrations": ["Member app calls Rewards API."],
+            "interface_objects": [
+                {"id": "interface-1", "text": "Member app calls Rewards API."},
+            ],
             "runtime_boundaries": ["Rewards API runs as a separate service."],
+            "runtime_boundary_objects": [
+                {"id": "runtime-boundary-1", "text": "Rewards API runs as a separate service."},
+            ],
         }
 
         rendered = render_requirements_spec(model)
 
         self.assertIn("## Logical View", rendered)
-        self.assertIn("Member", rendered)
+        self.assertIn("`entity-member` Member", rendered)
         self.assertIn("## Process View", rendered)
-        self.assertIn("Requested -> Approved -> Fulfilled", rendered)
+        self.assertIn("`state-transition-1` Requested -> Approved -> Fulfilled", rendered)
         self.assertIn("## Architecture View", rendered)
-        self.assertIn("Rewards API runs as a separate service.", rendered)
+        self.assertIn("`runtime-boundary-1` Rewards API runs as a separate service.", rendered)
 
     def test_use_case_render_includes_process_and_architecture_sections(self) -> None:
         """Use-case rendering should include relevant process and architecture sections when present."""
@@ -79,18 +108,27 @@ class RenderTests(unittest.TestCase):
         model = build_model()
         model["process_view"] = {
             "states_and_transitions": ["Requested -> Approved -> Fulfilled"],
+            "state_transition_objects": [
+                {"id": "state-transition-1", "text": "Requested -> Approved -> Fulfilled"},
+            ],
             "triggers_and_approvals": ["Approval is required for manual fulfillment."],
+            "trigger_objects": [
+                {"id": "trigger-1", "text": "Approval is required for manual fulfillment."},
+            ],
         }
         model["architecture_view"] = {
             "interfaces_and_integrations": ["Member app calls Rewards API."],
+            "interface_objects": [
+                {"id": "interface-1", "text": "Member app calls Rewards API."},
+            ],
         }
 
         rendered = render_use_case_model(model)
 
         self.assertIn("## States and Transitions", rendered)
-        self.assertIn("Requested -> Approved -> Fulfilled", rendered)
+        self.assertIn("`state-transition-1` Requested -> Approved -> Fulfilled", rendered)
         self.assertIn("## Interfaces and Integrations", rendered)
-        self.assertIn("Member app calls Rewards API.", rendered)
+        self.assertIn("`interface-1` Member app calls Rewards API.", rendered)
 
     def test_ucp_render_supports_structured_uncertainty_items(self) -> None:
         """UCP rendering should preserve uncertainty metadata when present."""


### PR DESCRIPTION
## Summary
- update the requirements and use-case renderers to prefer structured logical/process/architecture objects
- keep backward compatibility by falling back to the older string-list fields when object collections are absent
- surface stable object ids in the rendered output for the structured view sections

## Testing
- `uv run python -m unittest`

## Related Issues
- closes #39
- refs #23
- refs #27