### PR TITLE
docs: define V1.6 implementation order

### DIFF
--- a/docs/github-issue-map.md
+++ b/docs/github-issue-map.md
@@ -62,6 +62,14 @@ These themes now shape the completed bridge into V1.6 hardening work.
 - `#49` `Separate analysis structures from design structures in the canonical model`
 - `#48` `Prove one end-to-end formal artifact pipeline from the canonical model`
 
+## Recommended V1.6 Implementation Order
+
+1. `#47` `Formalize canonical analysis and design model semantics`
+2. `#46` `Define per-view completeness and readiness gates`
+3. `#50` `Implement cross-view specification traceability`
+4. `#49` `Separate analysis structures from design structures in the canonical model`
+5. `#48` `Prove one end-to-end formal artifact pipeline from the canonical model`
+
 ## Open Epics
 
 - `#8` `EPIC: SpecOps V2 UML and formal specification translation`

--- a/docs/v1.6-specification-hardening.md
+++ b/docs/v1.6-specification-hardening.md
@@ -30,6 +30,23 @@ V1.6 should focus on five areas:
 4. Separate analysis-level structures from design-level structures where needed.
 5. Prove at least one real formal artifact pipeline end to end.
 
+## Recommended Implementation Order
+
+V1.6 should not be worked as an unordered backlog. The recommended implementation sequence is:
+
+1. Formalize canonical analysis and design model semantics (`#47`).
+2. Define per-view completeness and readiness gates (`#46`).
+3. Implement cross-view specification traceability (`#50`).
+4. Separate analysis structures from design structures in the canonical model (`#49`).
+5. Prove one end-to-end formal artifact pipeline from the canonical model (`#48`).
+
+This order is deliberate:
+
+- model semantics need to stabilize before readiness rules can be objective
+- readiness and stable semantics should exist before traceability is treated as specification-grade
+- analysis/design separation depends on the stronger semantic model and clearer readiness rules
+- the proof artifact should validate the hardened model, not substitute for it
+
 ## What V1.6 Should Deliver
 
 ### 1. Stronger Canonical Semantics


### PR DESCRIPTION
## Summary
- add an explicit V1.6 implementation sequence to the roadmap docs
- record the same order on epic #45 in GitHub
- make the V1.6 backlog an ordered execution plan instead of an unordered set

## Testing
- not run (documentation and issue-hygiene only)