### PR TITLE
#11 Add domain-model proof artifact

### DIFF
--- a/skills/specops/references/specops-model.md
+++ b/skills/specops/references/specops-model.md
@@ -221,6 +221,7 @@ The model should be rich enough to generate:
 
 - `requirements-spec.md`
 - `use-case-model.md`
+- `domain-model.md`
 - `state-model.md`
 - `ucp-estimate.md`
 
@@ -238,6 +239,14 @@ For the V1.6 proof artifact, `state-model.md` is generated from the canonical pr
 - relevant `traceability.use_case_to_analysis` links for state entities
 - relevant `traceability.analysis_to_design` links where a stateful analysis object is realized by a
   design component
+
+For the first V2 domain/class artifact, `domain-model.md` is generated from the canonical logical
+semantics:
+
+- `analysis_view.domain_entity_objects`
+- `analysis_view.relationship_objects`
+- `analysis_view.business_rule_objects`
+- relevant `traceability.use_case_to_analysis` links for domain entities
 
 If any artifact would require invented inputs, stop and surface the missing fields.
 

--- a/src/specops_tools/readiness.py
+++ b/src/specops_tools/readiness.py
@@ -35,7 +35,7 @@ VIEW_GATES = {
 VIEW_ARTIFACTS = {
     "discovery": ["requirements-spec.md"],
     "use_case": ["requirements-spec.md", "use-case-model.md"],
-    "logical": ["requirements-spec.md"],
+    "logical": ["domain-model.md", "requirements-spec.md"],
     "process": ["requirements-spec.md", "use-case-model.md", "state-model.md"],
     "architecture": ["requirements-spec.md", "use-case-model.md"],
     "ucp": ["ucp-estimate.md"],

--- a/src/specops_tools/render.py
+++ b/src/specops_tools/render.py
@@ -375,6 +375,65 @@ def render_use_case_model(model: dict[str, Any]) -> str:
 """
 
 
+def render_domain_model(model: dict[str, Any]) -> str:
+    """Render the formal domain-model artifact.
+
+    Args:
+        model: Canonical SpecOps model.
+
+    Returns:
+        Markdown content.
+    """
+    project = model.get("project", {})
+    analysis_view = model.get("analysis_view", {})
+    logical_view = model.get("logical_view", {})
+    traceability = model.get("traceability", {})
+    domain_entity_objects = analysis_view.get(
+        "domain_entity_objects",
+        logical_view.get("domain_entity_objects", []),
+    )
+    relationship_objects = analysis_view.get(
+        "relationship_objects",
+        logical_view.get("relationship_objects", []),
+    )
+    business_rule_objects = analysis_view.get(
+        "business_rule_objects",
+        logical_view.get("business_rule_objects", []),
+    )
+    domain_entity_ids = {item.get("id", "") for item in domain_entity_objects if item.get("id")}
+
+    return f"""# Domain Model
+
+## Project
+
+- Name: {project.get("name", "Unnamed Project")}
+- Domain: {project.get("domain", "Unspecified")}
+
+## Scope
+
+{project.get("system_scope", "Unspecified")}
+{_object_name_section(
+    "Domain Entities",
+    domain_entity_objects,
+    logical_view.get("domain_entities", []),
+)}
+{_object_text_section(
+    "Relationships",
+    relationship_objects,
+    logical_view.get("relationships", []),
+)}
+{_object_text_section(
+    "Business Rules",
+    business_rule_objects,
+    logical_view.get("business_rules", []),
+)}
+{_traceability_section(
+    "Use-Case To Domain Traceability",
+    _filter_trace_links(traceability.get("use_case_to_analysis", []), domain_entity_ids),
+)}
+"""
+
+
 def render_state_model(model: dict[str, Any]) -> str:
     """Render the formal state-model artifact.
 
@@ -457,6 +516,7 @@ def render_all(model: dict[str, Any]) -> dict[str, str]:
     return {
         "requirements-spec.md": render_requirements_spec(model),
         "use-case-model.md": render_use_case_model(model),
+        "domain-model.md": render_domain_model(model),
         "state-model.md": render_state_model(model),
         "ucp-estimate.md": render_ucp_markdown(model, ucp_results),
     }

--- a/tests/test_readiness.py
+++ b/tests/test_readiness.py
@@ -144,6 +144,24 @@ class ReadinessTests(unittest.TestCase):
             ["requirements-spec.md", "state-model.md", "use-case-model.md"],
         )
 
+    def test_identify_stale_artifacts_marks_domain_model_for_logical_updates(self) -> None:
+        """Logical-view updates should mark the formal domain-model artifact stale."""
+        stale = identify_stale_artifacts(
+            [
+                {
+                    "round": 5,
+                    "responses": [
+                        {"key": "relationships", "answer": "A Member redeems Rewards"},
+                    ],
+                }
+            ]
+        )
+
+        self.assertEqual(
+            stale,
+            ["domain-model.md", "requirements-spec.md"],
+        )
+
     def test_evaluate_traceability_reports_missing_links(self) -> None:
         """Trace validation should identify missing links by family."""
         model = {

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -6,7 +6,12 @@ import unittest
 
 from specops_tools.discovery import normalize_replay_to_model
 from specops_tools.interview import replay_session
-from specops_tools.render import render_all, render_requirements_spec, render_state_model
+from specops_tools.render import (
+    render_all,
+    render_domain_model,
+    render_requirements_spec,
+    render_state_model,
+)
 from specops_tools.ucp import calculate_ucp, render_ucp_markdown
 
 try:
@@ -398,11 +403,62 @@ class RenderTests(unittest.TestCase):
             rendered,
         )
 
+    def test_domain_model_render_includes_logical_traceability(self) -> None:
+        """Domain-model rendering should surface logical semantics and relevant trace links."""
+        model = build_model()
+        model["analysis_view"] = {
+            "domain_entity_objects": [
+                {
+                    "id": "entity-member",
+                    "name": "Member",
+                    "trace": {"source_round": 5, "source_key": "domain_entities"},
+                }
+            ],
+            "relationship_objects": [
+                {
+                    "id": "relationship-1",
+                    "description": "A Member redeems Rewards.",
+                    "trace": {"source_round": 5, "source_key": "relationships"},
+                }
+            ],
+            "business_rule_objects": [
+                {
+                    "id": "business-rule-1",
+                    "rule_text": "A Member must have enough points.",
+                    "trace": {"source_round": 5, "source_key": "business_rules"},
+                }
+            ],
+        }
+        model["traceability"] = {
+            "use_case_to_analysis": [
+                {
+                    "id": "trace-uc-analysis-1",
+                    "from_id": "uc-redeem",
+                    "to_id": "entity-member",
+                    "basis": "use-case text references analysis object name",
+                }
+            ],
+        }
+
+        rendered = render_domain_model(model)
+
+        self.assertIn("# Domain Model", rendered)
+        self.assertIn("## Domain Entities", rendered)
+        self.assertIn("`entity-member` Member", rendered)
+        self.assertIn("## Relationships", rendered)
+        self.assertIn("A Member redeems Rewards.", rendered)
+        self.assertIn("## Business Rules", rendered)
+        self.assertIn("A Member must have enough points.", rendered)
+        self.assertIn("## Use-Case To Domain Traceability", rendered)
+        self.assertIn("`trace-uc-analysis-1` uc-redeem -> entity-member", rendered)
+
     def test_render_all_includes_state_model_artifact(self) -> None:
         """Primary rendering should emit the formal state-model artifact."""
         outputs = render_all(build_model())
 
+        self.assertIn("domain-model.md", outputs)
         self.assertIn("state-model.md", outputs)
+        self.assertTrue(outputs["domain-model.md"].startswith("# Domain Model"))
         self.assertTrue(outputs["state-model.md"].startswith("# State Model"))
 
     def test_end_to_end_state_model_pipeline_from_replay(self) -> None:
@@ -463,6 +519,51 @@ class RenderTests(unittest.TestCase):
 
         self.assertIn("Approval Request", rendered)
         self.assertIn("Draft -> Submitted -> Approved", rendered)
+
+    def test_end_to_end_domain_model_pipeline_from_replay(self) -> None:
+        """Replay normalization should be able to produce the formal domain-model artifact."""
+        replay = replay_session(
+            [
+                {
+                    "round": 1,
+                    "responses": [
+                        {"key": "idea", "answer": "Membership platform"},
+                        {"key": "problem", "answer": "Customer and reward rules are unclear"},
+                        {"key": "in_scope", "answer": "Reward redemption domain"},
+                    ],
+                },
+                {
+                    "round": 2,
+                    "responses": [
+                        {"key": "outcomes", "answer": "Clear domain language"},
+                    ],
+                },
+                {
+                    "round": 3,
+                    "responses": [
+                        {"key": "use_cases", "answer": ["Redeem Reward"]},
+                    ],
+                },
+                {
+                    "round": 5,
+                    "responses": [
+                        {"key": "domain_entities", "answer": ["Member", "Reward"]},
+                        {"key": "relationships", "answer": ["A Member redeems Rewards"]},
+                        {
+                            "key": "business_rules",
+                            "answer": ["A Member must have sufficient points"],
+                        },
+                    ],
+                },
+            ]
+        )
+
+        model = normalize_replay_to_model(replay)
+        rendered = render_domain_model(model)
+
+        self.assertIn("Member", rendered)
+        self.assertIn("Reward", rendered)
+        self.assertIn("A Member redeems Rewards", rendered)
 
     def test_ucp_render_supports_structured_uncertainty_items(self) -> None:
         """UCP rendering should preserve uncertainty metadata when present."""


### PR DESCRIPTION
## Summary
- add `domain-model.md` as the first V2 domain/class artifact path
- wire logical-view updates so replay marks `domain-model.md` stale when domain answers change
- document and test the end-to-end logical-view to domain-model rendering path

Closes #11