### PR TITLE
feat: validate cross-view traceability

### DIFF
--- a/src/specops_tools/interview.py
+++ b/src/specops_tools/interview.py
@@ -6,7 +6,13 @@ from dataclasses import dataclass
 import json
 from typing import Any
 
-from .readiness import evaluate_readiness, evaluate_readiness_details, identify_stale_artifacts
+from .discovery import normalize_replay_to_model
+from .readiness import (
+    evaluate_readiness,
+    evaluate_readiness_details,
+    evaluate_traceability,
+    identify_stale_artifacts,
+)
 
 
 def _normalize_key(value: str) -> str:
@@ -691,7 +697,7 @@ def replay_session(round_inputs: list[dict[str, Any]]) -> dict[str, Any]:
         transcript.append(result)
         merged_answers[f"round_{result['round']['number']}"] = result["parsed_answers"]
 
-    return {
+    replay = {
         "transcript": transcript,
         "merged_answers": merged_answers,
         "last_round": transcript[-1]["round"]["number"] if transcript else None,
@@ -700,6 +706,9 @@ def replay_session(round_inputs: list[dict[str, Any]]) -> dict[str, Any]:
         "readiness_details": evaluate_readiness_details(normalized_round_inputs),
         "stale_artifacts": [],
     }
+    model = normalize_replay_to_model(replay)
+    replay["traceability_validation"] = evaluate_traceability(model)
+    return replay
 
 
 def replay_session_with_updates(

--- a/src/specops_tools/readiness.py
+++ b/src/specops_tools/readiness.py
@@ -1,4 +1,4 @@
-"""Readiness and staleness reporting for SpecOps interview state."""
+"""Readiness, staleness, and traceability reporting for SpecOps interview state."""
 
 from __future__ import annotations
 
@@ -111,3 +111,71 @@ def identify_stale_artifacts(updates: list[dict[str, Any]]) -> list[str]:
         if updated_keys & (set(gate["required"]) | set(gate["supporting"])):
             stale_artifacts.update(VIEW_ARTIFACTS[view_name])
     return sorted(stale_artifacts)
+
+
+def _linked_source_ids(links: list[dict[str, Any]]) -> set[str]:
+    """Return source ids participating in a trace link collection."""
+    return {
+        str(link.get("from_id"))
+        for link in links
+        if str(link.get("from_id", "")).strip()
+    }
+
+
+def _trace_family_result(
+    expected_from_ids: list[str],
+    links: list[dict[str, Any]],
+    family: str,
+) -> dict[str, Any]:
+    """Return validation details for one trace family."""
+    expected = [item for item in expected_from_ids if item]
+    linked = _linked_source_ids(links)
+    missing = [item for item in expected if item not in linked]
+
+    if not expected:
+        status = "blocked"
+    elif not missing:
+        status = "ready"
+    elif len(missing) == len(expected):
+        status = "blocked"
+    else:
+        status = "partial"
+
+    return {
+        "status": status,
+        "expected_from_ids": expected,
+        "linked_from_ids": sorted(linked),
+        "missing_from_ids": missing,
+        "link_count": len(links),
+        "family": family,
+    }
+
+
+def evaluate_traceability(model: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """Evaluate cross-view traceability coverage from the canonical model."""
+    traceability = model.get("traceability", {})
+    requirement_objects = model.get("requirements", {}).get("functional_objects", [])
+    use_cases = model.get("use_cases", [])
+    analysis_objects = (
+        model.get("logical_view", {}).get("domain_entity_objects", [])
+        + model.get("process_view", {}).get("state_entity_objects", [])
+    )
+    design_objects = model.get("architecture_view", {}).get("component_objects", [])
+
+    return {
+        "requirement_to_use_case": _trace_family_result(
+            [item.get("id", "") for item in requirement_objects],
+            traceability.get("requirement_to_use_case", []),
+            "requirement_to_use_case",
+        ),
+        "use_case_to_analysis": _trace_family_result(
+            [item.get("id", "") for item in use_cases] if analysis_objects else [],
+            traceability.get("use_case_to_analysis", []),
+            "use_case_to_analysis",
+        ),
+        "analysis_to_design": _trace_family_result(
+            [item.get("id", "") for item in analysis_objects] if design_objects else [],
+            traceability.get("analysis_to_design", []),
+            "analysis_to_design",
+        ),
+    }

--- a/tests/test_interview.py
+++ b/tests/test_interview.py
@@ -72,6 +72,7 @@ class InterviewHarnessTests(unittest.TestCase):
         self.assertEqual(replay["readiness"]["process"], "blocked")
         self.assertEqual(replay["readiness"]["architecture"], "blocked")
         self.assertEqual(replay["readiness_details"]["discovery"]["required_missing"], [])
+        self.assertEqual(replay["traceability_validation"]["requirement_to_use_case"]["status"], "blocked")
         self.assertEqual(replay["stale_artifacts"], [])
 
     def test_replay_session_accepts_individual_question_responses(self) -> None:
@@ -162,6 +163,7 @@ class InterviewHarnessTests(unittest.TestCase):
         self.assertEqual(len(replay["merged_round_inputs"]), 2)
         self.assertEqual(replay["readiness"]["discovery"], "ready")
         self.assertEqual(replay["readiness_details"]["discovery"]["status"], "ready")
+        self.assertEqual(replay["traceability_validation"]["requirement_to_use_case"]["status"], "blocked")
         self.assertEqual(replay["stale_artifacts"], ["requirements-spec.md"])
 
     def test_cli_accepts_piped_round_answer(self) -> None:
@@ -367,6 +369,7 @@ class InterviewHarnessTests(unittest.TestCase):
         self.assertEqual(payload["readiness"]["process"], "blocked")
         self.assertEqual(payload["readiness"]["architecture"], "blocked")
         self.assertIn("domain_entities", payload["readiness_details"]["logical"]["required_missing"])
+        self.assertEqual(payload["traceability_validation"]["requirement_to_use_case"]["status"], "blocked")
 
     def test_replay_cli_applies_updates_fixture(self) -> None:
         """The replay CLI should support targeted updates without replay restarts."""
@@ -440,6 +443,7 @@ class InterviewHarnessTests(unittest.TestCase):
         self.assertEqual(payload["next_round"]["number"], 3)
         self.assertEqual(payload["readiness"]["discovery"], "ready")
         self.assertEqual(payload["readiness_details"]["discovery"]["required_missing"], [])
+        self.assertEqual(payload["traceability_validation"]["requirement_to_use_case"]["status"], "blocked")
         self.assertEqual(payload["stale_artifacts"], ["requirements-spec.md"])
 
 

--- a/tests/test_readiness.py
+++ b/tests/test_readiness.py
@@ -7,6 +7,7 @@ import unittest
 from specops_tools.readiness import (
     evaluate_readiness,
     evaluate_readiness_details,
+    evaluate_traceability,
     identify_stale_artifacts,
 )
 
@@ -120,4 +121,47 @@ class ReadinessTests(unittest.TestCase):
         self.assertEqual(
             stale,
             ["requirements-spec.md", "ucp-estimate.md"],
+        )
+
+    def test_evaluate_traceability_reports_missing_links(self) -> None:
+        """Trace validation should identify missing links by family."""
+        model = {
+            "requirements": {
+                "functional_objects": [
+                    {"id": "functional-requirement-1"},
+                    {"id": "functional-requirement-2"},
+                ]
+            },
+            "use_cases": [
+                {"id": "approve-system"},
+                {"id": "search-systems"},
+            ],
+            "logical_view": {"domain_entity_objects": [{"id": "entity-system"}]},
+            "process_view": {"state_entity_objects": []},
+            "architecture_view": {"component_objects": [{"id": "component-system-api"}]},
+            "traceability": {
+                "requirement_to_use_case": [
+                    {"from_id": "functional-requirement-1", "to_id": "approve-system"}
+                ],
+                "use_case_to_analysis": [],
+                "analysis_to_design": [],
+            },
+        }
+
+        validation = evaluate_traceability(model)
+
+        self.assertEqual(validation["requirement_to_use_case"]["status"], "partial")
+        self.assertEqual(
+            validation["requirement_to_use_case"]["missing_from_ids"],
+            ["functional-requirement-2"],
+        )
+        self.assertEqual(validation["use_case_to_analysis"]["status"], "blocked")
+        self.assertEqual(
+            validation["use_case_to_analysis"]["missing_from_ids"],
+            ["approve-system", "search-systems"],
+        )
+        self.assertEqual(validation["analysis_to_design"]["status"], "blocked")
+        self.assertEqual(
+            validation["analysis_to_design"]["missing_from_ids"],
+            ["entity-system"],
         )


### PR DESCRIPTION
## Summary
- add explicit cross-view trace validation over the canonical traceability graph
- expose traceability_validation in replay output
- report missing source-side links for requirement-to-use-case, use-case-to-analysis, and analysis-to-design families
- extend readiness and interview tests for the new trace validation output

## Testing
- uv run python -m unittest tests.test_readiness tests.test_interview
- uv run python -m unittest