### PR TITLE
Add trace metadata to normalized objects

### DIFF
--- a/src/specops_tools/discovery.py
+++ b/src/specops_tools/discovery.py
@@ -81,6 +81,7 @@ def _string_items_to_named_items(items: list[str], kind: str) -> list[dict[str, 
         {
             "id": f"{kind}-{_slugify(item)}",
             "name": item,
+            "trace": {},
         }
         for item in items
     ]
@@ -92,9 +93,27 @@ def _string_items_to_described_items(items: list[str], kind: str) -> list[dict[s
         {
             "id": f"{kind}-{index}",
             "text": item,
+            "trace": {},
         }
         for index, item in enumerate(items, 1)
     ]
+
+
+def _with_trace(
+    items: list[dict[str, Any]],
+    source_round: int,
+    source_key: str,
+) -> list[dict[str, Any]]:
+    """Attach deterministic source trace metadata to normalized objects."""
+    traced_items = []
+    for item in items:
+        traced_item = dict(item)
+        traced_item["trace"] = {
+            "source_round": source_round,
+            "source_key": source_key,
+        }
+        traced_items.append(traced_item)
+    return traced_items
 
 
 def _best_name_match(name: str, candidates: list[dict[str, Any]]) -> dict[str, Any] | None:
@@ -125,6 +144,30 @@ def _apply_complexity_answers(items: list[dict[str, Any]], answers: list[str]) -
         match = _best_name_match(name.strip(), items)
         if match is not None:
             match["complexity"] = complexity.strip().lower()
+            match["complexity_trace"] = {
+                "source_round": None,
+                "source_key": "",
+            }
+
+
+def _apply_complexity_answers_with_trace(
+    items: list[dict[str, Any]],
+    answers: list[str],
+    source_round: int,
+    source_key: str,
+) -> None:
+    """Apply complexity answers and attach their trace metadata."""
+    _apply_complexity_answers(items, answers)
+    for answer in answers:
+        if ":" not in answer:
+            continue
+        name, _complexity = answer.split(":", 1)
+        match = _best_name_match(name.strip(), items)
+        if match is not None:
+            match["complexity_trace"] = {
+                "source_round": source_round,
+                "source_key": source_key,
+            }
 
 
 def _normalize_factor_map(
@@ -168,6 +211,7 @@ def _normalize_actors(items: list[str]) -> list[dict[str, str]]:
                 "type": actor_type,
                 "description": "",
                 "complexity": "unclassified",
+                "trace": {},
             }
         )
     return actors
@@ -187,6 +231,7 @@ def _normalize_use_cases(items: list[str]) -> list[dict[str, Any]]:
                 "complexity": "unclassified",
                 "main_success_scenario": [],
                 "extensions": [],
+                "trace": {},
             }
         )
     return use_cases
@@ -246,10 +291,20 @@ def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
     components_and_services = _ensure_list(round_7.get("components_and_services"))
     interfaces_and_integrations = _ensure_list(round_7.get("interfaces_and_integrations"))
     runtime_boundaries = _ensure_list(round_7.get("runtime_boundaries"))
-    normalized_actors = _normalize_actors(actors)
-    normalized_use_cases = _normalize_use_cases(use_cases)
-    _apply_complexity_answers(normalized_actors, _ensure_list(round_8.get("actor_complexity")))
-    _apply_complexity_answers(normalized_use_cases, _ensure_list(round_9.get("use_case_complexity")))
+    normalized_actors = _with_trace(_normalize_actors(actors), 3, "actors")
+    normalized_use_cases = _with_trace(_normalize_use_cases(use_cases), 3, "use_cases")
+    _apply_complexity_answers_with_trace(
+        normalized_actors,
+        _ensure_list(round_8.get("actor_complexity")),
+        8,
+        "actor_complexity",
+    )
+    _apply_complexity_answers_with_trace(
+        normalized_use_cases,
+        _ensure_list(round_9.get("use_case_complexity")),
+        9,
+        "use_case_complexity",
+    )
     technical_factors = _normalize_factor_map(round_10, TECHNICAL_FACTOR_ALIASES)
     environmental_factors = _normalize_factor_map(round_11, ENVIRONMENTAL_FACTOR_ALIASES)
 
@@ -270,44 +325,80 @@ def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
         },
         "logical_view": {
             "domain_entities": domain_entities,
-            "domain_entity_objects": _string_items_to_named_items(domain_entities, "entity"),
+            "domain_entity_objects": _with_trace(
+                _string_items_to_named_items(domain_entities, "entity"),
+                5,
+                "domain_entities",
+            ),
             "relationships": relationships,
-            "relationship_objects": _string_items_to_described_items(relationships, "relationship"),
+            "relationship_objects": _with_trace(
+                _string_items_to_described_items(relationships, "relationship"),
+                5,
+                "relationships",
+            ),
             "business_rules": business_rules,
-            "business_rule_objects": _string_items_to_described_items(
-                business_rules,
-                "business-rule",
+            "business_rule_objects": _with_trace(
+                _string_items_to_described_items(
+                    business_rules,
+                    "business-rule",
+                ),
+                5,
+                "business_rules",
             ),
         },
         "process_view": {
             "state_entities": state_entities,
-            "state_entity_objects": _string_items_to_named_items(state_entities, "state-entity"),
+            "state_entity_objects": _with_trace(
+                _string_items_to_named_items(state_entities, "state-entity"),
+                6,
+                "state_entities",
+            ),
             "states_and_transitions": states_and_transitions,
-            "state_transition_objects": _string_items_to_described_items(
-                states_and_transitions,
-                "state-transition",
+            "state_transition_objects": _with_trace(
+                _string_items_to_described_items(
+                    states_and_transitions,
+                    "state-transition",
+                ),
+                6,
+                "states_and_transitions",
             ),
             "triggers_and_approvals": triggers_and_approvals,
-            "trigger_objects": _string_items_to_described_items(
-                triggers_and_approvals,
-                "trigger",
+            "trigger_objects": _with_trace(
+                _string_items_to_described_items(
+                    triggers_and_approvals,
+                    "trigger",
+                ),
+                6,
+                "triggers_and_approvals",
             ),
         },
         "architecture_view": {
             "components_and_services": components_and_services,
-            "component_objects": _string_items_to_named_items(
-                components_and_services,
-                "component",
+            "component_objects": _with_trace(
+                _string_items_to_named_items(
+                    components_and_services,
+                    "component",
+                ),
+                7,
+                "components_and_services",
             ),
             "interfaces_and_integrations": interfaces_and_integrations,
-            "interface_objects": _string_items_to_described_items(
-                interfaces_and_integrations,
-                "interface",
+            "interface_objects": _with_trace(
+                _string_items_to_described_items(
+                    interfaces_and_integrations,
+                    "interface",
+                ),
+                7,
+                "interfaces_and_integrations",
             ),
             "runtime_boundaries": runtime_boundaries,
-            "runtime_boundary_objects": _string_items_to_described_items(
-                runtime_boundaries,
-                "runtime-boundary",
+            "runtime_boundary_objects": _with_trace(
+                _string_items_to_described_items(
+                    runtime_boundaries,
+                    "runtime-boundary",
+                ),
+                7,
+                "runtime_boundaries",
             ),
         },
         "metadata_fields": _ensure_list(round_4.get("metadata_fields")),

--- a/src/specops_tools/render.py
+++ b/src/specops_tools/render.py
@@ -75,6 +75,11 @@ def _object_name_section(
             line = f"- `{item.get('id', 'item')}` {item.get('name', 'Unnamed')}"
             if item.get("description"):
                 line = f"{line}: {item['description']}"
+            if trace := item.get("trace"):
+                line = (
+                    f"{line} [source: round {trace.get('source_round')} "
+                    f"{trace.get('source_key')}]"
+                )
             rendered.append(line)
         return f"""
 ## {title}
@@ -91,7 +96,16 @@ def _object_text_section(
 ) -> str:
     """Render a section from text objects, falling back to strings."""
     if items:
-        rendered = "\n".join(f"- `{item.get('id', 'item')}` {item.get('text', '')}" for item in items)
+        rendered_lines = []
+        for item in items:
+            line = f"- `{item.get('id', 'item')}` {item.get('text', '')}"
+            if trace := item.get("trace"):
+                line = (
+                    f"{line} [source: round {trace.get('source_round')} "
+                    f"{trace.get('source_key')}]"
+                )
+            rendered_lines.append(line)
+        rendered = "\n".join(rendered_lines)
         return f"""
 ## {title}
 
@@ -208,11 +222,17 @@ def render_use_case_model(model: dict[str, Any]) -> str:
     """
     actor_lines = []
     for actor in model.get("actors", []):
-        actor_lines.append(
+        line = (
             f"- `{actor.get('id', 'actor')}` {actor.get('name', 'Unnamed')} "
             f"({actor.get('type', 'unspecified')}, {actor.get('complexity', 'unclassified')}): "
             f"{actor.get('description', 'No description')}"
         )
+        if trace := actor.get("trace"):
+            line = (
+                f"{line} [source: round {trace.get('source_round')} "
+                f"{trace.get('source_key')}]"
+            )
+        actor_lines.append(line)
 
     use_case_sections = []
     for use_case in model.get("use_cases", []):
@@ -227,6 +247,7 @@ def render_use_case_model(model: dict[str, Any]) -> str:
 - Primary actor: {use_case.get("primary_actor", "Unspecified")}
 - Complexity: {use_case.get("complexity", "unclassified")}
 - Goal: {use_case.get("goal", "Unspecified")}
+- Source: round {use_case.get("trace", {}).get("source_round", "n/a")} {use_case.get("trace", {}).get("source_key", "")}
 
 #### Main Success Scenario
 

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -91,6 +91,10 @@ class DiscoveryTests(unittest.TestCase):
             model["logical_view"]["domain_entity_objects"][0]["id"],
             "entity-system",
         )
+        self.assertEqual(
+            model["logical_view"]["domain_entity_objects"][0]["trace"]["source_round"],
+            5,
+        )
         self.assertIn(
             "Draft -> Submitted -> Approved",
             model["process_view"]["states_and_transitions"],
@@ -103,6 +107,10 @@ class DiscoveryTests(unittest.TestCase):
         self.assertEqual(
             model["architecture_view"]["component_objects"][0]["id"],
             "component-web-app",
+        )
+        self.assertEqual(
+            model["architecture_view"]["component_objects"][0]["trace"]["source_key"],
+            "components_and_services",
         )
 
     def test_normalize_replay_to_model_keeps_empty_sections_explicit(self) -> None:
@@ -154,10 +162,12 @@ class DiscoveryTests(unittest.TestCase):
 
         self.assertEqual(model["actors"][0]["id"], "operations-manager")
         self.assertEqual(model["actors"][0]["type"], "human")
+        self.assertEqual(model["actors"][0]["trace"]["source_round"], 3)
         self.assertEqual(model["actors"][1]["type"], "system")
         self.assertEqual(model["actors"][2]["type"], "system")
         self.assertEqual(model["use_cases"][0]["id"], "browse-rewards")
         self.assertEqual(model["use_cases"][0]["goal"], "Browse Rewards")
+        self.assertEqual(model["use_cases"][0]["trace"]["source_key"], "use_cases")
         self.assertEqual(model["use_cases"][1]["complexity"], "unclassified")
 
     def test_normalize_replay_to_model_applies_ucp_answers_to_objects(self) -> None:
@@ -225,8 +235,10 @@ class DiscoveryTests(unittest.TestCase):
         model = normalize_replay_to_model(replay)
 
         self.assertEqual(model["actors"][0]["complexity"], "average")
+        self.assertEqual(model["actors"][0]["complexity_trace"]["source_round"], 8)
         self.assertEqual(model["actors"][1]["complexity"], "simple")
         self.assertEqual(model["use_cases"][0]["complexity"], "average")
+        self.assertEqual(model["use_cases"][0]["complexity_trace"]["source_key"], "use_case_complexity")
         self.assertEqual(model["use_cases"][1]["complexity"], "complex")
         self.assertEqual(model["ucp"]["technical_factors"]["special_security"], 5)
         self.assertEqual(model["ucp"]["technical_factors"]["third_party_access"], 4)

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -50,56 +50,106 @@ class RenderTests(unittest.TestCase):
         model["logical_view"] = {
             "domain_entities": ["Member", "Reward"],
             "domain_entity_objects": [
-                {"id": "entity-member", "name": "Member"},
-                {"id": "entity-reward", "name": "Reward"},
+                {
+                    "id": "entity-member",
+                    "name": "Member",
+                    "trace": {"source_round": 5, "source_key": "domain_entities"},
+                },
+                {
+                    "id": "entity-reward",
+                    "name": "Reward",
+                    "trace": {"source_round": 5, "source_key": "domain_entities"},
+                },
             ],
             "relationships": ["A Member can redeem many Rewards."],
             "relationship_objects": [
-                {"id": "relationship-1", "text": "A Member can redeem many Rewards."},
+                {
+                    "id": "relationship-1",
+                    "text": "A Member can redeem many Rewards.",
+                    "trace": {"source_round": 5, "source_key": "relationships"},
+                },
             ],
             "business_rules": ["A Reward requires sufficient points."],
             "business_rule_objects": [
-                {"id": "business-rule-1", "text": "A Reward requires sufficient points."},
+                {
+                    "id": "business-rule-1",
+                    "text": "A Reward requires sufficient points.",
+                    "trace": {"source_round": 5, "source_key": "business_rules"},
+                },
             ],
         }
         model["process_view"] = {
             "state_entities": ["Redemption request"],
             "state_entity_objects": [
-                {"id": "state-entity-redemption-request", "name": "Redemption request"},
+                {
+                    "id": "state-entity-redemption-request",
+                    "name": "Redemption request",
+                    "trace": {"source_round": 6, "source_key": "state_entities"},
+                },
             ],
             "states_and_transitions": ["Requested -> Approved -> Fulfilled"],
             "state_transition_objects": [
-                {"id": "state-transition-1", "text": "Requested -> Approved -> Fulfilled"},
+                {
+                    "id": "state-transition-1",
+                    "text": "Requested -> Approved -> Fulfilled",
+                    "trace": {"source_round": 6, "source_key": "states_and_transitions"},
+                },
             ],
             "triggers_and_approvals": ["Approval is required for manual fulfillment."],
             "trigger_objects": [
-                {"id": "trigger-1", "text": "Approval is required for manual fulfillment."},
+                {
+                    "id": "trigger-1",
+                    "text": "Approval is required for manual fulfillment.",
+                    "trace": {"source_round": 6, "source_key": "triggers_and_approvals"},
+                },
             ],
         }
         model["architecture_view"] = {
             "components_and_services": ["Member app", "Rewards API"],
             "component_objects": [
-                {"id": "component-member-app", "name": "Member app"},
-                {"id": "component-rewards-api", "name": "Rewards API"},
+                {
+                    "id": "component-member-app",
+                    "name": "Member app",
+                    "trace": {"source_round": 7, "source_key": "components_and_services"},
+                },
+                {
+                    "id": "component-rewards-api",
+                    "name": "Rewards API",
+                    "trace": {"source_round": 7, "source_key": "components_and_services"},
+                },
             ],
             "interfaces_and_integrations": ["Member app calls Rewards API."],
             "interface_objects": [
-                {"id": "interface-1", "text": "Member app calls Rewards API."},
+                {
+                    "id": "interface-1",
+                    "text": "Member app calls Rewards API.",
+                    "trace": {"source_round": 7, "source_key": "interfaces_and_integrations"},
+                },
             ],
             "runtime_boundaries": ["Rewards API runs as a separate service."],
             "runtime_boundary_objects": [
-                {"id": "runtime-boundary-1", "text": "Rewards API runs as a separate service."},
+                {
+                    "id": "runtime-boundary-1",
+                    "text": "Rewards API runs as a separate service.",
+                    "trace": {"source_round": 7, "source_key": "runtime_boundaries"},
+                },
             ],
         }
 
         rendered = render_requirements_spec(model)
 
         self.assertIn("## Logical View", rendered)
-        self.assertIn("`entity-member` Member", rendered)
+        self.assertIn("`entity-member` Member [source: round 5 domain_entities]", rendered)
         self.assertIn("## Process View", rendered)
-        self.assertIn("`state-transition-1` Requested -> Approved -> Fulfilled", rendered)
+        self.assertIn(
+            "`state-transition-1` Requested -> Approved -> Fulfilled [source: round 6 states_and_transitions]",
+            rendered,
+        )
         self.assertIn("## Architecture View", rendered)
-        self.assertIn("`runtime-boundary-1` Rewards API runs as a separate service.", rendered)
+        self.assertIn(
+            "`runtime-boundary-1` Rewards API runs as a separate service. [source: round 7 runtime_boundaries]",
+            rendered,
+        )
 
     def test_use_case_render_includes_process_and_architecture_sections(self) -> None:
         """Use-case rendering should include relevant process and architecture sections when present."""
@@ -109,26 +159,44 @@ class RenderTests(unittest.TestCase):
         model["process_view"] = {
             "states_and_transitions": ["Requested -> Approved -> Fulfilled"],
             "state_transition_objects": [
-                {"id": "state-transition-1", "text": "Requested -> Approved -> Fulfilled"},
+                {
+                    "id": "state-transition-1",
+                    "text": "Requested -> Approved -> Fulfilled",
+                    "trace": {"source_round": 6, "source_key": "states_and_transitions"},
+                },
             ],
             "triggers_and_approvals": ["Approval is required for manual fulfillment."],
             "trigger_objects": [
-                {"id": "trigger-1", "text": "Approval is required for manual fulfillment."},
+                {
+                    "id": "trigger-1",
+                    "text": "Approval is required for manual fulfillment.",
+                    "trace": {"source_round": 6, "source_key": "triggers_and_approvals"},
+                },
             ],
         }
         model["architecture_view"] = {
             "interfaces_and_integrations": ["Member app calls Rewards API."],
             "interface_objects": [
-                {"id": "interface-1", "text": "Member app calls Rewards API."},
+                {
+                    "id": "interface-1",
+                    "text": "Member app calls Rewards API.",
+                    "trace": {"source_round": 7, "source_key": "interfaces_and_integrations"},
+                },
             ],
         }
 
         rendered = render_use_case_model(model)
 
         self.assertIn("## States and Transitions", rendered)
-        self.assertIn("`state-transition-1` Requested -> Approved -> Fulfilled", rendered)
+        self.assertIn(
+            "`state-transition-1` Requested -> Approved -> Fulfilled [source: round 6 states_and_transitions]",
+            rendered,
+        )
         self.assertIn("## Interfaces and Integrations", rendered)
-        self.assertIn("`interface-1` Member app calls Rewards API.", rendered)
+        self.assertIn(
+            "`interface-1` Member app calls Rewards API. [source: round 7 interfaces_and_integrations]",
+            rendered,
+        )
 
     def test_ucp_render_supports_structured_uncertainty_items(self) -> None:
         """UCP rendering should preserve uncertainty metadata when present."""


### PR DESCRIPTION
## Summary
- attach deterministic trace metadata to normalized actors, use cases, and logical/process/architecture view objects
- attach separate trace metadata for actor/use-case complexity updates coming from the UCP rounds
- surface trace metadata for structured objects in the generated artifacts

## Testing
- `uv run python -m unittest`

## Related Issues
- closes #40
- refs #23
- refs #27