### PR TITLE
feat: add field-level readiness gates

### DIFF
--- a/src/specops_tools/interview.py
+++ b/src/specops_tools/interview.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 import json
 from typing import Any
 
-from .readiness import evaluate_readiness, identify_stale_artifacts
+from .readiness import evaluate_readiness, evaluate_readiness_details, identify_stale_artifacts
 
 
 def _normalize_key(value: str) -> str:
@@ -697,6 +697,7 @@ def replay_session(round_inputs: list[dict[str, Any]]) -> dict[str, Any]:
         "last_round": transcript[-1]["round"]["number"] if transcript else None,
         "next_round": transcript[-1]["next_round"] if transcript else None,
         "readiness": evaluate_readiness(normalized_round_inputs),
+        "readiness_details": evaluate_readiness_details(normalized_round_inputs),
         "stale_artifacts": [],
     }
 

--- a/src/specops_tools/readiness.py
+++ b/src/specops_tools/readiness.py
@@ -5,13 +5,31 @@ from __future__ import annotations
 from typing import Any
 
 
-VIEW_REQUIREMENTS = {
-    "discovery": {1, 2},
-    "use_case": {3, 4},
-    "logical": {5},
-    "process": {6},
-    "architecture": {7},
-    "ucp": {8, 9, 10, 11},
+VIEW_GATES = {
+    "discovery": {
+        "required": ("idea", "problem", "in_scope", "outcomes"),
+        "supporting": ("users", "out_of_scope", "success_criteria", "required_data", "constraints"),
+    },
+    "use_case": {
+        "required": ("actors", "use_cases", "workflow_scope"),
+        "supporting": ("integrations", "metadata_fields", "non_functional_requirements"),
+    },
+    "logical": {
+        "required": ("domain_entities", "relationships"),
+        "supporting": ("business_rules",),
+    },
+    "process": {
+        "required": ("state_entities", "states_and_transitions"),
+        "supporting": ("triggers_and_approvals",),
+    },
+    "architecture": {
+        "required": ("components_and_services", "interfaces_and_integrations"),
+        "supporting": ("runtime_boundaries",),
+    },
+    "ucp": {
+        "required": ("actor_complexity", "use_case_complexity", "technical", "environmental"),
+        "supporting": (),
+    },
 }
 
 VIEW_ARTIFACTS = {
@@ -24,44 +42,72 @@ VIEW_ARTIFACTS = {
 }
 
 
-def _view_status(required_rounds: set[int], answered_rounds: set[int]) -> str:
-    """Return the readiness state for one view."""
-    answered_required = required_rounds & answered_rounds
-    if answered_required == required_rounds:
-        return "ready"
-    if answered_required:
-        return "partial"
-    return "blocked"
+def _has_answer(value: Any) -> bool:
+    """Return whether a replay answer should count as filled."""
+    return str(value).strip() != ""
+
+
+def _answered_keys(round_inputs: list[dict[str, Any]]) -> set[str]:
+    """Return all question keys that currently have non-empty answers."""
+    answered = set()
+    for item in round_inputs:
+        for response in item.get("responses", []):
+            if _has_answer(response.get("answer", "")):
+                answered.add(str(response["key"]))
+    return answered
+
+
+def _view_detail(
+    view_name: str,
+    answered_keys: set[str],
+) -> dict[str, Any]:
+    """Return detailed gate status for one view."""
+    gate = VIEW_GATES[view_name]
+    required = set(gate["required"])
+    supporting = set(gate["supporting"])
+    required_present = sorted(required & answered_keys)
+    required_missing = sorted(required - answered_keys)
+    supporting_present = sorted(supporting & answered_keys)
+    supporting_missing = sorted(supporting - answered_keys)
+
+    if not required_missing:
+        status = "ready"
+    elif required_present or supporting_present:
+        status = "partial"
+    else:
+        status = "blocked"
+
+    return {
+        "status": status,
+        "required_present": required_present,
+        "required_missing": required_missing,
+        "supporting_present": supporting_present,
+        "supporting_missing": supporting_missing,
+    }
+
+
+def evaluate_readiness_details(round_inputs: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    """Evaluate detailed readiness by view from replay rounds."""
+    answered_keys = _answered_keys(round_inputs)
+    return {
+        view_name: _view_detail(view_name, answered_keys)
+        for view_name in VIEW_GATES
+    }
 
 
 def evaluate_readiness(round_inputs: list[dict[str, Any]]) -> dict[str, str]:
-    """Evaluate readiness by view from replay rounds.
-
-    Args:
-        round_inputs: Canonical replay round inputs.
-
-    Returns:
-        Mapping of view name to readiness status.
-    """
-    answered_rounds = {int(item["round"]) for item in round_inputs}
+    """Evaluate readiness by view from replay rounds."""
     return {
-        view_name: _view_status(required_rounds, answered_rounds)
-        for view_name, required_rounds in VIEW_REQUIREMENTS.items()
+        view_name: detail["status"]
+        for view_name, detail in evaluate_readiness_details(round_inputs).items()
     }
 
 
 def identify_stale_artifacts(updates: list[dict[str, Any]]) -> list[str]:
-    """Identify downstream artifacts impacted by updated interview rounds.
-
-    Args:
-        updates: Round update items.
-
-    Returns:
-        Sorted stale artifact names.
-    """
-    updated_rounds = {int(item["round"]) for item in updates}
+    """Identify downstream artifacts impacted by updated interview rounds."""
+    updated_keys = _answered_keys(updates)
     stale_artifacts: set[str] = set()
-    for view_name, required_rounds in VIEW_REQUIREMENTS.items():
-        if updated_rounds & required_rounds:
+    for view_name, gate in VIEW_GATES.items():
+        if updated_keys & (set(gate["required"]) | set(gate["supporting"])):
             stale_artifacts.update(VIEW_ARTIFACTS[view_name])
     return sorted(stale_artifacts)

--- a/tests/test_interview.py
+++ b/tests/test_interview.py
@@ -71,6 +71,7 @@ class InterviewHarnessTests(unittest.TestCase):
         self.assertEqual(replay["readiness"]["logical"], "blocked")
         self.assertEqual(replay["readiness"]["process"], "blocked")
         self.assertEqual(replay["readiness"]["architecture"], "blocked")
+        self.assertEqual(replay["readiness_details"]["discovery"]["required_missing"], [])
         self.assertEqual(replay["stale_artifacts"], [])
 
     def test_replay_session_accepts_individual_question_responses(self) -> None:
@@ -160,6 +161,7 @@ class InterviewHarnessTests(unittest.TestCase):
         self.assertEqual(replay["next_round"]["number"], 3)
         self.assertEqual(len(replay["merged_round_inputs"]), 2)
         self.assertEqual(replay["readiness"]["discovery"], "ready")
+        self.assertEqual(replay["readiness_details"]["discovery"]["status"], "ready")
         self.assertEqual(replay["stale_artifacts"], ["requirements-spec.md"])
 
     def test_cli_accepts_piped_round_answer(self) -> None:
@@ -364,6 +366,7 @@ class InterviewHarnessTests(unittest.TestCase):
         self.assertEqual(payload["readiness"]["logical"], "blocked")
         self.assertEqual(payload["readiness"]["process"], "blocked")
         self.assertEqual(payload["readiness"]["architecture"], "blocked")
+        self.assertIn("domain_entities", payload["readiness_details"]["logical"]["required_missing"])
 
     def test_replay_cli_applies_updates_fixture(self) -> None:
         """The replay CLI should support targeted updates without replay restarts."""
@@ -436,6 +439,7 @@ class InterviewHarnessTests(unittest.TestCase):
         self.assertEqual(payload["merged_answers"]["round_2"]["outcomes"], "Better planning")
         self.assertEqual(payload["next_round"]["number"], 3)
         self.assertEqual(payload["readiness"]["discovery"], "ready")
+        self.assertEqual(payload["readiness_details"]["discovery"]["required_missing"], [])
         self.assertEqual(payload["stale_artifacts"], ["requirements-spec.md"])
 
 

--- a/tests/test_readiness.py
+++ b/tests/test_readiness.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 import unittest
 
-from specops_tools.readiness import evaluate_readiness, identify_stale_artifacts
+from specops_tools.readiness import (
+    evaluate_readiness,
+    evaluate_readiness_details,
+    identify_stale_artifacts,
+)
 
 
 class ReadinessTests(unittest.TestCase):
@@ -14,29 +18,102 @@ class ReadinessTests(unittest.TestCase):
         """Readiness should distinguish complete, partial, and blocked views."""
         readiness = evaluate_readiness(
             [
-                {"round": 1, "responses": []},
-                {"round": 3, "responses": []},
-                {"round": 4, "responses": []},
-                {"round": 5, "responses": []},
-                {"round": 6, "responses": []},
-                {"round": 7, "responses": []},
-                {"round": 8, "responses": []},
+                {
+                    "round": 1,
+                    "responses": [
+                        {"key": "idea", "answer": "Inventory system"},
+                        {"key": "problem", "answer": "Poor visibility"},
+                        {"key": "in_scope", "answer": "Non-OT"},
+                    ],
+                },
+                {
+                    "round": 2,
+                    "responses": [
+                        {"key": "outcomes", "answer": "Better planning"},
+                    ],
+                },
+                {
+                    "round": 3,
+                    "responses": [
+                        {"key": "actors", "answer": "Architect"},
+                        {"key": "use_cases", "answer": "Search systems"},
+                    ],
+                },
+                {
+                    "round": 4,
+                    "responses": [
+                        {"key": "workflow_scope", "answer": "Edit metadata"},
+                    ],
+                },
+                {
+                    "round": 5,
+                    "responses": [
+                        {"key": "domain_entities", "answer": "System"},
+                    ],
+                },
+                {
+                    "round": 6,
+                    "responses": [
+                        {"key": "state_entities", "answer": "System lifecycle"},
+                        {"key": "states_and_transitions", "answer": "Proposed -> Active"},
+                    ],
+                },
+                {
+                    "round": 7,
+                    "responses": [
+                        {"key": "components_and_services", "answer": "Web app"},
+                        {"key": "interfaces_and_integrations", "answer": "Web app calls API"},
+                    ],
+                },
+                {
+                    "round": 8,
+                    "responses": [
+                        {"key": "actor_complexity", "answer": "Architect: complex"},
+                    ],
+                },
             ]
         )
 
-        self.assertEqual(readiness["discovery"], "partial")
+        self.assertEqual(readiness["discovery"], "ready")
         self.assertEqual(readiness["use_case"], "ready")
-        self.assertEqual(readiness["logical"], "ready")
+        self.assertEqual(readiness["logical"], "partial")
         self.assertEqual(readiness["process"], "ready")
         self.assertEqual(readiness["architecture"], "ready")
         self.assertEqual(readiness["ucp"], "partial")
+
+    def test_evaluate_readiness_details_reports_missing_gate_fields(self) -> None:
+        """Detailed readiness should expose the specific missing keys per view."""
+        details = evaluate_readiness_details(
+            [
+                {
+                    "round": 1,
+                    "responses": [
+                        {"key": "idea", "answer": "Inventory system"},
+                        {"key": "problem", "answer": "Poor visibility"},
+                    ],
+                },
+                {
+                    "round": 5,
+                    "responses": [
+                        {"key": "domain_entities", "answer": "System"},
+                        {"key": "business_rules", "answer": "Owner required"},
+                    ],
+                },
+            ]
+        )
+
+        self.assertEqual(details["discovery"]["status"], "partial")
+        self.assertEqual(details["discovery"]["required_missing"], ["in_scope", "outcomes"])
+        self.assertEqual(details["logical"]["status"], "partial")
+        self.assertEqual(details["logical"]["required_missing"], ["relationships"])
+        self.assertEqual(details["logical"]["supporting_present"], ["business_rules"])
 
     def test_identify_stale_artifacts_maps_round_updates_to_outputs(self) -> None:
         """Updated rounds should mark only dependent artifacts stale."""
         stale = identify_stale_artifacts(
             [
-                {"round": 2, "responses": []},
-                {"round": 9, "responses": []},
+                {"round": 2, "responses": [{"key": "constraints", "answer": "Web UI"}]},
+                {"round": 9, "responses": [{"key": "use_case_complexity", "answer": "Search: average"}]},
             ]
         )
 


### PR DESCRIPTION
## Summary
- replace round-presence readiness with explicit field-level gate definitions per view
- add detailed readiness output showing required and supporting fields present or missing
- keep the existing flat readiness map for compatibility while exposing readiness_details in replay output
- make stale artifact detection follow updated keys instead of just round numbers

## Testing
- uv run python -m unittest tests.test_readiness tests.test_interview
- uv run python -m unittest