### PR TITLE
feat: separate analysis and design collections

### DIFF
--- a/skills/specops/references/specops-model.md
+++ b/skills/specops/references/specops-model.md
@@ -56,6 +56,15 @@ The canonical project model is `specops-model.yaml`.
     - `fit_criterion`
     - `trace`
 - `analysis_view`
+  - `actors`
+  - `use_cases`
+  - `requirement_objects`
+  - `domain_entity_objects`
+  - `relationship_objects`
+  - `business_rule_objects`
+  - `state_entity_objects`
+  - `state_transition_objects`
+  - `trigger_objects`
   - `actor_ids`
   - `use_case_ids`
   - `requirement_ids`
@@ -145,6 +154,9 @@ The canonical project model is `specops-model.yaml`.
     - `approval_required`
     - `trace`
 - `design_view`
+  - `component_objects`
+  - `interface_objects`
+  - `runtime_boundary_objects`
   - `component_ids`
   - `interface_ids`
   - `runtime_boundary_ids`

--- a/src/specops_tools/discovery.py
+++ b/src/specops_tools/discovery.py
@@ -792,6 +792,15 @@ def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
         "requirement_ids": [
             item["id"] for item in functional_requirement_objects + non_functional_requirement_objects
         ],
+        "actors": normalized_actors,
+        "use_cases": normalized_use_cases,
+        "requirement_objects": functional_requirement_objects + non_functional_requirement_objects,
+        "domain_entity_objects": domain_entity_objects,
+        "relationship_objects": relationship_objects,
+        "business_rule_objects": business_rule_objects,
+        "state_entity_objects": state_entity_objects,
+        "state_transition_objects": state_transition_objects,
+        "trigger_objects": trigger_objects,
         "domain_entity_ids": [item["id"] for item in domain_entity_objects],
         "relationship_ids": [item["id"] for item in relationship_objects],
         "business_rule_ids": [item["id"] for item in business_rule_objects],
@@ -800,6 +809,9 @@ def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
         "trigger_ids": [item["id"] for item in trigger_objects],
     }
     design_view = {
+        "component_objects": component_objects,
+        "interface_objects": interface_objects,
+        "runtime_boundary_objects": runtime_boundary_objects,
         "component_ids": [item["id"] for item in component_objects],
         "interface_ids": [item["id"] for item in interface_objects],
         "runtime_boundary_ids": [item["id"] for item in runtime_boundary_objects],

--- a/src/specops_tools/render.py
+++ b/src/specops_tools/render.py
@@ -147,10 +147,27 @@ def render_requirements_spec(model: dict[str, Any]) -> str:
     """
     project = model.get("project", {})
     requirements = model.get("requirements", {})
+    analysis_view = model.get("analysis_view", {})
+    design_view = model.get("design_view", {})
     logical_view = model.get("logical_view", {})
     process_view = model.get("process_view", {})
     architecture_view = model.get("architecture_view", {})
     traceability = model.get("traceability", {})
+    domain_entity_objects = analysis_view.get("domain_entity_objects", logical_view.get("domain_entity_objects", []))
+    relationship_objects = analysis_view.get("relationship_objects", logical_view.get("relationship_objects", []))
+    business_rule_objects = analysis_view.get("business_rule_objects", logical_view.get("business_rule_objects", []))
+    state_entity_objects = analysis_view.get("state_entity_objects", process_view.get("state_entity_objects", []))
+    state_transition_objects = analysis_view.get(
+        "state_transition_objects",
+        process_view.get("state_transition_objects", []),
+    )
+    trigger_objects = analysis_view.get("trigger_objects", process_view.get("trigger_objects", []))
+    component_objects = design_view.get("component_objects", architecture_view.get("component_objects", []))
+    interface_objects = design_view.get("interface_objects", architecture_view.get("interface_objects", []))
+    runtime_boundary_objects = design_view.get(
+        "runtime_boundary_objects",
+        architecture_view.get("runtime_boundary_objects", []),
+    )
     return f"""# Requirements Specification
 
 ## Project
@@ -180,47 +197,47 @@ def render_requirements_spec(model: dict[str, Any]) -> str:
 {_bullet_list(requirements.get("non_functional", []))}
 {_object_name_section(
     "Logical View",
-    logical_view.get("domain_entity_objects", []),
+    domain_entity_objects,
     logical_view.get("domain_entities", []),
 )}
 {_object_text_section(
     "Relationships",
-    logical_view.get("relationship_objects", []),
+    relationship_objects,
     logical_view.get("relationships", []),
 )}
 {_object_text_section(
     "Business Rules",
-    logical_view.get("business_rule_objects", []),
+    business_rule_objects,
     logical_view.get("business_rules", []),
 )}
 {_object_name_section(
     "Process View",
-    process_view.get("state_entity_objects", []),
+    state_entity_objects,
     process_view.get("state_entities", []),
 )}
 {_object_text_section(
     "States and Transitions",
-    process_view.get("state_transition_objects", []),
+    state_transition_objects,
     process_view.get("states_and_transitions", []),
 )}
 {_object_text_section(
     "Triggers and Approvals",
-    process_view.get("trigger_objects", []),
+    trigger_objects,
     process_view.get("triggers_and_approvals", []),
 )}
 {_object_name_section(
     "Architecture View",
-    architecture_view.get("component_objects", []),
+    component_objects,
     architecture_view.get("components_and_services", []),
 )}
 {_object_text_section(
     "Interfaces and Integrations",
-    architecture_view.get("interface_objects", []),
+    interface_objects,
     architecture_view.get("interfaces_and_integrations", []),
 )}
 {_object_text_section(
     "Runtime Boundaries",
-    architecture_view.get("runtime_boundary_objects", []),
+    runtime_boundary_objects,
     architecture_view.get("runtime_boundaries", []),
 )}
 {_traceability_section(
@@ -255,8 +272,12 @@ def render_use_case_model(model: dict[str, Any]) -> str:
     Returns:
         Markdown content.
     """
+    analysis_view = model.get("analysis_view", {})
+    design_view = model.get("design_view", {})
+    actors = analysis_view.get("actors", model.get("actors", []))
+    use_cases = analysis_view.get("use_cases", model.get("use_cases", []))
     actor_lines = []
-    for actor in model.get("actors", []):
+    for actor in actors:
         line = (
             f"- `{actor.get('id', 'actor')}` {actor.get('name', 'Unnamed')} "
             f"({actor.get('type', 'unspecified')}, {actor.get('complexity', 'unclassified')}): "
@@ -270,7 +291,7 @@ def render_use_case_model(model: dict[str, Any]) -> str:
         actor_lines.append(line)
 
     use_case_sections = []
-    for use_case in model.get("use_cases", []):
+    for use_case in use_cases:
         main_flow = "\n".join(
             f"{index}. {step}" for index, step in enumerate(use_case.get("main_success_scenario", []), 1)
         ) or "1. No main success scenario documented."
@@ -299,6 +320,12 @@ def render_use_case_model(model: dict[str, Any]) -> str:
     process_view = model.get("process_view", {})
     architecture_view = model.get("architecture_view", {})
     traceability = model.get("traceability", {})
+    state_transition_objects = analysis_view.get(
+        "state_transition_objects",
+        process_view.get("state_transition_objects", []),
+    )
+    trigger_objects = analysis_view.get("trigger_objects", process_view.get("trigger_objects", []))
+    interface_objects = design_view.get("interface_objects", architecture_view.get("interface_objects", []))
 
     return f"""# Use-Case Model
 
@@ -311,17 +338,17 @@ def render_use_case_model(model: dict[str, Any]) -> str:
 {use_case_block}
 {_object_text_section(
     "States and Transitions",
-    process_view.get("state_transition_objects", []),
+    state_transition_objects,
     process_view.get("states_and_transitions", []),
 )}
 {_object_text_section(
     "Triggers and Approvals",
-    process_view.get("trigger_objects", []),
+    trigger_objects,
     process_view.get("triggers_and_approvals", []),
 )}
 {_object_text_section(
     "Interfaces and Integrations",
-    architecture_view.get("interface_objects", []),
+    interface_objects,
     architecture_view.get("interfaces_and_integrations", []),
 )}
 {_traceability_section(

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -100,6 +100,10 @@ class DiscoveryTests(unittest.TestCase):
             model["analysis_view"]["requirement_ids"][0],
             model["requirements"]["functional_objects"][0]["id"],
         )
+        self.assertEqual(
+            model["analysis_view"]["domain_entity_objects"][0]["id"],
+            "entity-system",
+        )
         self.assertEqual(model["actors"], [])
         self.assertEqual(model["use_cases"], [])
         self.assertIn("System", model["logical_view"]["domain_entities"])
@@ -167,6 +171,10 @@ class DiscoveryTests(unittest.TestCase):
         self.assertEqual(
             model["design_view"]["component_ids"][0],
             model["architecture_view"]["component_objects"][0]["id"],
+        )
+        self.assertEqual(
+            model["design_view"]["component_objects"][0]["id"],
+            "component-web-app",
         )
         self.assertEqual(
             model["architecture_view"]["interface_objects"][0]["source_component_id"],
@@ -249,6 +257,8 @@ class DiscoveryTests(unittest.TestCase):
         self.assertEqual(model["use_cases"][1]["complexity"], "unclassified")
         self.assertEqual(model["analysis_view"]["actor_ids"][0], "operations-manager")
         self.assertEqual(model["analysis_view"]["use_case_ids"][0], "browse-rewards")
+        self.assertEqual(model["analysis_view"]["actors"][0]["id"], "operations-manager")
+        self.assertEqual(model["analysis_view"]["use_cases"][0]["id"], "browse-rewards")
 
     def test_normalize_replay_to_model_applies_ucp_answers_to_objects(self) -> None:
         """UCP round answers should update normalized actor/use-case complexity and factors."""

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -151,6 +151,62 @@ class RenderTests(unittest.TestCase):
             rendered,
         )
 
+    def test_render_prefers_layer_collections_when_present(self) -> None:
+        """Rendering should remain coherent when analysis/design objects live under layer sections."""
+        from specops_tools.render import render_use_case_model
+
+        model = build_model()
+        model["actors"] = []
+        model["use_cases"] = []
+        model["analysis_view"] = {
+            "actors": [
+                {
+                    "id": "member",
+                    "name": "Member",
+                    "type": "human",
+                    "complexity": "average",
+                    "description": "",
+                    "trace": {"source_round": 3, "source_key": "actors"},
+                }
+            ],
+            "use_cases": [
+                {
+                    "id": "redeem-reward",
+                    "name": "Redeem Reward",
+                    "primary_actor": "Member",
+                    "goal": "Redeem Reward",
+                    "complexity": "average",
+                    "main_success_scenario": [],
+                    "extensions": [],
+                    "trace": {"source_round": 3, "source_key": "use_cases"},
+                }
+            ],
+            "state_transition_objects": [
+                {
+                    "id": "state-transition-1",
+                    "text": "Requested -> Approved",
+                    "trace": {"source_round": 6, "source_key": "states_and_transitions"},
+                }
+            ],
+            "trigger_objects": [],
+        }
+        model["design_view"] = {
+            "interface_objects": [
+                {
+                    "id": "interface-1",
+                    "text": "App calls API",
+                    "trace": {"source_round": 7, "source_key": "interfaces_and_integrations"},
+                }
+            ]
+        }
+
+        rendered = render_use_case_model(model)
+
+        self.assertIn("`member` Member", rendered)
+        self.assertIn("### Redeem Reward", rendered)
+        self.assertIn("`state-transition-1` Requested -> Approved", rendered)
+        self.assertIn("`interface-1` App calls API", rendered)
+
     def test_requirements_render_includes_traceability_sections(self) -> None:
         """Requirements rendering should surface cross-view traceability links when present."""
         model = build_model()


### PR DESCRIPTION
## Summary
- move analysis-layer objects into first-class analysis_view collections
- move design-layer objects into first-class design_view collections
- update renderers to prefer the layer-owned collections while keeping compatibility fallbacks
- document and test the new layer-owned structure

## Testing
- uv run python -m unittest tests.test_discovery tests.test_render
- uv run python -m unittest