### PR TITLE
#69 Add richer domain-model semantics

### DIFF
--- a/skills/specops/references/specops-model.md
+++ b/skills/specops/references/specops-model.md
@@ -114,6 +114,10 @@ The canonical project model is `specops-model.yaml`.
     - `source_entity_id`
     - `target_name`
     - `target_entity_id`
+    - `source_multiplicity`
+    - `target_multiplicity`
+    - `source_role_name`
+    - `target_role_name`
     - `trace`
   - `business_rules`
   - `business_rule_objects`

--- a/src/specops_tools/discovery.py
+++ b/src/specops_tools/discovery.py
@@ -134,6 +134,16 @@ def _normalize_domain_entities(items: list[str]) -> list[dict[str, Any]]:
     entities = []
     for item in items:
         normalized_name = item.strip()
+        attributes = []
+        name_part = normalized_name
+        if ":" in normalized_name:
+            name_part, attribute_part = normalized_name.split(":", 1)
+            normalized_name = name_part.strip()
+            attributes = [
+                attribute.strip()
+                for attribute in attribute_part.split(",")
+                if attribute.strip()
+            ]
         entities.append(
             {
                 "id": f"entity-{_slugify(normalized_name)}",
@@ -141,7 +151,7 @@ def _normalize_domain_entities(items: list[str]) -> list[dict[str, Any]]:
                 "entity_type": "domain_entity",
                 "model_layer": "analysis",
                 "description": "",
-                "attributes": [],
+                "attributes": attributes,
                 "responsibilities": [],
                 "trace": {},
             }
@@ -160,17 +170,27 @@ def _normalize_relationships(
         source_name = ""
         target_name = ""
         relationship_type = ""
+        source_multiplicity = ""
+        target_multiplicity = ""
+        source_role_name = ""
+        target_role_name = ""
         normalized = text.lower()
 
         if " has many " in normalized:
             source_name, target_name = re.split(r"\bhas many\b", text, maxsplit=1, flags=re.IGNORECASE)
             relationship_type = "has_many"
+            source_multiplicity = "1"
+            target_multiplicity = "*"
         elif " has a " in normalized:
             source_name, target_name = re.split(r"\bhas a\b", text, maxsplit=1, flags=re.IGNORECASE)
             relationship_type = "has_one"
+            source_multiplicity = "1"
+            target_multiplicity = "1"
         elif " has an " in normalized:
             source_name, target_name = re.split(r"\bhas an\b", text, maxsplit=1, flags=re.IGNORECASE)
             relationship_type = "has_one"
+            source_multiplicity = "1"
+            target_multiplicity = "1"
         elif " belongs to " in normalized:
             source_name, target_name = re.split(
                 r"\bbelongs to\b",
@@ -179,9 +199,14 @@ def _normalize_relationships(
                 flags=re.IGNORECASE,
             )
             relationship_type = "belongs_to"
+            source_multiplicity = "*"
+            target_multiplicity = "1"
 
         source_name = source_name.strip()
         target_name = target_name.strip()
+        if source_name and target_name:
+            source_role_name = _slugify(target_name).replace("-", "_")
+            target_role_name = _slugify(source_name).replace("-", "_")
         source_match = _best_name_match(source_name, entities) if source_name else None
         target_match = _best_name_match(target_name, entities) if target_name else None
         relationships.append(
@@ -194,6 +219,10 @@ def _normalize_relationships(
                 "source_entity_id": source_match["id"] if source_match else "",
                 "target_name": target_name,
                 "target_entity_id": target_match["id"] if target_match else "",
+                "source_multiplicity": source_multiplicity,
+                "target_multiplicity": target_multiplicity,
+                "source_role_name": source_role_name,
+                "target_role_name": target_role_name,
                 "trace": {},
             }
         )

--- a/src/specops_tools/render.py
+++ b/src/specops_tools/render.py
@@ -73,6 +73,8 @@ def _object_name_section(
         rendered = []
         for item in items:
             line = f"- `{item.get('id', 'item')}` {item.get('name', 'Unnamed')}"
+            if item.get("attributes"):
+                line = f"{line} [{', '.join(item['attributes'])}]"
             if item.get("description"):
                 line = f"{line}: {item['description']}"
             if trace := item.get("trace"):
@@ -135,6 +137,41 @@ def _traceability_section(
 
 {"\n".join(rendered)}
 """
+
+
+def _relationship_section(
+    title: str,
+    items: list[dict[str, Any]],
+    fallback: list[str],
+) -> str:
+    """Render relationships with richer class-model semantics when present."""
+    if items:
+        rendered = []
+        for item in items:
+            semantic_bits = []
+            if item.get("source_multiplicity") or item.get("target_multiplicity"):
+                semantic_bits.append(
+                    f"multiplicity: {item.get('source_multiplicity', '')} -> {item.get('target_multiplicity', '')}"
+                )
+            if item.get("source_role_name") or item.get("target_role_name"):
+                semantic_bits.append(
+                    f"roles: {item.get('source_role_name', '')} / {item.get('target_role_name', '')}"
+                )
+            line = f"- `{item.get('id', 'item')}` {item.get('description', '')}"
+            if semantic_bits:
+                line = f"{line} ({'; '.join(semantic_bits)})"
+            if trace := item.get("trace"):
+                line = (
+                    f"{line} [source: round {trace.get('source_round')} "
+                    f"{trace.get('source_key')}]"
+                )
+            rendered.append(line)
+        return f"""
+## {title}
+
+{"\n".join(rendered)}
+"""
+    return _named_section(title, fallback)
 
 
 def _filter_trace_links(
@@ -417,7 +454,7 @@ def render_domain_model(model: dict[str, Any]) -> str:
     domain_entity_objects,
     logical_view.get("domain_entities", []),
 )}
-{_object_text_section(
+{_relationship_section(
     "Relationships",
     relationship_objects,
     logical_view.get("relationships", []),

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -108,6 +108,10 @@ class DiscoveryTests(unittest.TestCase):
             model["analysis_view"]["domain_entity_objects"][0]["id"],
             "entity-system",
         )
+        self.assertEqual(
+            model["analysis_view"]["domain_entity_objects"][1]["attributes"],
+            [],
+        )
         self.assertEqual(model["actors"], [])
         self.assertEqual(model["use_cases"], [])
         self.assertIn("System", model["logical_view"]["domain_entities"])
@@ -134,6 +138,14 @@ class DiscoveryTests(unittest.TestCase):
         self.assertEqual(
             model["logical_view"]["relationship_objects"][0]["source_entity_id"],
             "entity-system",
+        )
+        self.assertEqual(
+            model["logical_view"]["relationship_objects"][0]["source_multiplicity"],
+            "1",
+        )
+        self.assertEqual(
+            model["logical_view"]["relationship_objects"][0]["target_multiplicity"],
+            "*",
         )
         self.assertIn(
             "Draft -> Submitted -> Approved",
@@ -386,6 +398,8 @@ class DiscoveryTests(unittest.TestCase):
         self.assertEqual(relationship["relationship_type"], "")
         self.assertEqual(relationship["source_entity_id"], "")
         self.assertEqual(relationship["target_entity_id"], "")
+        self.assertEqual(relationship["source_multiplicity"], "")
+        self.assertEqual(relationship["target_multiplicity"], "")
         self.assertEqual(relationship["description"], "Ledger Entry interacts with reporting")
 
         transition = model["process_view"]["state_transition_objects"][0]
@@ -397,6 +411,28 @@ class DiscoveryTests(unittest.TestCase):
         self.assertEqual(interface["source_component_id"], "")
         self.assertEqual(interface["target_component_id"], "")
         self.assertEqual(interface["interaction_verb"], "")
+
+    def test_normalize_replay_to_model_parses_domain_attributes(self) -> None:
+        """Domain entities should parse simple attribute lists when explicitly stated."""
+        replay = replay_session(
+            [
+                {
+                    "round": 5,
+                    "responses": [
+                        {
+                            "key": "domain_entities",
+                            "answer": ["Member: id, email, points balance"],
+                        },
+                    ],
+                }
+            ]
+        )
+
+        model = normalize_replay_to_model(replay)
+
+        entity = model["logical_view"]["domain_entity_objects"][0]
+        self.assertEqual(entity["name"], "Member")
+        self.assertEqual(entity["attributes"], ["id", "email", "points balance"])
 
     def test_normalize_replay_to_model_adds_requirement_objects(self) -> None:
         """Requirement lists should also have explicit semantic object forms."""

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -411,6 +411,7 @@ class RenderTests(unittest.TestCase):
                 {
                     "id": "entity-member",
                     "name": "Member",
+                    "attributes": ["id", "email"],
                     "trace": {"source_round": 5, "source_key": "domain_entities"},
                 }
             ],
@@ -418,6 +419,10 @@ class RenderTests(unittest.TestCase):
                 {
                     "id": "relationship-1",
                     "description": "A Member redeems Rewards.",
+                    "source_multiplicity": "1",
+                    "target_multiplicity": "*",
+                    "source_role_name": "rewards",
+                    "target_role_name": "member",
                     "trace": {"source_round": 5, "source_key": "relationships"},
                 }
             ],
@@ -444,9 +449,11 @@ class RenderTests(unittest.TestCase):
 
         self.assertIn("# Domain Model", rendered)
         self.assertIn("## Domain Entities", rendered)
-        self.assertIn("`entity-member` Member", rendered)
+        self.assertIn("`entity-member` Member [id, email]", rendered)
         self.assertIn("## Relationships", rendered)
         self.assertIn("A Member redeems Rewards.", rendered)
+        self.assertIn("multiplicity: 1 -> *", rendered)
+        self.assertIn("roles: rewards / member", rendered)
         self.assertIn("## Business Rules", rendered)
         self.assertIn("A Member must have enough points.", rendered)
         self.assertIn("## Use-Case To Domain Traceability", rendered)


### PR DESCRIPTION
## Summary
- extend domain entities with deterministic attribute parsing from straightforward source text
- extend relationships with conservative multiplicity and role-name semantics for class-model readiness
- render the stronger logical semantics in `domain-model.md` without inventing structure when parsing is unclear

Closes #69