### PR TITLE
feat: harden canonical model semantics

### DIFF
--- a/skills/specops/references/specops-model.md
+++ b/skills/specops/references/specops-model.md
@@ -30,16 +30,86 @@ The canonical project model is `specops-model.yaml`.
   - `non_functional`
 - `logical_view` (optional in V1, expected for V1.5+ full-spec work)
   - `domain_entities`
+  - `domain_entity_objects`
+    - `id`
+    - `name`
+    - `entity_type`
+    - `description`
+    - `attributes`
+    - `responsibilities`
+    - `trace`
   - `relationships`
+  - `relationship_objects`
+    - `id`
+    - `description`
+    - `relationship_type`
+    - `source_name`
+    - `source_entity_id`
+    - `target_name`
+    - `target_entity_id`
+    - `trace`
   - `business_rules`
+  - `business_rule_objects`
+    - `id`
+    - `name`
+    - `rule_text`
+    - `scope`
+    - `trace`
 - `process_view` (optional in V1, expected for V1.5+ full-spec work)
   - `state_entities`
+  - `state_entity_objects`
+    - `id`
+    - `name`
+    - `entity_type`
+    - `description`
+    - `states`
+    - `trace`
   - `states_and_transitions`
+  - `state_transition_objects`
+    - `id`
+    - `description`
+    - `state_entity_id`
+    - `state_entity_name`
+    - `from_state`
+    - `to_state`
+    - `trigger`
+    - `trace`
   - `triggers_and_approvals`
+  - `trigger_objects`
+    - `id`
+    - `event_name`
+    - `outcome`
+    - `description`
+    - `approval_required`
+    - `trace`
 - `architecture_view` (optional in V1, expected for V1.5+ full-spec work)
   - `components_and_services`
+  - `component_objects`
+    - `id`
+    - `name`
+    - `component_kind`
+    - `responsibility`
+    - `runtime_environment`
+    - `trace`
   - `interfaces_and_integrations`
+  - `interface_objects`
+    - `id`
+    - `description`
+    - `source_component_name`
+    - `source_component_id`
+    - `target_component_name`
+    - `target_component_id`
+    - `interaction_verb`
+    - `protocol`
+    - `trace`
   - `runtime_boundaries`
+  - `runtime_boundary_objects`
+    - `id`
+    - `name`
+    - `boundary_type`
+    - `description`
+    - `deployment_nodes`
+    - `trace`
 - `assumptions`
   - supports plain strings
   - may also use structured items with:

--- a/src/specops_tools/discovery.py
+++ b/src/specops_tools/discovery.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 TECHNICAL_FACTOR_ALIASES = {
@@ -59,6 +60,18 @@ def _slugify(value: str) -> str:
     return result or "item"
 
 
+def _match_slug(value: str) -> str:
+    """Create a looser deterministic slug for reference matching."""
+    tokens = [token for token in _slugify(value).split("-") if token not in {"a", "an", "the"}]
+    normalized_tokens = []
+    for token in tokens:
+        if len(token) > 3 and token.endswith("s"):
+            normalized_tokens.append(token[:-1])
+        else:
+            normalized_tokens.append(token)
+    return "-".join(normalized_tokens)
+
+
 def _ensure_list(value: Any) -> list[str]:
     """Normalize a scalar or list answer into a clean string list."""
     def _clean(item: Any) -> str:
@@ -99,6 +112,267 @@ def _string_items_to_described_items(items: list[str], kind: str) -> list[dict[s
     ]
 
 
+def _normalize_domain_entities(items: list[str]) -> list[dict[str, Any]]:
+    """Convert domain entity strings into explicit analysis objects."""
+    entities = []
+    for item in items:
+        normalized_name = item.strip()
+        entities.append(
+            {
+                "id": f"entity-{_slugify(normalized_name)}",
+                "name": normalized_name,
+                "entity_type": "domain_entity",
+                "description": "",
+                "attributes": [],
+                "responsibilities": [],
+                "trace": {},
+            }
+        )
+    return entities
+
+
+def _normalize_relationships(
+    items: list[str],
+    entities: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Convert relationship strings into structured relationship objects."""
+    relationships = []
+    for index, item in enumerate(items, 1):
+        text = item.strip()
+        source_name = ""
+        target_name = ""
+        relationship_type = ""
+        normalized = text.lower()
+
+        if " has many " in normalized:
+            source_name, target_name = re.split(r"\bhas many\b", text, maxsplit=1, flags=re.IGNORECASE)
+            relationship_type = "has_many"
+        elif " has a " in normalized:
+            source_name, target_name = re.split(r"\bhas a\b", text, maxsplit=1, flags=re.IGNORECASE)
+            relationship_type = "has_one"
+        elif " has an " in normalized:
+            source_name, target_name = re.split(r"\bhas an\b", text, maxsplit=1, flags=re.IGNORECASE)
+            relationship_type = "has_one"
+        elif " belongs to " in normalized:
+            source_name, target_name = re.split(
+                r"\bbelongs to\b",
+                text,
+                maxsplit=1,
+                flags=re.IGNORECASE,
+            )
+            relationship_type = "belongs_to"
+
+        source_name = source_name.strip()
+        target_name = target_name.strip()
+        source_match = _best_name_match(source_name, entities) if source_name else None
+        target_match = _best_name_match(target_name, entities) if target_name else None
+        relationships.append(
+            {
+                "id": f"relationship-{index}",
+                "description": text,
+                "relationship_type": relationship_type,
+                "source_name": source_name,
+                "source_entity_id": source_match["id"] if source_match else "",
+                "target_name": target_name,
+                "target_entity_id": target_match["id"] if target_match else "",
+                "trace": {},
+            }
+        )
+    return relationships
+
+
+def _normalize_business_rules(items: list[str]) -> list[dict[str, Any]]:
+    """Convert business-rule strings into explicit rule objects."""
+    rules = []
+    for index, item in enumerate(items, 1):
+        text = item.strip()
+        normalized = text.lower()
+        scope = ""
+        if " requires " in normalized:
+            scope = text.split(" requires ", 1)[0].strip()
+        elif " must " in normalized:
+            scope = text.split(" must ", 1)[0].strip()
+        rules.append(
+            {
+                "id": f"business-rule-{index}",
+                "name": f"Rule {index}",
+                "rule_text": text,
+                "scope": scope,
+                "trace": {},
+            }
+        )
+    return rules
+
+
+def _normalize_state_entities(items: list[str]) -> list[dict[str, Any]]:
+    """Convert state-entity strings into explicit lifecycle owner objects."""
+    entities = []
+    for item in items:
+        normalized_name = item.strip()
+        entities.append(
+            {
+                "id": f"state-entity-{_slugify(normalized_name)}",
+                "name": normalized_name,
+                "entity_type": "stateful_entity",
+                "description": "",
+                "states": [],
+                "trace": {},
+            }
+        )
+    return entities
+
+
+def _normalize_state_transitions(items: list[str]) -> list[dict[str, Any]]:
+    """Convert transition strings into structured transition objects."""
+    transitions = []
+    for item in items:
+        text = item.strip()
+        if "->" not in text:
+            transitions.append(
+                {
+                    "id": f"state-transition-{len(transitions) + 1}",
+                    "description": text,
+                    "state_entity_id": "",
+                    "state_entity_name": "",
+                    "from_state": "",
+                    "to_state": "",
+                    "trigger": "",
+                    "trace": {},
+                }
+            )
+            continue
+
+        states = [part.strip() for part in text.split("->") if part.strip()]
+        for source_state, target_state in zip(states, states[1:]):
+            transitions.append(
+                {
+                    "id": f"state-transition-{len(transitions) + 1}",
+                    "description": text,
+                    "state_entity_id": "",
+                    "state_entity_name": "",
+                    "from_state": source_state,
+                    "to_state": target_state,
+                    "trigger": "",
+                    "trace": {},
+                }
+            )
+    return transitions
+
+
+def _normalize_triggers(items: list[str]) -> list[dict[str, Any]]:
+    """Convert trigger strings into structured process event objects."""
+    triggers = []
+    for index, item in enumerate(items, 1):
+        text = item.strip()
+        event_name = ""
+        outcome = ""
+        normalized = text.lower()
+        if " triggers " in normalized:
+            event_name, outcome = re.split(r"\btriggers\b", text, maxsplit=1, flags=re.IGNORECASE)
+        elif " requires " in normalized:
+            event_name, outcome = re.split(r"\brequires\b", text, maxsplit=1, flags=re.IGNORECASE)
+        triggers.append(
+            {
+                "id": f"trigger-{index}",
+                "event_name": event_name.strip(),
+                "outcome": outcome.strip(),
+                "description": text,
+                "approval_required": "approval" in normalized,
+                "trace": {},
+            }
+        )
+    return triggers
+
+
+def _normalize_components(items: list[str]) -> list[dict[str, Any]]:
+    """Convert component strings into explicit architecture objects."""
+    components = []
+    for item in items:
+        normalized_name = item.strip()
+        lowered = normalized_name.lower()
+        component_kind = "component"
+        if "api" in lowered:
+            component_kind = "api"
+        elif "service" in lowered:
+            component_kind = "service"
+        elif "web" in lowered or "ui" in lowered or "portal" in lowered:
+            component_kind = "application"
+        components.append(
+            {
+                "id": f"component-{_slugify(normalized_name)}",
+                "name": normalized_name,
+                "component_kind": component_kind,
+                "responsibility": "",
+                "runtime_environment": "",
+                "trace": {},
+            }
+        )
+    return components
+
+
+def _normalize_interfaces(
+    items: list[str],
+    components: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Convert interface strings into structured interface objects."""
+    interfaces = []
+    for index, item in enumerate(items, 1):
+        text = item.strip()
+        source_name = ""
+        target_name = ""
+        interaction_verb = ""
+        normalized = text.lower()
+
+        if " calls " in normalized:
+            source_name, target_name = re.split(r"\bcalls\b", text, maxsplit=1, flags=re.IGNORECASE)
+            interaction_verb = "calls"
+        elif " sends " in normalized:
+            source_name, target_name = re.split(r"\bsends\b", text, maxsplit=1, flags=re.IGNORECASE)
+            interaction_verb = "sends"
+        elif " receives " in normalized:
+            source_name, target_name = re.split(r"\breceives\b", text, maxsplit=1, flags=re.IGNORECASE)
+            interaction_verb = "receives"
+
+        source_name = source_name.strip()
+        target_name = target_name.strip()
+        source_match = _best_name_match(source_name, components) if source_name else None
+        target_match = _best_name_match(target_name, components) if target_name else None
+        interfaces.append(
+            {
+                "id": f"interface-{index}",
+                "description": text,
+                "source_component_name": source_name,
+                "source_component_id": source_match["id"] if source_match else "",
+                "target_component_name": target_name,
+                "target_component_id": target_match["id"] if target_match else "",
+                "interaction_verb": interaction_verb,
+                "protocol": "",
+                "trace": {},
+            }
+        )
+    return interfaces
+
+
+def _normalize_runtime_boundaries(items: list[str]) -> list[dict[str, Any]]:
+    """Convert runtime boundary strings into explicit deployment boundary objects."""
+    boundaries = []
+    for index, item in enumerate(items, 1):
+        text = item.strip()
+        normalized = text.lower()
+        boundary_type = "runtime_separation" if "separate" in normalized else ""
+        boundaries.append(
+            {
+                "id": f"runtime-boundary-{index}",
+                "name": f"Runtime Boundary {index}",
+                "boundary_type": boundary_type,
+                "description": text,
+                "deployment_nodes": [],
+                "trace": {},
+            }
+        )
+    return boundaries
+
+
 def _with_trace(
     items: list[dict[str, Any]],
     source_round: int,
@@ -118,16 +392,16 @@ def _with_trace(
 
 def _best_name_match(name: str, candidates: list[dict[str, Any]]) -> dict[str, Any] | None:
     """Find the best deterministic name match for a complexity entry."""
-    target_slug = _slugify(name)
+    target_slug = _match_slug(name)
     for candidate in candidates:
-        if _slugify(candidate.get("name", "")) == target_slug:
+        if _match_slug(candidate.get("name", "")) == target_slug:
             return candidate
 
     target_tokens = set(target_slug.split("-"))
     best_match = None
     best_score = 0
     for candidate in candidates:
-        candidate_tokens = set(_slugify(candidate.get("name", "")).split("-"))
+        candidate_tokens = set(_match_slug(candidate.get("name", "")).split("-"))
         score = len(target_tokens & candidate_tokens)
         if score > best_score and score >= 2:
             best_score = score
@@ -308,6 +582,44 @@ def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
     technical_factors = _normalize_factor_map(round_10, TECHNICAL_FACTOR_ALIASES)
     environmental_factors = _normalize_factor_map(round_11, ENVIRONMENTAL_FACTOR_ALIASES)
 
+    domain_entity_objects = _with_trace(_normalize_domain_entities(domain_entities), 5, "domain_entities")
+    relationship_objects = _with_trace(
+        _normalize_relationships(relationships, domain_entity_objects),
+        5,
+        "relationships",
+    )
+    business_rule_objects = _with_trace(
+        _normalize_business_rules(business_rules),
+        5,
+        "business_rules",
+    )
+    state_entity_objects = _with_trace(_normalize_state_entities(state_entities), 6, "state_entities")
+    state_transition_objects = _with_trace(
+        _normalize_state_transitions(states_and_transitions),
+        6,
+        "states_and_transitions",
+    )
+    trigger_objects = _with_trace(
+        _normalize_triggers(triggers_and_approvals),
+        6,
+        "triggers_and_approvals",
+    )
+    component_objects = _with_trace(
+        _normalize_components(components_and_services),
+        7,
+        "components_and_services",
+    )
+    interface_objects = _with_trace(
+        _normalize_interfaces(interfaces_and_integrations, component_objects),
+        7,
+        "interfaces_and_integrations",
+    )
+    runtime_boundary_objects = _with_trace(
+        _normalize_runtime_boundaries(runtime_boundaries),
+        7,
+        "runtime_boundaries",
+    )
+
     return {
         "project": {
             "name": _text_or_empty(round_1.get("idea")) or "Unnamed Project",
@@ -325,81 +637,27 @@ def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
         },
         "logical_view": {
             "domain_entities": domain_entities,
-            "domain_entity_objects": _with_trace(
-                _string_items_to_named_items(domain_entities, "entity"),
-                5,
-                "domain_entities",
-            ),
+            "domain_entity_objects": domain_entity_objects,
             "relationships": relationships,
-            "relationship_objects": _with_trace(
-                _string_items_to_described_items(relationships, "relationship"),
-                5,
-                "relationships",
-            ),
+            "relationship_objects": relationship_objects,
             "business_rules": business_rules,
-            "business_rule_objects": _with_trace(
-                _string_items_to_described_items(
-                    business_rules,
-                    "business-rule",
-                ),
-                5,
-                "business_rules",
-            ),
+            "business_rule_objects": business_rule_objects,
         },
         "process_view": {
             "state_entities": state_entities,
-            "state_entity_objects": _with_trace(
-                _string_items_to_named_items(state_entities, "state-entity"),
-                6,
-                "state_entities",
-            ),
+            "state_entity_objects": state_entity_objects,
             "states_and_transitions": states_and_transitions,
-            "state_transition_objects": _with_trace(
-                _string_items_to_described_items(
-                    states_and_transitions,
-                    "state-transition",
-                ),
-                6,
-                "states_and_transitions",
-            ),
+            "state_transition_objects": state_transition_objects,
             "triggers_and_approvals": triggers_and_approvals,
-            "trigger_objects": _with_trace(
-                _string_items_to_described_items(
-                    triggers_and_approvals,
-                    "trigger",
-                ),
-                6,
-                "triggers_and_approvals",
-            ),
+            "trigger_objects": trigger_objects,
         },
         "architecture_view": {
             "components_and_services": components_and_services,
-            "component_objects": _with_trace(
-                _string_items_to_named_items(
-                    components_and_services,
-                    "component",
-                ),
-                7,
-                "components_and_services",
-            ),
+            "component_objects": component_objects,
             "interfaces_and_integrations": interfaces_and_integrations,
-            "interface_objects": _with_trace(
-                _string_items_to_described_items(
-                    interfaces_and_integrations,
-                    "interface",
-                ),
-                7,
-                "interfaces_and_integrations",
-            ),
+            "interface_objects": interface_objects,
             "runtime_boundaries": runtime_boundaries,
-            "runtime_boundary_objects": _with_trace(
-                _string_items_to_described_items(
-                    runtime_boundaries,
-                    "runtime-boundary",
-                ),
-                7,
-                "runtime_boundaries",
-            ),
+            "runtime_boundary_objects": runtime_boundary_objects,
         },
         "metadata_fields": _ensure_list(round_4.get("metadata_fields")),
         "assumptions": [],

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -92,8 +92,20 @@ class DiscoveryTests(unittest.TestCase):
             "entity-system",
         )
         self.assertEqual(
+            model["logical_view"]["domain_entity_objects"][0]["entity_type"],
+            "domain_entity",
+        )
+        self.assertEqual(
             model["logical_view"]["domain_entity_objects"][0]["trace"]["source_round"],
             5,
+        )
+        self.assertEqual(
+            model["logical_view"]["relationship_objects"][0]["relationship_type"],
+            "has_many",
+        )
+        self.assertEqual(
+            model["logical_view"]["relationship_objects"][0]["source_entity_id"],
+            "entity-system",
         )
         self.assertIn(
             "Draft -> Submitted -> Approved",
@@ -103,14 +115,42 @@ class DiscoveryTests(unittest.TestCase):
             model["process_view"]["state_entity_objects"][0]["id"],
             "state-entity-approval-request",
         )
+        self.assertEqual(
+            model["process_view"]["state_transition_objects"][0]["from_state"],
+            "Draft",
+        )
+        self.assertEqual(
+            model["process_view"]["state_transition_objects"][0]["to_state"],
+            "Submitted",
+        )
+        self.assertEqual(
+            model["process_view"]["trigger_objects"][0]["event_name"],
+            "Submission",
+        )
         self.assertIn("Web app", model["architecture_view"]["components_and_services"])
         self.assertEqual(
             model["architecture_view"]["component_objects"][0]["id"],
             "component-web-app",
         )
         self.assertEqual(
+            model["architecture_view"]["component_objects"][0]["component_kind"],
+            "application",
+        )
+        self.assertEqual(
             model["architecture_view"]["component_objects"][0]["trace"]["source_key"],
             "components_and_services",
+        )
+        self.assertEqual(
+            model["architecture_view"]["interface_objects"][0]["source_component_id"],
+            "component-web-app",
+        )
+        self.assertEqual(
+            model["architecture_view"]["interface_objects"][0]["target_component_id"],
+            "component-api",
+        )
+        self.assertEqual(
+            model["architecture_view"]["runtime_boundary_objects"][0]["boundary_type"],
+            "runtime_separation",
         )
 
     def test_normalize_replay_to_model_keeps_empty_sections_explicit(self) -> None:
@@ -244,6 +284,51 @@ class DiscoveryTests(unittest.TestCase):
         self.assertEqual(model["ucp"]["technical_factors"]["third_party_access"], 4)
         self.assertEqual(model["ucp"]["environmental_factors"]["familiar_with_process"], 4)
         self.assertEqual(model["ucp"]["environmental_factors"]["part_time_staff"], 1)
+
+    def test_normalize_replay_to_model_keeps_semantic_fields_explicit_when_unparsed(self) -> None:
+        """Hardening should expose semantic fields even when deterministic parsing finds no structure."""
+        replay = replay_session(
+            [
+                {
+                    "round": 5,
+                    "responses": [
+                        {"key": "domain_entities", "answer": ["Ledger Entry"]},
+                        {"key": "relationships", "answer": ["Ledger Entry interacts with reporting"]},
+                        {"key": "business_rules", "answer": ["Ledger Entry must be retained"]},
+                    ],
+                },
+                {
+                    "round": 6,
+                    "responses": [
+                        {"key": "states_and_transitions", "answer": ["Manual review path"]},
+                    ],
+                },
+                {
+                    "round": 7,
+                    "responses": [
+                        {"key": "interfaces_and_integrations", "answer": ["Event bridge integration"]},
+                    ],
+                },
+            ]
+        )
+
+        model = normalize_replay_to_model(replay)
+
+        relationship = model["logical_view"]["relationship_objects"][0]
+        self.assertEqual(relationship["relationship_type"], "")
+        self.assertEqual(relationship["source_entity_id"], "")
+        self.assertEqual(relationship["target_entity_id"], "")
+        self.assertEqual(relationship["description"], "Ledger Entry interacts with reporting")
+
+        transition = model["process_view"]["state_transition_objects"][0]
+        self.assertEqual(transition["from_state"], "")
+        self.assertEqual(transition["to_state"], "")
+        self.assertEqual(transition["description"], "Manual review path")
+
+        interface = model["architecture_view"]["interface_objects"][0]
+        self.assertEqual(interface["source_component_id"], "")
+        self.assertEqual(interface["target_component_id"], "")
+        self.assertEqual(interface["interaction_verb"], "")
 
     def test_normalize_replay_to_model_with_real_fixture(self) -> None:
         """The checked-in interview fixture should normalize into the canonical V1.5 shape."""


### PR DESCRIPTION
## Summary
- document stronger canonical object schemas for logical, process, and architecture views
- harden deterministic normalization so those views emit typed semantic objects instead of mostly label-only structures
- keep parsing conservative by leaving semantic fields explicit but empty when structure cannot be resolved deterministically
- extend discovery tests to cover parsed and unparsed semantic cases

## Testing
- uv run python -m unittest tests.test_discovery
- uv run python -m unittest