### PR TITLE
feat: render traceability links

### DIFF
--- a/src/specops_tools/render.py
+++ b/src/specops_tools/render.py
@@ -114,6 +114,28 @@ def _object_text_section(
     return _named_section(title, fallback)
 
 
+def _traceability_section(
+    title: str,
+    links: list[dict[str, Any]],
+) -> str:
+    """Render a cross-view traceability section when links exist."""
+    if not links:
+        return ""
+
+    rendered = []
+    for link in links:
+        rendered.append(
+            f"- `{link.get('id', 'trace')}` {link.get('from_id', 'unknown')} -> "
+            f"{link.get('to_id', 'unknown')} ({link.get('basis', 'unspecified basis')})"
+        )
+
+    return f"""
+## {title}
+
+{"\n".join(rendered)}
+"""
+
+
 def render_requirements_spec(model: dict[str, Any]) -> str:
     """Render the requirements specification artifact.
 
@@ -128,6 +150,7 @@ def render_requirements_spec(model: dict[str, Any]) -> str:
     logical_view = model.get("logical_view", {})
     process_view = model.get("process_view", {})
     architecture_view = model.get("architecture_view", {})
+    traceability = model.get("traceability", {})
     return f"""# Requirements Specification
 
 ## Project
@@ -200,6 +223,18 @@ def render_requirements_spec(model: dict[str, Any]) -> str:
     architecture_view.get("runtime_boundary_objects", []),
     architecture_view.get("runtime_boundaries", []),
 )}
+{_traceability_section(
+    "Requirement To Use-Case Traceability",
+    traceability.get("requirement_to_use_case", []),
+)}
+{_traceability_section(
+    "Use-Case To Analysis Traceability",
+    traceability.get("use_case_to_analysis", []),
+)}
+{_traceability_section(
+    "Analysis To Design Traceability",
+    traceability.get("analysis_to_design", []),
+)}
 
 ## Assumptions
 
@@ -263,6 +298,7 @@ def render_use_case_model(model: dict[str, Any]) -> str:
     use_case_block = "\n".join(use_case_sections) or "No use cases documented."
     process_view = model.get("process_view", {})
     architecture_view = model.get("architecture_view", {})
+    traceability = model.get("traceability", {})
 
     return f"""# Use-Case Model
 
@@ -287,6 +323,14 @@ def render_use_case_model(model: dict[str, Any]) -> str:
     "Interfaces and Integrations",
     architecture_view.get("interface_objects", []),
     architecture_view.get("interfaces_and_integrations", []),
+)}
+{_traceability_section(
+    "Requirement To Use-Case Traceability",
+    traceability.get("requirement_to_use_case", []),
+)}
+{_traceability_section(
+    "Use-Case To Analysis Traceability",
+    traceability.get("use_case_to_analysis", []),
 )}
 """
 

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -151,6 +151,46 @@ class RenderTests(unittest.TestCase):
             rendered,
         )
 
+    def test_requirements_render_includes_traceability_sections(self) -> None:
+        """Requirements rendering should surface cross-view traceability links when present."""
+        model = build_model()
+        model["traceability"] = {
+            "requirement_to_use_case": [
+                {
+                    "id": "trace-req-uc-1",
+                    "from_id": "functional-requirement-1",
+                    "to_id": "redeem-reward",
+                    "basis": "requirement statement references use-case name",
+                }
+            ],
+            "use_case_to_analysis": [
+                {
+                    "id": "trace-uc-analysis-1",
+                    "from_id": "redeem-reward",
+                    "to_id": "entity-reward",
+                    "basis": "use-case text references analysis object name",
+                }
+            ],
+            "analysis_to_design": [
+                {
+                    "id": "trace-analysis-design-1",
+                    "from_id": "entity-reward",
+                    "to_id": "component-rewards-api",
+                    "basis": "design component name references analysis object name",
+                }
+            ],
+        }
+
+        rendered = render_requirements_spec(model)
+
+        self.assertIn("## Requirement To Use-Case Traceability", rendered)
+        self.assertIn(
+            "`trace-req-uc-1` functional-requirement-1 -> redeem-reward",
+            rendered,
+        )
+        self.assertIn("## Use-Case To Analysis Traceability", rendered)
+        self.assertIn("## Analysis To Design Traceability", rendered)
+
     def test_use_case_render_includes_process_and_architecture_sections(self) -> None:
         """Use-case rendering should include relevant process and architecture sections when present."""
         from specops_tools.render import render_use_case_model
@@ -195,6 +235,39 @@ class RenderTests(unittest.TestCase):
         self.assertIn("## Interfaces and Integrations", rendered)
         self.assertIn(
             "`interface-1` Member app calls Rewards API. [source: round 7 interfaces_and_integrations]",
+            rendered,
+        )
+
+    def test_use_case_render_includes_traceability_sections(self) -> None:
+        """Use-case rendering should surface use-case traceability links when present."""
+        from specops_tools.render import render_use_case_model
+
+        model = build_model()
+        model["traceability"] = {
+            "requirement_to_use_case": [
+                {
+                    "id": "trace-req-uc-1",
+                    "from_id": "functional-requirement-1",
+                    "to_id": "redeem-reward",
+                    "basis": "requirement statement references use-case name",
+                }
+            ],
+            "use_case_to_analysis": [
+                {
+                    "id": "trace-uc-analysis-1",
+                    "from_id": "redeem-reward",
+                    "to_id": "entity-reward",
+                    "basis": "use-case text references analysis object name",
+                }
+            ],
+        }
+
+        rendered = render_use_case_model(model)
+
+        self.assertIn("## Requirement To Use-Case Traceability", rendered)
+        self.assertIn("## Use-Case To Analysis Traceability", rendered)
+        self.assertIn(
+            "`trace-uc-analysis-1` redeem-reward -> entity-reward",
             rendered,
         )
 


### PR DESCRIPTION
## Summary
- render the canonical cross-view traceability links in requirements and use-case artifacts
- surface requirement-to-use-case, use-case-to-analysis, and analysis-to-design links where relevant
- add render coverage for the new traceability sections

## Testing
- uv run python -m unittest tests.test_render
- uv run python -m unittest