### PR TITLE
#14 Add interaction-model proof artifact

### DIFF
--- a/skills/specops/references/specops-model.md
+++ b/skills/specops/references/specops-model.md
@@ -93,6 +93,28 @@ The canonical project model is `specops-model.yaml`.
     - `to_id`
     - `link_type`
     - `basis`
+- `interaction_view`
+  - `realization_objects`
+    - `id`
+    - `use_case_id`
+    - `use_case_name`
+    - `participant_ids`
+    - `participant_names`
+    - `steps`
+    - `model_layer`: `analysis`
+    - `trace`
+  - `message_objects`
+    - `id`
+    - `source_name`
+    - `source_id`
+    - `target_name`
+    - `target_id`
+    - `interaction_verb`
+    - `description`
+    - `model_layer`: `design`
+    - `trace`
+  - `realization_ids`
+  - `message_ids`
 - `logical_view` (derived compatibility view from `analysis_view` for V1/V1.5 renderers)
   - `domain_entities`
   - `domain_entity_objects`
@@ -226,6 +248,7 @@ The model should be rich enough to generate:
 - `requirements-spec.md`
 - `use-case-model.md`
 - `domain-model.md`
+- `interaction-model.md`
 - `state-model.md`
 - `ucp-estimate.md`
 
@@ -251,6 +274,14 @@ semantics:
 - `analysis_view.relationship_objects`
 - `analysis_view.business_rule_objects`
 - relevant `traceability.use_case_to_analysis` links for domain entities
+
+For the first V2 interaction artifact, `interaction-model.md` is generated from the canonical
+interaction semantics:
+
+- `interaction_view.realization_objects`
+- `interaction_view.message_objects`
+- use-case realizations anchored to canonical use-case objects
+- message flows anchored to canonical interface objects
 
 If any artifact would require invented inputs, stop and surface the missing fields.
 

--- a/src/specops_tools/discovery.py
+++ b/src/specops_tools/discovery.py
@@ -735,6 +735,70 @@ def _derive_architecture_view(design_view: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _build_interaction_view(
+    use_cases: list[dict[str, Any]],
+    actors: list[dict[str, Any]],
+    interface_objects: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Build a conservative interaction view from use-case and interface data."""
+    actor_name_to_id = {
+        item.get("name", ""): item.get("id", "")
+        for item in actors
+        if item.get("name") and item.get("id")
+    }
+
+    realization_objects = []
+    for index, use_case in enumerate(use_cases, 1):
+        participant_ids = []
+        participant_names = []
+        primary_actor_name = use_case.get("primary_actor", "")
+        primary_actor_id = use_case.get("primary_actor_id", "") or actor_name_to_id.get(primary_actor_name, "")
+        if primary_actor_id:
+            participant_ids.append(primary_actor_id)
+        if primary_actor_name and primary_actor_name != "Unspecified":
+            participant_names.append(primary_actor_name)
+
+        for actor_id in use_case.get("supporting_actor_ids", []):
+            if actor_id and actor_id not in participant_ids:
+                participant_ids.append(actor_id)
+
+        realization_objects.append(
+            {
+                "id": f"interaction-realization-{index}",
+                "use_case_id": use_case.get("id", ""),
+                "use_case_name": use_case.get("name", ""),
+                "participant_ids": participant_ids,
+                "participant_names": participant_names,
+                "steps": list(use_case.get("main_success_scenario", [])),
+                "model_layer": "analysis",
+                "trace": use_case.get("trace", {}),
+            }
+        )
+
+    message_objects = []
+    for index, interface in enumerate(interface_objects, 1):
+        message_objects.append(
+            {
+                "id": f"interaction-message-{index}",
+                "source_name": interface.get("source_component_name", ""),
+                "source_id": interface.get("source_component_id", ""),
+                "target_name": interface.get("target_component_name", ""),
+                "target_id": interface.get("target_component_id", ""),
+                "interaction_verb": interface.get("interaction_verb", ""),
+                "description": interface.get("description", ""),
+                "model_layer": "design",
+                "trace": interface.get("trace", {}),
+            }
+        )
+
+    return {
+        "realization_objects": realization_objects,
+        "message_objects": message_objects,
+        "realization_ids": [item["id"] for item in realization_objects],
+        "message_ids": [item["id"] for item in message_objects],
+    }
+
+
 def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
     """Normalize replay output into a canonical SpecOps model shape.
 
@@ -901,6 +965,11 @@ def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
     logical_view = _derive_logical_view(analysis_view)
     process_view = _derive_process_view(analysis_view)
     architecture_view = _derive_architecture_view(design_view)
+    interaction_view = _build_interaction_view(
+        normalized_use_cases,
+        normalized_actors,
+        interface_objects,
+    )
 
     return {
         "project": {
@@ -925,6 +994,7 @@ def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
         "process_view": process_view,
         "architecture_view": architecture_view,
         "design_view": design_view,
+        "interaction_view": interaction_view,
         "metadata_fields": _ensure_list(round_4.get("metadata_fields")),
         "assumptions": [],
         "open_questions": [],

--- a/src/specops_tools/readiness.py
+++ b/src/specops_tools/readiness.py
@@ -34,10 +34,10 @@ VIEW_GATES = {
 
 VIEW_ARTIFACTS = {
     "discovery": ["requirements-spec.md"],
-    "use_case": ["requirements-spec.md", "use-case-model.md"],
+    "use_case": ["interaction-model.md", "requirements-spec.md", "use-case-model.md"],
     "logical": ["domain-model.md", "requirements-spec.md"],
     "process": ["requirements-spec.md", "use-case-model.md", "state-model.md"],
-    "architecture": ["requirements-spec.md", "use-case-model.md"],
+    "architecture": ["interaction-model.md", "requirements-spec.md", "use-case-model.md"],
     "ucp": ["ucp-estimate.md"],
 }
 

--- a/src/specops_tools/render.py
+++ b/src/specops_tools/render.py
@@ -471,6 +471,81 @@ def render_domain_model(model: dict[str, Any]) -> str:
 """
 
 
+def render_interaction_model(model: dict[str, Any]) -> str:
+    """Render the formal interaction-model artifact.
+
+    Args:
+        model: Canonical SpecOps model.
+
+    Returns:
+        Markdown content.
+    """
+    project = model.get("project", {})
+    interaction_view = model.get("interaction_view", {})
+    realization_objects = interaction_view.get("realization_objects", [])
+    message_objects = interaction_view.get("message_objects", [])
+
+    realizations = []
+    for realization in realization_objects:
+        steps = "\n".join(
+            f"{index}. {step}" for index, step in enumerate(realization.get("steps", []), 1)
+        ) or "1. No interaction steps documented."
+        participant_names = ", ".join(realization.get("participant_names", [])) or "Unspecified"
+        line = f"""### {realization.get("use_case_name", "Unnamed Use Case")}
+
+- Realization ID: `{realization.get("id", "interaction-realization")}`
+- Use case ID: `{realization.get("use_case_id", "use-case")}`
+- Participants: {participant_names}
+
+#### Steps
+
+{steps}
+"""
+        if trace := realization.get("trace"):
+            line = (
+                f"{line}\n- Source: round {trace.get('source_round', 'n/a')} "
+                f"{trace.get('source_key', '')}"
+            )
+        realizations.append(line)
+
+    message_lines = []
+    for message in message_objects:
+        line = (
+            f"- `{message.get('id', 'interaction-message')}` "
+            f"{message.get('source_name', 'Unknown')} -> {message.get('target_name', 'Unknown')}"
+        )
+        if message.get("interaction_verb"):
+            line = f"{line} ({message['interaction_verb']})"
+        if message.get("description"):
+            line = f"{line}: {message['description']}"
+        if trace := message.get("trace"):
+            line = (
+                f"{line} [source: round {trace.get('source_round')} "
+                f"{trace.get('source_key')}]"
+            )
+        message_lines.append(line)
+
+    return f"""# Interaction Model
+
+## Project
+
+- Name: {project.get("name", "Unnamed Project")}
+- Domain: {project.get("domain", "Unspecified")}
+
+## Scope
+
+{project.get("system_scope", "Unspecified")}
+
+## Use-Case Realizations
+
+{"\n\n".join(realizations) or "No interaction realizations documented."}
+
+## Message Flows
+
+{"\n".join(message_lines) or "- None"}
+"""
+
+
 def render_state_model(model: dict[str, Any]) -> str:
     """Render the formal state-model artifact.
 
@@ -554,6 +629,7 @@ def render_all(model: dict[str, Any]) -> dict[str, str]:
         "requirements-spec.md": render_requirements_spec(model),
         "use-case-model.md": render_use_case_model(model),
         "domain-model.md": render_domain_model(model),
+        "interaction-model.md": render_interaction_model(model),
         "state-model.md": render_state_model(model),
         "ucp-estimate.md": render_ucp_markdown(model, ucp_results),
     }

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -204,6 +204,11 @@ class DiscoveryTests(unittest.TestCase):
             model["architecture_view"]["runtime_boundary_objects"][0]["boundary_type"],
             "runtime_separation",
         )
+        self.assertEqual(model["interaction_view"]["realization_objects"], [])
+        self.assertEqual(
+            model["interaction_view"]["message_objects"][0]["interaction_verb"],
+            "calls",
+        )
         self.assertEqual(
             model["logical_view"]["domain_entity_objects"],
             model["analysis_view"]["domain_entity_objects"],
@@ -289,6 +294,14 @@ class DiscoveryTests(unittest.TestCase):
         self.assertEqual(model["analysis_view"]["use_cases"][0]["id"], "browse-rewards")
         self.assertEqual(model["actors"], model["analysis_view"]["actors"])
         self.assertEqual(model["use_cases"], model["analysis_view"]["use_cases"])
+        self.assertEqual(
+            model["interaction_view"]["realization_objects"][0]["use_case_id"],
+            "browse-rewards",
+        )
+        self.assertEqual(
+            model["interaction_view"]["realization_objects"][0]["steps"],
+            [],
+        )
 
     def test_normalize_replay_to_model_applies_ucp_answers_to_objects(self) -> None:
         """UCP round answers should update normalized actor/use-case complexity and factors."""

--- a/tests/test_readiness.py
+++ b/tests/test_readiness.py
@@ -162,6 +162,30 @@ class ReadinessTests(unittest.TestCase):
             ["domain-model.md", "requirements-spec.md"],
         )
 
+    def test_identify_stale_artifacts_marks_interaction_model_for_use_case_and_architecture_updates(self) -> None:
+        """Use-case or architecture updates should mark the formal interaction-model artifact stale."""
+        stale = identify_stale_artifacts(
+            [
+                {
+                    "round": 3,
+                    "responses": [
+                        {"key": "use_cases", "answer": "Redeem Reward"},
+                    ],
+                },
+                {
+                    "round": 7,
+                    "responses": [
+                        {"key": "interfaces_and_integrations", "answer": "Member App calls Rewards API"},
+                    ],
+                },
+            ]
+        )
+
+        self.assertEqual(
+            stale,
+            ["interaction-model.md", "requirements-spec.md", "use-case-model.md"],
+        )
+
     def test_evaluate_traceability_reports_missing_links(self) -> None:
         """Trace validation should identify missing links by family."""
         model = {

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -9,6 +9,7 @@ from specops_tools.interview import replay_session
 from specops_tools.render import (
     render_all,
     render_domain_model,
+    render_interaction_model,
     render_requirements_spec,
     render_state_model,
 )
@@ -464,9 +465,93 @@ class RenderTests(unittest.TestCase):
         outputs = render_all(build_model())
 
         self.assertIn("domain-model.md", outputs)
+        self.assertIn("interaction-model.md", outputs)
         self.assertIn("state-model.md", outputs)
         self.assertTrue(outputs["domain-model.md"].startswith("# Domain Model"))
+        self.assertTrue(outputs["interaction-model.md"].startswith("# Interaction Model"))
         self.assertTrue(outputs["state-model.md"].startswith("# State Model"))
+
+    def test_interaction_model_render_includes_realizations_and_messages(self) -> None:
+        """Interaction-model rendering should surface use-case realizations and message flows."""
+        model = build_model()
+        model["interaction_view"] = {
+            "realization_objects": [
+                {
+                    "id": "interaction-realization-1",
+                    "use_case_id": "uc-redeem",
+                    "use_case_name": "Redeem Reward",
+                    "participant_ids": ["customer"],
+                    "participant_names": ["Customer"],
+                    "steps": ["Customer selects reward.", "System validates points."],
+                    "trace": {"source_round": 3, "source_key": "use_cases"},
+                }
+            ],
+            "message_objects": [
+                {
+                    "id": "interaction-message-1",
+                    "source_name": "Member App",
+                    "source_id": "component-member-app",
+                    "target_name": "Rewards API",
+                    "target_id": "component-rewards-api",
+                    "interaction_verb": "calls",
+                    "description": "Member App calls Rewards API",
+                    "trace": {"source_round": 7, "source_key": "interfaces_and_integrations"},
+                }
+            ],
+        }
+
+        rendered = render_interaction_model(model)
+
+        self.assertIn("# Interaction Model", rendered)
+        self.assertIn("### Redeem Reward", rendered)
+        self.assertIn("Customer selects reward.", rendered)
+        self.assertIn("## Message Flows", rendered)
+        self.assertIn("Member App -> Rewards API", rendered)
+        self.assertIn("(calls)", rendered)
+
+    def test_end_to_end_interaction_model_pipeline_from_replay(self) -> None:
+        """Replay normalization should be able to produce the formal interaction-model artifact."""
+        replay = replay_session(
+            [
+                {
+                    "round": 1,
+                    "responses": [
+                        {"key": "idea", "answer": "Rewards system"},
+                        {"key": "problem", "answer": "Interaction flow is unclear"},
+                        {"key": "in_scope", "answer": "Reward redemption flow"},
+                    ],
+                },
+                {
+                    "round": 2,
+                    "responses": [
+                        {"key": "outcomes", "answer": "Clearer interaction path"},
+                    ],
+                },
+                {
+                    "round": 3,
+                    "responses": [
+                        {"key": "actors", "answer": ["Customer"]},
+                        {"key": "use_cases", "answer": ["Redeem Reward"]},
+                    ],
+                },
+                {
+                    "round": 7,
+                    "responses": [
+                        {"key": "components_and_services", "answer": ["Member App", "Rewards API"]},
+                        {
+                            "key": "interfaces_and_integrations",
+                            "answer": ["Member App calls Rewards API"],
+                        },
+                    ],
+                },
+            ]
+        )
+
+        model = normalize_replay_to_model(replay)
+        rendered = render_interaction_model(model)
+
+        self.assertIn("Redeem Reward", rendered)
+        self.assertIn("Member App -> Rewards API", rendered)
 
     def test_end_to_end_state_model_pipeline_from_replay(self) -> None:
         """Replay normalization should be able to produce the formal state-model artifact."""


### PR DESCRIPTION
## Summary
- add a canonical `interaction_view` with use-case realizations and message flows
- add `interaction-model.md` as the first V2 interaction artifact path
- wire use-case and architecture changes so replay marks `interaction-model.md` stale when interaction inputs change
- prove the replay -> normalize -> interaction-model rendering path with tests

Closes #14