### PR TITLE
#49 Make analysis and design views canonical

### DIFF
--- a/skills/specops/references/specops-model.md
+++ b/skills/specops/references/specops-model.md
@@ -11,7 +11,7 @@ The canonical project model is `specops-model.yaml`.
   - `system_scope`
 - `business_goals`
 - `success_criteria`
-- `actors`
+- `actors` (compatibility mirror derived from `analysis_view.actors`)
   - `id`
   - `name`
   - `type`
@@ -20,7 +20,7 @@ The canonical project model is `specops-model.yaml`.
   - `interaction_style`
   - `responsibilities`
   - `complexity`: `simple`, `average`, or `complex`
-- `use_cases`
+- `use_cases` (compatibility mirror derived from `analysis_view.use_cases`)
   - `id`
   - `name`
   - `primary_actor`
@@ -55,7 +55,7 @@ The canonical project model is `specops-model.yaml`.
     - `linked_use_case_ids`
     - `fit_criterion`
     - `trace`
-- `analysis_view`
+- `analysis_view` (authoritative source for analysis-layer objects)
   - `actors`
   - `use_cases`
   - `requirement_objects`
@@ -93,7 +93,7 @@ The canonical project model is `specops-model.yaml`.
     - `to_id`
     - `link_type`
     - `basis`
-- `logical_view` (optional in V1, expected for V1.5+ full-spec work)
+- `logical_view` (derived compatibility view from `analysis_view` for V1/V1.5 renderers)
   - `domain_entities`
   - `domain_entity_objects`
     - `id`
@@ -123,7 +123,7 @@ The canonical project model is `specops-model.yaml`.
     - `model_layer`: `analysis`
     - `scope`
     - `trace`
-- `process_view` (optional in V1, expected for V1.5+ full-spec work)
+- `process_view` (derived compatibility view from `analysis_view` for V1/V1.5 renderers)
   - `state_entities`
   - `state_entity_objects`
     - `id`
@@ -153,14 +153,14 @@ The canonical project model is `specops-model.yaml`.
     - `model_layer`: `analysis`
     - `approval_required`
     - `trace`
-- `design_view`
+- `design_view` (authoritative source for design-layer objects)
   - `component_objects`
   - `interface_objects`
   - `runtime_boundary_objects`
   - `component_ids`
   - `interface_ids`
   - `runtime_boundary_ids`
-- `architecture_view` (optional in V1, expected for V1.5+ full-spec work)
+- `architecture_view` (derived compatibility view from `design_view` for V1/V1.5 renderers)
   - `components_and_services`
   - `component_objects`
     - `id`
@@ -230,3 +230,8 @@ For V1.5+ work, the same model should also have stable places to hold:
 - architecture/deployment-view discovery
 
 If any artifact would require invented inputs, stop and surface the missing fields.
+
+For V1.6 hardening, `analysis_view` and `design_view` are the source of truth. The older top-level
+and per-view object collections remain in the contract as compatibility mirrors for existing
+renderers and fixtures, but they should be derived from the layer-owned collections rather than
+maintained independently.

--- a/src/specops_tools/discovery.py
+++ b/src/specops_tools/discovery.py
@@ -649,6 +649,63 @@ def _text_or_empty(value: Any) -> str:
     return str(value).strip()
 
 
+def _requirement_statements_by_kind(
+    requirement_objects: list[dict[str, Any]],
+    requirement_kind: str,
+) -> list[str]:
+    """Derive legacy requirement statement lists from canonical requirement objects."""
+    return [
+        item["statement"]
+        for item in requirement_objects
+        if item.get("requirement_kind") == requirement_kind and item.get("statement")
+    ]
+
+
+def _derive_logical_view(analysis_view: dict[str, Any]) -> dict[str, Any]:
+    """Build the legacy logical view mirror from analysis-layer source data."""
+    domain_entity_objects = analysis_view["domain_entity_objects"]
+    relationship_objects = analysis_view["relationship_objects"]
+    business_rule_objects = analysis_view["business_rule_objects"]
+    return {
+        "domain_entities": [item["name"] for item in domain_entity_objects],
+        "domain_entity_objects": domain_entity_objects,
+        "relationships": [item["description"] for item in relationship_objects],
+        "relationship_objects": relationship_objects,
+        "business_rules": [item["rule_text"] for item in business_rule_objects],
+        "business_rule_objects": business_rule_objects,
+    }
+
+
+def _derive_process_view(analysis_view: dict[str, Any]) -> dict[str, Any]:
+    """Build the legacy process view mirror from analysis-layer source data."""
+    state_entity_objects = analysis_view["state_entity_objects"]
+    state_transition_objects = analysis_view["state_transition_objects"]
+    trigger_objects = analysis_view["trigger_objects"]
+    return {
+        "state_entities": [item["name"] for item in state_entity_objects],
+        "state_entity_objects": state_entity_objects,
+        "states_and_transitions": [item["description"] for item in state_transition_objects],
+        "state_transition_objects": state_transition_objects,
+        "triggers_and_approvals": [item["description"] for item in trigger_objects],
+        "trigger_objects": trigger_objects,
+    }
+
+
+def _derive_architecture_view(design_view: dict[str, Any]) -> dict[str, Any]:
+    """Build the legacy architecture view mirror from design-layer source data."""
+    component_objects = design_view["component_objects"]
+    interface_objects = design_view["interface_objects"]
+    runtime_boundary_objects = design_view["runtime_boundary_objects"]
+    return {
+        "components_and_services": [item["name"] for item in component_objects],
+        "component_objects": component_objects,
+        "interfaces_and_integrations": [item["description"] for item in interface_objects],
+        "interface_objects": interface_objects,
+        "runtime_boundaries": [item["description"] for item in runtime_boundary_objects],
+        "runtime_boundary_objects": runtime_boundary_objects,
+    }
+
+
 def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
     """Normalize replay output into a canonical SpecOps model shape.
 
@@ -673,31 +730,13 @@ def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
     round_9 = merged_answers.get("round_9", {})
     round_10 = merged_answers.get("round_10", {})
     round_11 = merged_answers.get("round_11", {})
-    actors = _ensure_list(round_3.get("actors"))
-    use_cases = _ensure_list(round_3.get("use_cases"))
-
-    functional_requirements = []
-    if workflow_scope := _text_or_empty(round_4.get("workflow_scope")):
-        functional_requirements.append(workflow_scope)
-    if integrations := _text_or_empty(round_3.get("integrations")):
-        functional_requirements.append(integrations)
-
     constraints = _ensure_list(round_2.get("constraints"))
-    non_functional = _ensure_list(round_4.get("non_functional_requirements"))
-    if constraints:
-        non_functional = constraints + non_functional
-
-    domain_entities = _ensure_list(round_5.get("domain_entities"))
-    relationships = _ensure_list(round_5.get("relationships"))
-    business_rules = _ensure_list(round_5.get("business_rules"))
-    state_entities = _ensure_list(round_6.get("state_entities"))
-    states_and_transitions = _ensure_list(round_6.get("states_and_transitions"))
-    triggers_and_approvals = _ensure_list(round_6.get("triggers_and_approvals"))
-    components_and_services = _ensure_list(round_7.get("components_and_services"))
-    interfaces_and_integrations = _ensure_list(round_7.get("interfaces_and_integrations"))
-    runtime_boundaries = _ensure_list(round_7.get("runtime_boundaries"))
-    normalized_actors = _with_trace(_normalize_actors(actors), 3, "actors")
-    normalized_use_cases = _with_trace(_normalize_use_cases(use_cases), 3, "use_cases")
+    normalized_actors = _with_trace(_normalize_actors(_ensure_list(round_3.get("actors"))), 3, "actors")
+    normalized_use_cases = _with_trace(
+        _normalize_use_cases(_ensure_list(round_3.get("use_cases"))),
+        3,
+        "use_cases",
+    )
     _apply_complexity_answers_with_trace(
         normalized_actors,
         _ensure_list(round_8.get("actor_complexity")),
@@ -749,52 +788,59 @@ def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
             )
         )
 
-    domain_entity_objects = _with_trace(_normalize_domain_entities(domain_entities), 5, "domain_entities")
+    domain_entity_objects = _with_trace(
+        _normalize_domain_entities(_ensure_list(round_5.get("domain_entities"))),
+        5,
+        "domain_entities",
+    )
     relationship_objects = _with_trace(
-        _normalize_relationships(relationships, domain_entity_objects),
+        _normalize_relationships(_ensure_list(round_5.get("relationships")), domain_entity_objects),
         5,
         "relationships",
     )
     business_rule_objects = _with_trace(
-        _normalize_business_rules(business_rules),
+        _normalize_business_rules(_ensure_list(round_5.get("business_rules"))),
         5,
         "business_rules",
     )
-    state_entity_objects = _with_trace(_normalize_state_entities(state_entities), 6, "state_entities")
+    state_entity_objects = _with_trace(
+        _normalize_state_entities(_ensure_list(round_6.get("state_entities"))),
+        6,
+        "state_entities",
+    )
     state_transition_objects = _with_trace(
-        _normalize_state_transitions(states_and_transitions),
+        _normalize_state_transitions(_ensure_list(round_6.get("states_and_transitions"))),
         6,
         "states_and_transitions",
     )
     trigger_objects = _with_trace(
-        _normalize_triggers(triggers_and_approvals),
+        _normalize_triggers(_ensure_list(round_6.get("triggers_and_approvals"))),
         6,
         "triggers_and_approvals",
     )
     component_objects = _with_trace(
-        _normalize_components(components_and_services),
+        _normalize_components(_ensure_list(round_7.get("components_and_services"))),
         7,
         "components_and_services",
     )
     interface_objects = _with_trace(
-        _normalize_interfaces(interfaces_and_integrations, component_objects),
+        _normalize_interfaces(_ensure_list(round_7.get("interfaces_and_integrations")), component_objects),
         7,
         "interfaces_and_integrations",
     )
     runtime_boundary_objects = _with_trace(
-        _normalize_runtime_boundaries(runtime_boundaries),
+        _normalize_runtime_boundaries(_ensure_list(round_7.get("runtime_boundaries"))),
         7,
         "runtime_boundaries",
     )
+    all_requirement_objects = functional_requirement_objects + non_functional_requirement_objects
     analysis_view = {
         "actor_ids": [item["id"] for item in normalized_actors],
         "use_case_ids": [item["id"] for item in normalized_use_cases],
-        "requirement_ids": [
-            item["id"] for item in functional_requirement_objects + non_functional_requirement_objects
-        ],
+        "requirement_ids": [item["id"] for item in all_requirement_objects],
         "actors": normalized_actors,
         "use_cases": normalized_use_cases,
-        "requirement_objects": functional_requirement_objects + non_functional_requirement_objects,
+        "requirement_objects": all_requirement_objects,
         "domain_entity_objects": domain_entity_objects,
         "relationship_objects": relationship_objects,
         "business_rule_objects": business_rule_objects,
@@ -816,7 +862,6 @@ def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
         "interface_ids": [item["id"] for item in interface_objects],
         "runtime_boundary_ids": [item["id"] for item in runtime_boundary_objects],
     }
-    all_requirement_objects = functional_requirement_objects + non_functional_requirement_objects
     traceability = _build_trace_links(
         all_requirement_objects,
         normalized_use_cases,
@@ -824,6 +869,9 @@ def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
         state_entity_objects,
         component_objects,
     )
+    logical_view = _derive_logical_view(analysis_view)
+    process_view = _derive_process_view(analysis_view)
+    architecture_view = _derive_architecture_view(design_view)
 
     return {
         "project": {
@@ -837,37 +885,16 @@ def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
         "actors": normalized_actors,
         "use_cases": normalized_use_cases,
         "requirements": {
-            "functional": functional_requirements,
+            "functional": _requirement_statements_by_kind(all_requirement_objects, "functional"),
             "functional_objects": functional_requirement_objects,
-            "non_functional": non_functional,
+            "non_functional": _requirement_statements_by_kind(all_requirement_objects, "non_functional"),
             "non_functional_objects": non_functional_requirement_objects,
         },
         "analysis_view": analysis_view,
         "traceability": traceability,
-        "logical_view": {
-            "domain_entities": domain_entities,
-            "domain_entity_objects": domain_entity_objects,
-            "relationships": relationships,
-            "relationship_objects": relationship_objects,
-            "business_rules": business_rules,
-            "business_rule_objects": business_rule_objects,
-        },
-        "process_view": {
-            "state_entities": state_entities,
-            "state_entity_objects": state_entity_objects,
-            "states_and_transitions": states_and_transitions,
-            "state_transition_objects": state_transition_objects,
-            "triggers_and_approvals": triggers_and_approvals,
-            "trigger_objects": trigger_objects,
-        },
-        "architecture_view": {
-            "components_and_services": components_and_services,
-            "component_objects": component_objects,
-            "interfaces_and_integrations": interfaces_and_integrations,
-            "interface_objects": interface_objects,
-            "runtime_boundaries": runtime_boundaries,
-            "runtime_boundary_objects": runtime_boundary_objects,
-        },
+        "logical_view": logical_view,
+        "process_view": process_view,
+        "architecture_view": architecture_view,
         "design_view": design_view,
         "metadata_fields": _ensure_list(round_4.get("metadata_fields")),
         "assumptions": [],

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -101,6 +101,10 @@ class DiscoveryTests(unittest.TestCase):
             model["requirements"]["functional_objects"][0]["id"],
         )
         self.assertEqual(
+            model["analysis_view"]["requirement_objects"][0]["id"],
+            model["requirements"]["functional_objects"][0]["id"],
+        )
+        self.assertEqual(
             model["analysis_view"]["domain_entity_objects"][0]["id"],
             "entity-system",
         )
@@ -188,6 +192,18 @@ class DiscoveryTests(unittest.TestCase):
             model["architecture_view"]["runtime_boundary_objects"][0]["boundary_type"],
             "runtime_separation",
         )
+        self.assertEqual(
+            model["logical_view"]["domain_entity_objects"],
+            model["analysis_view"]["domain_entity_objects"],
+        )
+        self.assertEqual(
+            model["process_view"]["state_entity_objects"],
+            model["analysis_view"]["state_entity_objects"],
+        )
+        self.assertEqual(
+            model["architecture_view"]["component_objects"],
+            model["design_view"]["component_objects"],
+        )
 
     def test_normalize_replay_to_model_keeps_empty_sections_explicit(self) -> None:
         """Missing optional view rounds should still produce stable empty sections."""
@@ -259,6 +275,8 @@ class DiscoveryTests(unittest.TestCase):
         self.assertEqual(model["analysis_view"]["use_case_ids"][0], "browse-rewards")
         self.assertEqual(model["analysis_view"]["actors"][0]["id"], "operations-manager")
         self.assertEqual(model["analysis_view"]["use_cases"][0]["id"], "browse-rewards")
+        self.assertEqual(model["actors"], model["analysis_view"]["actors"])
+        self.assertEqual(model["use_cases"], model["analysis_view"]["use_cases"])
 
     def test_normalize_replay_to_model_applies_ucp_answers_to_objects(self) -> None:
         """UCP round answers should update normalized actor/use-case complexity and factors."""
@@ -407,12 +425,24 @@ class DiscoveryTests(unittest.TestCase):
         self.assertEqual(functional_object["model_layer"], "analysis")
         self.assertEqual(functional_object["linked_use_case_ids"], [])
         self.assertEqual(functional_object["fit_criterion"], "")
+        self.assertEqual(
+            model["requirements"]["functional"],
+            [item["statement"] for item in model["analysis_view"]["requirement_objects"][:1]],
+        )
 
         non_functional_object = model["requirements"]["non_functional_objects"][0]
         self.assertEqual(non_functional_object["statement"], "Security: SSO required")
         self.assertEqual(non_functional_object["quality_attribute"], "Security")
         self.assertEqual(non_functional_object["requirement_kind"], "non_functional")
         self.assertEqual(non_functional_object["model_layer"], "analysis")
+        self.assertEqual(
+            model["requirements"]["non_functional"],
+            [
+                item["statement"]
+                for item in model["analysis_view"]["requirement_objects"]
+                if item["requirement_kind"] == "non_functional"
+            ],
+        )
 
     def test_normalize_replay_to_model_builds_cross_view_trace_links(self) -> None:
         """Normalization should create deterministic cross-view links when names match explicitly."""


### PR DESCRIPTION
## Summary
- make `analysis_view` and `design_view` the authoritative object collections
- derive legacy top-level and per-view compatibility mirrors from those layer-owned collections
- document the source-of-truth rule and add discovery coverage for the mirror behavior

Closes #49