### PR TITLE
Add document ingestion future direction

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ uv sync --extra yaml
 - [V1.5 Interview Readiness](docs/v1.5-interview-readiness.md)
 - [V1.6 Specification Hardening](docs/v1.6-specification-hardening.md)
 - [V2 Go/No-Go Decision](docs/v2-go-no-go-decision.md)
+- [Document Ingestion Future Direction](docs/document-ingestion-future.md)
 - [Dogfooding Workflow](docs/dogfooding.md)
 - [GitHub Issue Map](docs/github-issue-map.md)
 - [SpecKit Constitution](.specify/memory/constitution.md)

--- a/docs/document-ingestion-future.md
+++ b/docs/document-ingestion-future.md
@@ -1,0 +1,82 @@
+# Document Ingestion Future Direction
+
+## Purpose
+
+SpecOps should eventually support one or more unstructured documents as first-class input for
+building a system specification.
+
+This should not replace the canonical model or bypass the interview workflow. It should add a new
+input path into the same model and artifact pipeline.
+
+Related issue: `#65`
+
+## Product Shape
+
+The intended future flow is:
+
+1. ingest one or more source documents
+2. extract candidate facts and evidence from those documents
+3. normalize the extracted information into the canonical model
+4. identify gaps, conflicts, and unresolved areas
+5. generate targeted follow-up interview questions only where needed
+6. render the existing artifacts from the merged canonical model
+
+This means SpecOps would support:
+
+- interview-first specification
+- document-first specification
+- hybrid document + interview specification
+
+## Design Principles
+
+- documents produce evidence-backed candidate model data, not silent final truth
+- the canonical model remains the source of truth
+- conflicts and uncertainty stay explicit
+- document provenance must be preserved down to the normalized model objects
+- document ingestion should converge with the existing readiness, staleness, and traceability
+  pipeline
+
+## Expected Model Impact
+
+Document ingestion will need explicit source metadata on normalized objects, such as:
+
+- document id
+- section, heading, or page reference
+- extraction note or evidence summary
+- confidence
+- conflict status
+
+This should align with the existing provenance and traceability direction rather than create a
+second parallel metadata scheme.
+
+## Why This Matters
+
+Real system knowledge is often distributed across:
+
+- architecture notes
+- business process documents
+- operational manuals
+- interface descriptions
+- old requirement sets
+
+If SpecOps can only interview stakeholders, it leaves value on the table and forces manual
+re-entry of information that already exists in written form.
+
+## Recommended Implementation Order
+
+1. define the document source and provenance contract
+2. add deterministic extraction targets for canonical structures
+3. support gap analysis against readiness gates
+4. add hybrid merge behavior between documents and interview answers
+5. expose the workflow through a CLI or skill entry point
+
+## Non-Goal
+
+The goal is not to generate a specification directly from opaque document text without an explicit
+canonical model step.
+
+The correct architecture is:
+
+- documents -> candidate model data
+- candidate model data -> canonical model
+- canonical model -> rendered specification artifacts

--- a/docs/github-issue-map.md
+++ b/docs/github-issue-map.md
@@ -71,8 +71,10 @@ These themes now shape the completed bridge into V1.6 hardening work.
 
 - `#8` `EPIC: SpecOps V2 UML and formal specification translation`
 - `#7` `EPIC: SpecOps V2 integrations and productization`
+- `#65` `Add document ingestion and hybrid document-to-spec workflow`
 
 See also: [V2 Go/No-Go Decision](v2-go-no-go-decision.md)
+See also: [Document Ingestion Future Direction](document-ingestion-future.md)
 
 ## Open V2 Decomposition for Epic #8
 


### PR DESCRIPTION
## Summary
- add a future-direction note for document ingestion and hybrid document-to-spec workflows
- create and reference issue `#65` for the feature backlog
- link the new note from the README and issue map so the roadmap is explicit

Closes #65