### PR TITLE
#48 Prove state-model artifact pipeline

### DIFF
--- a/skills/specops/references/specops-model.md
+++ b/skills/specops/references/specops-model.md
@@ -221,6 +221,7 @@ The model should be rich enough to generate:
 
 - `requirements-spec.md`
 - `use-case-model.md`
+- `state-model.md`
 - `ucp-estimate.md`
 
 For V1.5+ work, the same model should also have stable places to hold:
@@ -228,6 +229,15 @@ For V1.5+ work, the same model should also have stable places to hold:
 - logical-view discovery
 - process/state-view discovery
 - architecture/deployment-view discovery
+
+For the V1.6 proof artifact, `state-model.md` is generated from the canonical process semantics:
+
+- `analysis_view.state_entity_objects`
+- `analysis_view.state_transition_objects`
+- `analysis_view.trigger_objects`
+- relevant `traceability.use_case_to_analysis` links for state entities
+- relevant `traceability.analysis_to_design` links where a stateful analysis object is realized by a
+  design component
 
 If any artifact would require invented inputs, stop and surface the missing fields.
 

--- a/src/specops_tools/readiness.py
+++ b/src/specops_tools/readiness.py
@@ -36,7 +36,7 @@ VIEW_ARTIFACTS = {
     "discovery": ["requirements-spec.md"],
     "use_case": ["requirements-spec.md", "use-case-model.md"],
     "logical": ["requirements-spec.md"],
-    "process": ["requirements-spec.md", "use-case-model.md"],
+    "process": ["requirements-spec.md", "use-case-model.md", "state-model.md"],
     "architecture": ["requirements-spec.md", "use-case-model.md"],
     "ucp": ["ucp-estimate.md"],
 }

--- a/src/specops_tools/render.py
+++ b/src/specops_tools/render.py
@@ -98,7 +98,8 @@ def _object_text_section(
     if items:
         rendered_lines = []
         for item in items:
-            line = f"- `{item.get('id', 'item')}` {item.get('text', '')}"
+            text = item.get("text") or item.get("description") or item.get("rule_text") or ""
+            line = f"- `{item.get('id', 'item')}` {text}"
             if trace := item.get("trace"):
                 line = (
                     f"{line} [source: round {trace.get('source_round')} "
@@ -134,6 +135,18 @@ def _traceability_section(
 
 {"\n".join(rendered)}
 """
+
+
+def _filter_trace_links(
+    links: list[dict[str, Any]],
+    relevant_ids: set[str],
+) -> list[dict[str, Any]]:
+    """Keep only trace links that reference the relevant ids."""
+    return [
+        link
+        for link in links
+        if link.get("from_id") in relevant_ids or link.get("to_id") in relevant_ids
+    ]
 
 
 def render_requirements_spec(model: dict[str, Any]) -> str:
@@ -362,6 +375,75 @@ def render_use_case_model(model: dict[str, Any]) -> str:
 """
 
 
+def render_state_model(model: dict[str, Any]) -> str:
+    """Render the formal state-model artifact.
+
+    Args:
+        model: Canonical SpecOps model.
+
+    Returns:
+        Markdown content.
+    """
+    project = model.get("project", {})
+    analysis_view = model.get("analysis_view", {})
+    process_view = model.get("process_view", {})
+    design_view = model.get("design_view", {})
+    traceability = model.get("traceability", {})
+    state_entity_objects = analysis_view.get(
+        "state_entity_objects",
+        process_view.get("state_entity_objects", []),
+    )
+    state_transition_objects = analysis_view.get(
+        "state_transition_objects",
+        process_view.get("state_transition_objects", []),
+    )
+    trigger_objects = analysis_view.get(
+        "trigger_objects",
+        process_view.get("trigger_objects", []),
+    )
+    component_objects = design_view.get("component_objects", [])
+    state_entity_ids = {item.get("id", "") for item in state_entity_objects if item.get("id")}
+    component_ids = {item.get("id", "") for item in component_objects if item.get("id")}
+
+    return f"""# State Model
+
+## Project
+
+- Name: {project.get("name", "Unnamed Project")}
+- Domain: {project.get("domain", "Unspecified")}
+
+## Scope
+
+{project.get("system_scope", "Unspecified")}
+{_object_name_section(
+    "State Entities",
+    state_entity_objects,
+    process_view.get("state_entities", []),
+)}
+{_object_text_section(
+    "State Transitions",
+    state_transition_objects,
+    process_view.get("states_and_transitions", []),
+)}
+{_object_text_section(
+    "Triggers and Approvals",
+    trigger_objects,
+    process_view.get("triggers_and_approvals", []),
+)}
+{_traceability_section(
+    "Use-Case To State Traceability",
+    _filter_trace_links(traceability.get("use_case_to_analysis", []), state_entity_ids),
+)}
+{_traceability_section(
+    "State To Design Traceability",
+    _filter_trace_links(
+        traceability.get("analysis_to_design", []),
+        state_entity_ids | component_ids,
+    ),
+)}
+"""
+
+
 def render_all(model: dict[str, Any]) -> dict[str, str]:
     """Render all primary artifacts for a model.
 
@@ -375,5 +457,6 @@ def render_all(model: dict[str, Any]) -> dict[str, str]:
     return {
         "requirements-spec.md": render_requirements_spec(model),
         "use-case-model.md": render_use_case_model(model),
+        "state-model.md": render_state_model(model),
         "ucp-estimate.md": render_ucp_markdown(model, ucp_results),
     }

--- a/tests/test_readiness.py
+++ b/tests/test_readiness.py
@@ -123,6 +123,27 @@ class ReadinessTests(unittest.TestCase):
             ["requirements-spec.md", "ucp-estimate.md"],
         )
 
+    def test_identify_stale_artifacts_marks_state_model_for_process_updates(self) -> None:
+        """Process-view updates should mark the formal state-model artifact stale."""
+        stale = identify_stale_artifacts(
+            [
+                {
+                    "round": 6,
+                    "responses": [
+                        {
+                            "key": "states_and_transitions",
+                            "answer": "Draft -> Submitted -> Approved",
+                        }
+                    ],
+                }
+            ]
+        )
+
+        self.assertEqual(
+            stale,
+            ["requirements-spec.md", "state-model.md", "use-case-model.md"],
+        )
+
     def test_evaluate_traceability_reports_missing_links(self) -> None:
         """Trace validation should identify missing links by family."""
         model = {

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import unittest
 
-from specops_tools.render import render_requirements_spec
+from specops_tools.discovery import normalize_replay_to_model
+from specops_tools.interview import replay_session
+from specops_tools.render import render_all, render_requirements_spec, render_state_model
 from specops_tools.ucp import calculate_ucp, render_ucp_markdown
 
 try:
@@ -326,6 +328,141 @@ class RenderTests(unittest.TestCase):
             "`trace-uc-analysis-1` redeem-reward -> entity-reward",
             rendered,
         )
+
+    def test_state_model_render_includes_process_traceability(self) -> None:
+        """State-model rendering should surface process semantics and relevant trace links."""
+        model = build_model()
+        model["analysis_view"] = {
+            "state_entity_objects": [
+                {
+                    "id": "state-entity-redemption-request",
+                    "name": "Redemption Request",
+                    "trace": {"source_round": 6, "source_key": "state_entities"},
+                }
+            ],
+            "state_transition_objects": [
+                {
+                    "id": "state-transition-1",
+                    "text": "Requested -> Approved -> Fulfilled",
+                    "trace": {"source_round": 6, "source_key": "states_and_transitions"},
+                }
+            ],
+            "trigger_objects": [
+                {
+                    "id": "trigger-1",
+                    "text": "Approval event moves request to Approved.",
+                    "trace": {"source_round": 6, "source_key": "triggers_and_approvals"},
+                }
+            ],
+        }
+        model["design_view"] = {
+            "component_objects": [
+                {
+                    "id": "component-rewards-api",
+                    "name": "Rewards API",
+                    "trace": {"source_round": 7, "source_key": "components_and_services"},
+                }
+            ]
+        }
+        model["traceability"] = {
+            "use_case_to_analysis": [
+                {
+                    "id": "trace-uc-analysis-1",
+                    "from_id": "uc-redeem",
+                    "to_id": "state-entity-redemption-request",
+                    "basis": "use-case text references analysis object name",
+                }
+            ],
+            "analysis_to_design": [
+                {
+                    "id": "trace-analysis-design-1",
+                    "from_id": "state-entity-redemption-request",
+                    "to_id": "component-rewards-api",
+                    "basis": "design component realizes stateful workflow",
+                }
+            ],
+        }
+
+        rendered = render_state_model(model)
+
+        self.assertIn("# State Model", rendered)
+        self.assertIn("## State Entities", rendered)
+        self.assertIn("`state-entity-redemption-request` Redemption Request", rendered)
+        self.assertIn("## State Transitions", rendered)
+        self.assertIn("Requested -> Approved -> Fulfilled", rendered)
+        self.assertIn("## Use-Case To State Traceability", rendered)
+        self.assertIn("`trace-uc-analysis-1` uc-redeem -> state-entity-redemption-request", rendered)
+        self.assertIn("## State To Design Traceability", rendered)
+        self.assertIn(
+            "`trace-analysis-design-1` state-entity-redemption-request -> component-rewards-api",
+            rendered,
+        )
+
+    def test_render_all_includes_state_model_artifact(self) -> None:
+        """Primary rendering should emit the formal state-model artifact."""
+        outputs = render_all(build_model())
+
+        self.assertIn("state-model.md", outputs)
+        self.assertTrue(outputs["state-model.md"].startswith("# State Model"))
+
+    def test_end_to_end_state_model_pipeline_from_replay(self) -> None:
+        """Replay normalization should be able to produce the formal state-model artifact."""
+        replay = replay_session(
+            [
+                {
+                    "round": 1,
+                    "responses": [
+                        {"key": "idea", "answer": "Workflow system"},
+                        {"key": "problem", "answer": "Approval flow is opaque"},
+                        {"key": "in_scope", "answer": "Approval lifecycle"},
+                    ],
+                },
+                {
+                    "round": 2,
+                    "responses": [
+                        {"key": "outcomes", "answer": "Clear workflow status"},
+                    ],
+                },
+                {
+                    "round": 3,
+                    "responses": [
+                        {"key": "use_cases", "answer": ["Approve Request"]},
+                    ],
+                },
+                {
+                    "round": 4,
+                    "responses": [
+                        {"key": "workflow_scope", "answer": "Approve Request"},
+                    ],
+                },
+                {
+                    "round": 6,
+                    "responses": [
+                        {"key": "state_entities", "answer": ["Approval Request"]},
+                        {
+                            "key": "states_and_transitions",
+                            "answer": ["Draft -> Submitted -> Approved"],
+                        },
+                        {
+                            "key": "triggers_and_approvals",
+                            "answer": ["Submission triggers approval review"],
+                        },
+                    ],
+                },
+                {
+                    "round": 7,
+                    "responses": [
+                        {"key": "components_and_services", "answer": ["Approval API"]},
+                    ],
+                },
+            ]
+        )
+
+        model = normalize_replay_to_model(replay)
+        rendered = render_state_model(model)
+
+        self.assertIn("Approval Request", rendered)
+        self.assertIn("Draft -> Submitted -> Approved", rendered)
 
     def test_ucp_render_supports_structured_uncertainty_items(self) -> None:
         """UCP rendering should preserve uncertainty metadata when present."""


### PR DESCRIPTION
## Summary
- add a deterministic `state-model.md` artifact from canonical process semantics
- wire process updates so replay marks `state-model.md` stale when process answers change
- document and test the end-to-end replay -> normalize -> state-model rendering path

Closes #48