### PR TITLE
Add V2 go/no-go decision memo

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ uv sync --extra yaml
 - [Solution Architecture](docs/solution-architecture.md)
 - [V1.5 Interview Readiness](docs/v1.5-interview-readiness.md)
 - [V1.6 Specification Hardening](docs/v1.6-specification-hardening.md)
+- [V2 Go/No-Go Decision](docs/v2-go-no-go-decision.md)
 - [Dogfooding Workflow](docs/dogfooding.md)
 - [GitHub Issue Map](docs/github-issue-map.md)
 - [SpecKit Constitution](.specify/memory/constitution.md)

--- a/docs/github-issue-map.md
+++ b/docs/github-issue-map.md
@@ -72,6 +72,8 @@ These themes now shape the completed bridge into V1.6 hardening work.
 - `#8` `EPIC: SpecOps V2 UML and formal specification translation`
 - `#7` `EPIC: SpecOps V2 integrations and productization`
 
+See also: [V2 Go/No-Go Decision](v2-go-no-go-decision.md)
+
 ## Open V2 Decomposition for Epic #8
 
 - `#11` `Implement V2 domain and class modeling`

--- a/docs/v2-go-no-go-decision.md
+++ b/docs/v2-go-no-go-decision.md
@@ -1,0 +1,89 @@
+# SpecOps V2 Go/No-Go Decision
+
+## Decision
+
+Proceed with V2 only if the product goal remains a real RUP/UML specification system.
+
+If the intended endpoint is a strong requirements-and-analysis system with limited formal output,
+SpecOps can stop after V1.6 without being internally inconsistent.
+
+## Current State After V1.6
+
+SpecOps now has:
+
+- a stronger canonical model for analysis and design structures
+- per-view readiness gates
+- explicit cross-view traceability and validation
+- analysis/design separation with layer-owned source-of-truth collections
+- one proven formal artifact pipeline via `state-model.md`
+
+That is enough to claim that SpecOps is specification-ready.
+
+It is not yet enough to claim that SpecOps is specification-complete across the relevant RUP/UML
+views.
+
+## Reasons To Stop After V1.6
+
+- The repo now already solves a credible internal problem: structured discovery, replayable
+  interview flow, deterministic normalization, and trace-aware artifact generation.
+- V1.6 removed the main architectural risks. Stopping here would still leave a coherent product.
+- V2 breadth work is meaningfully more expensive than V1.6 hardening. It will add output families,
+  stricter formal semantics, and more surface area to maintain.
+- If the practical need is improved requirements quality rather than broad formal specification
+  output, further investment may have low marginal return.
+
+## Reasons To Proceed With V2
+
+- A true RUP/UML specification system still requires broader formal artifact coverage than the repo
+  currently provides.
+- One proof artifact is enough to validate the hardened baseline, but not enough to satisfy the
+  original broader ambition.
+- The remaining open V2 items are exactly the breadth layer that V1.6 prepared for:
+  - domain/class modeling
+  - interaction diagrams
+  - broader state modeling support
+  - component/deployment modeling
+  - broader RUP traceability
+- Without V2, SpecOps stops at “capable of formal output” rather than “systematically produces the
+  relevant formal views.”
+
+## Decision Criteria
+
+Proceed with V2 if most of these are true:
+
+- the target product claim still includes real UML or RUP-aligned specification breadth
+- stakeholders need more than one formal artifact family
+- the team is willing to maintain stricter semantic contracts and more output validation
+- the value of generated formal views is expected to outweigh the added complexity
+
+Stop after V1.6 if most of these are true:
+
+- the main value is discovery quality, structured requirements, and estimation
+- one or two formal artifacts are enough for the near-term workflow
+- product simplicity matters more than broad specification coverage
+- the team does not currently need full UML breadth
+
+## Recommendation
+
+Proceed with V2 if the original ambition still stands.
+
+The technical foundation is now strong enough that V2 work should be breadth-first rather than
+repair-first. That is the right time to continue.
+
+If there is uncertainty about value, do not start all of V2 at once. Start with the highest-value
+artifact family after `state-model.md`, validate usage, and continue only if the broader formal
+outputs are actually used.
+
+## Practical Next Step
+
+If V2 proceeds, the next issue should be chosen explicitly from the open V2 backlog rather than
+starting ad hoc implementation:
+
+- `#11` domain and class modeling
+- `#14` interaction diagram support
+- `#15` broader state modeling support
+- `#12` component and deployment modeling
+- `#13` broader RUP traceability
+
+The strongest next candidate is probably `#11`, because domain/class modeling is the clearest next
+formal artifact family after the V1.6 state-model proof.


### PR DESCRIPTION
## Summary
- add a V2 go/no-go decision memo after the completed V1.6 hardening phase
- capture the reasons to stop after V1.6 versus proceed with V2
- link the memo from the README and issue map so the recommendation is discoverable

Refs #8