### PR TITLE
feat: clarify analysis and design layers

### DIFF
--- a/skills/specops/references/specops-model.md
+++ b/skills/specops/references/specops-model.md
@@ -16,6 +16,7 @@ The canonical project model is `specops-model.yaml`.
   - `name`
   - `type`
   - `description`
+  - `model_layer`: `analysis`
   - `interaction_style`
   - `responsibilities`
   - `complexity`: `simple`, `average`, or `complex`
@@ -25,6 +26,7 @@ The canonical project model is `specops-model.yaml`.
   - `primary_actor`
   - `primary_actor_id`
   - `supporting_actor_ids`
+  - `model_layer`: `analysis`
   - `goal`
   - `trigger`
   - `preconditions`
@@ -39,6 +41,7 @@ The canonical project model is `specops-model.yaml`.
     - `statement`
     - `requirement_kind`
     - `quality_attribute`
+    - `model_layer`: `analysis`
     - `linked_use_case_ids`
     - `fit_criterion`
     - `trace`
@@ -48,15 +51,27 @@ The canonical project model is `specops-model.yaml`.
     - `statement`
     - `requirement_kind`
     - `quality_attribute`
+    - `model_layer`: `analysis`
     - `linked_use_case_ids`
     - `fit_criterion`
     - `trace`
+- `analysis_view`
+  - `actor_ids`
+  - `use_case_ids`
+  - `requirement_ids`
+  - `domain_entity_ids`
+  - `relationship_ids`
+  - `business_rule_ids`
+  - `state_entity_ids`
+  - `state_transition_ids`
+  - `trigger_ids`
 - `logical_view` (optional in V1, expected for V1.5+ full-spec work)
   - `domain_entities`
   - `domain_entity_objects`
     - `id`
     - `name`
     - `entity_type`
+    - `model_layer`: `analysis`
     - `description`
     - `attributes`
     - `responsibilities`
@@ -66,6 +81,7 @@ The canonical project model is `specops-model.yaml`.
     - `id`
     - `description`
     - `relationship_type`
+    - `model_layer`: `analysis`
     - `source_name`
     - `source_entity_id`
     - `target_name`
@@ -76,6 +92,7 @@ The canonical project model is `specops-model.yaml`.
     - `id`
     - `name`
     - `rule_text`
+    - `model_layer`: `analysis`
     - `scope`
     - `trace`
 - `process_view` (optional in V1, expected for V1.5+ full-spec work)
@@ -84,6 +101,7 @@ The canonical project model is `specops-model.yaml`.
     - `id`
     - `name`
     - `entity_type`
+    - `model_layer`: `analysis`
     - `description`
     - `states`
     - `trace`
@@ -91,6 +109,7 @@ The canonical project model is `specops-model.yaml`.
   - `state_transition_objects`
     - `id`
     - `description`
+    - `model_layer`: `analysis`
     - `state_entity_id`
     - `state_entity_name`
     - `from_state`
@@ -103,14 +122,20 @@ The canonical project model is `specops-model.yaml`.
     - `event_name`
     - `outcome`
     - `description`
+    - `model_layer`: `analysis`
     - `approval_required`
     - `trace`
+- `design_view`
+  - `component_ids`
+  - `interface_ids`
+  - `runtime_boundary_ids`
 - `architecture_view` (optional in V1, expected for V1.5+ full-spec work)
   - `components_and_services`
   - `component_objects`
     - `id`
     - `name`
     - `component_kind`
+    - `model_layer`: `design`
     - `responsibility`
     - `runtime_environment`
     - `trace`
@@ -118,6 +143,7 @@ The canonical project model is `specops-model.yaml`.
   - `interface_objects`
     - `id`
     - `description`
+    - `model_layer`: `design`
     - `source_component_name`
     - `source_component_id`
     - `target_component_name`
@@ -131,6 +157,7 @@ The canonical project model is `specops-model.yaml`.
     - `name`
     - `boundary_type`
     - `description`
+    - `model_layer`: `design`
     - `deployment_nodes`
     - `trace`
 - `assumptions`

--- a/src/specops_tools/discovery.py
+++ b/src/specops_tools/discovery.py
@@ -122,6 +122,7 @@ def _normalize_domain_entities(items: list[str]) -> list[dict[str, Any]]:
                 "id": f"entity-{_slugify(normalized_name)}",
                 "name": normalized_name,
                 "entity_type": "domain_entity",
+                "model_layer": "analysis",
                 "description": "",
                 "attributes": [],
                 "responsibilities": [],
@@ -171,6 +172,7 @@ def _normalize_relationships(
                 "id": f"relationship-{index}",
                 "description": text,
                 "relationship_type": relationship_type,
+                "model_layer": "analysis",
                 "source_name": source_name,
                 "source_entity_id": source_match["id"] if source_match else "",
                 "target_name": target_name,
@@ -197,6 +199,7 @@ def _normalize_business_rules(items: list[str]) -> list[dict[str, Any]]:
                 "id": f"business-rule-{index}",
                 "name": f"Rule {index}",
                 "rule_text": text,
+                "model_layer": "analysis",
                 "scope": scope,
                 "trace": {},
             }
@@ -214,6 +217,7 @@ def _normalize_state_entities(items: list[str]) -> list[dict[str, Any]]:
                 "id": f"state-entity-{_slugify(normalized_name)}",
                 "name": normalized_name,
                 "entity_type": "stateful_entity",
+                "model_layer": "analysis",
                 "description": "",
                 "states": [],
                 "trace": {},
@@ -232,6 +236,7 @@ def _normalize_state_transitions(items: list[str]) -> list[dict[str, Any]]:
                 {
                     "id": f"state-transition-{len(transitions) + 1}",
                     "description": text,
+                    "model_layer": "analysis",
                     "state_entity_id": "",
                     "state_entity_name": "",
                     "from_state": "",
@@ -248,6 +253,7 @@ def _normalize_state_transitions(items: list[str]) -> list[dict[str, Any]]:
                 {
                     "id": f"state-transition-{len(transitions) + 1}",
                     "description": text,
+                    "model_layer": "analysis",
                     "state_entity_id": "",
                     "state_entity_name": "",
                     "from_state": source_state,
@@ -277,6 +283,7 @@ def _normalize_triggers(items: list[str]) -> list[dict[str, Any]]:
                 "event_name": event_name.strip(),
                 "outcome": outcome.strip(),
                 "description": text,
+                "model_layer": "analysis",
                 "approval_required": "approval" in normalized,
                 "trace": {},
             }
@@ -302,6 +309,7 @@ def _normalize_components(items: list[str]) -> list[dict[str, Any]]:
                 "id": f"component-{_slugify(normalized_name)}",
                 "name": normalized_name,
                 "component_kind": component_kind,
+                "model_layer": "design",
                 "responsibility": "",
                 "runtime_environment": "",
                 "trace": {},
@@ -341,6 +349,7 @@ def _normalize_interfaces(
             {
                 "id": f"interface-{index}",
                 "description": text,
+                "model_layer": "design",
                 "source_component_name": source_name,
                 "source_component_id": source_match["id"] if source_match else "",
                 "target_component_name": target_name,
@@ -366,6 +375,7 @@ def _normalize_runtime_boundaries(items: list[str]) -> list[dict[str, Any]]:
                 "name": f"Runtime Boundary {index}",
                 "boundary_type": boundary_type,
                 "description": text,
+                "model_layer": "design",
                 "deployment_nodes": [],
                 "trace": {},
             }
@@ -484,6 +494,7 @@ def _normalize_actors(items: list[str]) -> list[dict[str, str]]:
                 "name": normalized_name,
                 "type": actor_type,
                 "description": "",
+                "model_layer": "analysis",
                 "interaction_style": "user_interface" if actor_type == "human" else "system_interface",
                 "responsibilities": [],
                 "complexity": "unclassified",
@@ -505,6 +516,7 @@ def _normalize_use_cases(items: list[str]) -> list[dict[str, Any]]:
                 "primary_actor": "Unspecified",
                 "primary_actor_id": "",
                 "supporting_actor_ids": [],
+                "model_layer": "analysis",
                 "goal": normalized_name,
                 "trigger": "",
                 "preconditions": [],
@@ -535,6 +547,7 @@ def _normalize_requirement_objects(
                 "statement": text,
                 "requirement_kind": requirement_kind,
                 "quality_attribute": quality_attribute,
+                "model_layer": "analysis",
                 "linked_use_case_ids": [],
                 "fit_criterion": "",
                 "trace": {},
@@ -687,6 +700,24 @@ def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
         7,
         "runtime_boundaries",
     )
+    analysis_view = {
+        "actor_ids": [item["id"] for item in normalized_actors],
+        "use_case_ids": [item["id"] for item in normalized_use_cases],
+        "requirement_ids": [
+            item["id"] for item in functional_requirement_objects + non_functional_requirement_objects
+        ],
+        "domain_entity_ids": [item["id"] for item in domain_entity_objects],
+        "relationship_ids": [item["id"] for item in relationship_objects],
+        "business_rule_ids": [item["id"] for item in business_rule_objects],
+        "state_entity_ids": [item["id"] for item in state_entity_objects],
+        "state_transition_ids": [item["id"] for item in state_transition_objects],
+        "trigger_ids": [item["id"] for item in trigger_objects],
+    }
+    design_view = {
+        "component_ids": [item["id"] for item in component_objects],
+        "interface_ids": [item["id"] for item in interface_objects],
+        "runtime_boundary_ids": [item["id"] for item in runtime_boundary_objects],
+    }
 
     return {
         "project": {
@@ -705,6 +736,7 @@ def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
             "non_functional": non_functional,
             "non_functional_objects": non_functional_requirement_objects,
         },
+        "analysis_view": analysis_view,
         "logical_view": {
             "domain_entities": domain_entities,
             "domain_entity_objects": domain_entity_objects,
@@ -729,6 +761,7 @@ def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
             "runtime_boundaries": runtime_boundaries,
             "runtime_boundary_objects": runtime_boundary_objects,
         },
+        "design_view": design_view,
         "metadata_fields": _ensure_list(round_4.get("metadata_fields")),
         "assumptions": [],
         "open_questions": [],

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -89,8 +89,16 @@ class DiscoveryTests(unittest.TestCase):
             "functional",
         )
         self.assertEqual(
+            model["requirements"]["functional_objects"][0]["model_layer"],
+            "analysis",
+        )
+        self.assertEqual(
             model["requirements"]["non_functional_objects"][0]["requirement_kind"],
             "non_functional",
+        )
+        self.assertEqual(
+            model["analysis_view"]["requirement_ids"][0],
+            model["requirements"]["functional_objects"][0]["id"],
         )
         self.assertEqual(model["actors"], [])
         self.assertEqual(model["use_cases"], [])
@@ -102,6 +110,10 @@ class DiscoveryTests(unittest.TestCase):
         self.assertEqual(
             model["logical_view"]["domain_entity_objects"][0]["entity_type"],
             "domain_entity",
+        )
+        self.assertEqual(
+            model["logical_view"]["domain_entity_objects"][0]["model_layer"],
+            "analysis",
         )
         self.assertEqual(
             model["logical_view"]["domain_entity_objects"][0]["trace"]["source_round"],
@@ -145,8 +157,16 @@ class DiscoveryTests(unittest.TestCase):
             "application",
         )
         self.assertEqual(
+            model["architecture_view"]["component_objects"][0]["model_layer"],
+            "design",
+        )
+        self.assertEqual(
             model["architecture_view"]["component_objects"][0]["trace"]["source_key"],
             "components_and_services",
+        )
+        self.assertEqual(
+            model["design_view"]["component_ids"][0],
+            model["architecture_view"]["component_objects"][0]["id"],
         )
         self.assertEqual(
             model["architecture_view"]["interface_objects"][0]["source_component_id"],
@@ -210,6 +230,7 @@ class DiscoveryTests(unittest.TestCase):
 
         self.assertEqual(model["actors"][0]["id"], "operations-manager")
         self.assertEqual(model["actors"][0]["type"], "human")
+        self.assertEqual(model["actors"][0]["model_layer"], "analysis")
         self.assertEqual(model["actors"][0]["interaction_style"], "user_interface")
         self.assertEqual(model["actors"][0]["responsibilities"], [])
         self.assertEqual(model["actors"][0]["trace"]["source_round"], 3)
@@ -218,6 +239,7 @@ class DiscoveryTests(unittest.TestCase):
         self.assertEqual(model["actors"][2]["type"], "system")
         self.assertEqual(model["use_cases"][0]["id"], "browse-rewards")
         self.assertEqual(model["use_cases"][0]["goal"], "Browse Rewards")
+        self.assertEqual(model["use_cases"][0]["model_layer"], "analysis")
         self.assertEqual(model["use_cases"][0]["primary_actor_id"], "")
         self.assertEqual(model["use_cases"][0]["supporting_actor_ids"], [])
         self.assertEqual(model["use_cases"][0]["trigger"], "")
@@ -225,6 +247,8 @@ class DiscoveryTests(unittest.TestCase):
         self.assertEqual(model["use_cases"][0]["postconditions"], [])
         self.assertEqual(model["use_cases"][0]["trace"]["source_key"], "use_cases")
         self.assertEqual(model["use_cases"][1]["complexity"], "unclassified")
+        self.assertEqual(model["analysis_view"]["actor_ids"][0], "operations-manager")
+        self.assertEqual(model["analysis_view"]["use_case_ids"][0], "browse-rewards")
 
     def test_normalize_replay_to_model_applies_ucp_answers_to_objects(self) -> None:
         """UCP round answers should update normalized actor/use-case complexity and factors."""
@@ -370,6 +394,7 @@ class DiscoveryTests(unittest.TestCase):
 
         functional_object = model["requirements"]["functional_objects"][0]
         self.assertEqual(functional_object["statement"], "Support change approval flow")
+        self.assertEqual(functional_object["model_layer"], "analysis")
         self.assertEqual(functional_object["linked_use_case_ids"], [])
         self.assertEqual(functional_object["fit_criterion"], "")
 
@@ -377,6 +402,7 @@ class DiscoveryTests(unittest.TestCase):
         self.assertEqual(non_functional_object["statement"], "Security: SSO required")
         self.assertEqual(non_functional_object["quality_attribute"], "Security")
         self.assertEqual(non_functional_object["requirement_kind"], "non_functional")
+        self.assertEqual(non_functional_object["model_layer"], "analysis")
 
     def test_normalize_replay_to_model_with_real_fixture(self) -> None:
         """The checked-in interview fixture should normalize into the canonical V1.5 shape."""


### PR DESCRIPTION
## Summary
- add explicit model-layer markers to canonical analysis and design objects
- add separate analysis_view and design_view reference sections to the canonical model
- update the model contract and discovery coverage to reflect the new layer boundary

## Testing
- uv run python -m unittest tests.test_discovery
- uv run python -m unittest