### PR TITLE
docs: introduce V1.6 specification hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ Delivered in V1:
 - dogfooding examples and replayable interview fixtures
 - interview UX and UCP guidance refinements from real usage
 
-Open roadmap work is now V2-oriented, especially UML/formalization and integrations.
+V1.5 is complete and established the interview/model readiness bridge.
 
-An immediate bridge phase is now also defined as `V1.5`: improve the interview and canonical model
-so SpecOps can cover the relevant RUP-aligned specification views, manage ambiguity explicitly, and
-support targeted re-interview when new information appears later.
+The immediate next phase is now `V1.6`: strengthen the canonical model, readiness rules, and
+cross-view traceability so SpecOps becomes specification-ready before broad V2 UML/formalization and
+integration work.
 
 ## Repository Layout
 
@@ -72,6 +72,7 @@ uv sync --extra yaml
 - [Implementation Plan](docs/implementation-plan.md)
 - [Solution Architecture](docs/solution-architecture.md)
 - [V1.5 Interview Readiness](docs/v1.5-interview-readiness.md)
+- [V1.6 Specification Hardening](docs/v1.6-specification-hardening.md)
 - [Dogfooding Workflow](docs/dogfooding.md)
 - [GitHub Issue Map](docs/github-issue-map.md)
 - [SpecKit Constitution](.specify/memory/constitution.md)

--- a/docs/github-issue-map.md
+++ b/docs/github-issue-map.md
@@ -17,8 +17,8 @@ Closed V1 issues:
 - `#16` `Improve interview UX and reduce wall-of-text responses`
 - `#17` `Improve UCP scoring guidance in the interview flow`
 
-V1 is complete. V1.5 is also complete and now serves as the bridge before the existing V2 UML work
-is treated as implementation-ready.
+V1 is complete. V1.5 is also complete. The next active bridge is now V1.6, which exists to harden
+the model and workflow before broad V2 UML/formalization work is treated as implementation-ready.
 
 ## Closed V1.5 Work
 
@@ -40,7 +40,27 @@ is treated as implementation-ready.
 - deterministic normalization from replay output into the richer canonical model
 - structured rendering and trace-aware artifact output
 
-These themes now shape the completed bridge between V1 and the remaining V2 work.
+These themes now shape the completed bridge into V1.6 hardening work.
+
+## Open V1.6 Work
+
+- `#45` `EPIC: SpecOps V1.6 specification hardening`
+
+## V1.6 Focus
+
+- formalize the canonical analysis and design model
+- define per-view completeness and readiness gates
+- strengthen cross-view traceability
+- separate analysis-level and design-level structures where needed
+- prove at least one real formal artifact pipeline end to end
+
+## Open V1.6 Decomposition for Epic #45
+
+- `#47` `Formalize canonical analysis and design model semantics`
+- `#46` `Define per-view completeness and readiness gates`
+- `#50` `Implement cross-view specification traceability`
+- `#49` `Separate analysis structures from design structures in the canonical model`
+- `#48` `Prove one end-to-end formal artifact pipeline from the canonical model`
 
 ## Open Epics
 
@@ -60,7 +80,10 @@ These themes now shape the completed bridge between V1 and the remaining V2 work
 - V1 foundation epic owns repo documentation, constitution, and branch conventions
 - V1 workflow epic owns the orchestrator, subskills, model, renderer, and UCP logic
 - V1 dogfooding epic owns the self-hosting spec, validation loop, and workflow adjustments
-- V2 epics are explicitly future-facing and begin after the completed V1 baseline
+- V1.6 is the active hardening bridge between the completed V1.5 work and the future-facing V2
+  epics
+- V2 epics remain future-facing and should build on the stricter V1.6 baseline rather than bypass
+  it
 
 ## Labels To Use
 

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -3,8 +3,8 @@
 ## Status
 
 V1 is complete. This document now serves as the implementation record for what was delivered in V1,
-the bridge work now identified as V1.5, and the shape that should be preserved while later work
-expands UML/formalization and integration support.
+the completed V1.5 bridge, the new V1.6 hardening phase, and the shape that should be preserved
+while later work expands UML/formalization and integration support.
 
 ## Objective
 
@@ -73,7 +73,22 @@ V1.5 focuses on:
 
 Reference: [V1.5 Interview Readiness](v1.5-interview-readiness.md)
 
-## Remaining Roadmap After V1.5
+## V1.6 Hardening Work
 
-- V2 UML and formal specification translation
+V1.6 exists because the current system is interview-ready and model-aware, but not yet a full
+RUP-grade specification system.
+
+V1.6 focuses on:
+
+- stronger canonical semantics for analysis and design structures
+- per-view completeness and readiness gates
+- cross-view traceability beyond simple provenance
+- explicit separation between analysis-level and design-level structures where needed
+- one proven end-to-end formal artifact pipeline
+
+Reference: [V1.6 Specification Hardening](v1.6-specification-hardening.md)
+
+## Remaining Roadmap After V1.6
+
+- V2 UML and formal specification translation at broader artifact breadth
 - V2 integrations and productization

--- a/docs/issue-drafts/epic-v1.6-specification-hardening.md
+++ b/docs/issue-drafts/epic-v1.6-specification-hardening.md
@@ -1,0 +1,22 @@
+# V1.6 Specification Hardening
+
+SpecOps now has a completed V1.5 interview-readiness bridge, but it is not yet a full RUP-grade
+specification system.
+
+V1.6 should be the explicit hardening phase between V1.5 and broad V2 UML/productization work.
+
+## Scope
+
+- formalize the canonical analysis/design model
+- define per-view completeness and readiness gates
+- strengthen traceability into a real cross-view trace model
+- separate analysis structures from design structures where needed
+- prove at least one end-to-end formal artifact pipeline from the model
+
+## Why This Is Not Yet V2
+
+This work is still about specification-readiness. It is foundational hardening, not broad output
+delivery.
+
+Until this phase is complete, labeling the next work as V2 UML output delivery would be
+premature.

--- a/docs/v1.6-specification-hardening.md
+++ b/docs/v1.6-specification-hardening.md
@@ -1,0 +1,105 @@
+# SpecOps V1.6 Specification Hardening
+
+## Why V1.6 Exists
+
+SpecOps V1.5 completed the interview-readiness bridge. The repository can now:
+
+- cover the key RUP-aligned discovery views during interview
+- manage ambiguity and provenance explicitly
+- replay and update interviews incrementally
+- normalize replay output into a richer canonical model
+- render structured, trace-aware artifacts from that model
+
+That is necessary progress, but it is not yet the same thing as a full RUP-grade specification
+system.
+
+V1.6 is the explicit hardening phase between V1.5 and broad V2 UML/formalization work.
+
+## Objective
+
+Make the canonical model and workflow strict enough that formal analysis and design artifacts can be
+generated from it credibly, rather than from partially structured discovery output.
+
+## V1.6 Focus
+
+V1.6 should focus on five areas:
+
+1. Formalize the canonical analysis and design model.
+2. Define per-view completeness and readiness gates.
+3. Strengthen cross-view traceability.
+4. Separate analysis-level structures from design-level structures where needed.
+5. Prove at least one real formal artifact pipeline end to end.
+
+## What V1.6 Should Deliver
+
+### 1. Stronger Canonical Semantics
+
+The model should move beyond mixed free text and light structure toward explicit objects for:
+
+- domain concepts, attributes, responsibilities, and relationships
+- stateful entities, events, transitions, and invariants
+- interaction realizations and message flow
+- components, interfaces, deployment nodes, and runtime links
+- analysis objects versus design objects when the distinction matters
+
+### 2. Readiness Gates by View
+
+Every major view should have a minimum definition of done. A view should not be marked `ready`
+unless its required structures and trace links exist.
+
+At minimum, this should apply to:
+
+- use-case view
+- logical/domain view
+- process/state view
+- architecture/deployment view
+
+### 3. Real Traceability
+
+Traceability should move from object provenance to cross-view specification traceability.
+
+The system should support links such as:
+
+- stakeholder concern -> requirement
+- requirement -> use case
+- use case -> analysis object or interaction
+- analysis object -> design element
+- model element -> generated artifact
+
+### 4. Analysis/Design Separation
+
+The model should stop implying that discovery objects and design objects are the same thing.
+
+V1.6 should define where SpecOps keeps:
+
+- analysis-level abstractions
+- design-level realizations
+- links between the two
+
+### 5. One Proven Formal Output
+
+V1.6 does not need to deliver every UML artifact. It does need to prove one serious path all the
+way through.
+
+The best first candidate is probably one of:
+
+- domain/class modeling
+- state modeling
+
+## What V1.6 Is Not
+
+V1.6 is not the phase for broad diagram generation across every view, polished product integrations,
+or pretending the current model is already complete enough for all UML outputs.
+
+That broader delivery still belongs in V2.
+
+## Exit Criteria
+
+V1.6 is complete when:
+
+- the canonical model has stricter semantics for analysis/design structures
+- readiness is enforced by view rather than inferred loosely
+- cross-view traceability is explicit
+- at least one formal artifact pipeline is demonstrably credible end to end
+- the remaining V2 work is mostly about breadth of output and productization, not foundational model
+  repair


### PR DESCRIPTION
## Summary
- introduce V1.6 as the explicit hardening phase between completed V1.5 work and broader V2 delivery
- add a V1.6 design note and issue-draft document
- update the issue map, README, and implementation plan to reflect the new roadmap
- create a V1.6 epic and child issues in GitHub

## Testing
- not run (documentation and issue-hygiene only)