### PR TITLE
#12 Add deployment-model proof artifact

### DIFF
--- a/skills/specops/references/specops-model.md
+++ b/skills/specops/references/specops-model.md
@@ -249,6 +249,7 @@ The model should be rich enough to generate:
 - `use-case-model.md`
 - `domain-model.md`
 - `interaction-model.md`
+- `deployment-model.md`
 - `state-model.md`
 - `ucp-estimate.md`
 
@@ -282,6 +283,14 @@ interaction semantics:
 - `interaction_view.message_objects`
 - use-case realizations anchored to canonical use-case objects
 - message flows anchored to canonical interface objects
+
+For the first V2 component/deployment artifact, `deployment-model.md` is generated from the
+canonical design and architecture semantics:
+
+- `design_view.component_objects`
+- `design_view.interface_objects`
+- `design_view.runtime_boundary_objects`
+- current deployment/runtime boundary data without invented node structure
 
 If any artifact would require invented inputs, stop and surface the missing fields.
 

--- a/src/specops_tools/readiness.py
+++ b/src/specops_tools/readiness.py
@@ -37,7 +37,12 @@ VIEW_ARTIFACTS = {
     "use_case": ["interaction-model.md", "requirements-spec.md", "use-case-model.md"],
     "logical": ["domain-model.md", "requirements-spec.md"],
     "process": ["requirements-spec.md", "use-case-model.md", "state-model.md"],
-    "architecture": ["interaction-model.md", "requirements-spec.md", "use-case-model.md"],
+    "architecture": [
+        "deployment-model.md",
+        "interaction-model.md",
+        "requirements-spec.md",
+        "use-case-model.md",
+    ],
     "ucp": ["ucp-estimate.md"],
 }
 

--- a/src/specops_tools/render.py
+++ b/src/specops_tools/render.py
@@ -546,6 +546,59 @@ def render_interaction_model(model: dict[str, Any]) -> str:
 """
 
 
+def render_deployment_model(model: dict[str, Any]) -> str:
+    """Render the formal deployment-model artifact.
+
+    Args:
+        model: Canonical SpecOps model.
+
+    Returns:
+        Markdown content.
+    """
+    project = model.get("project", {})
+    design_view = model.get("design_view", {})
+    architecture_view = model.get("architecture_view", {})
+    component_objects = design_view.get(
+        "component_objects",
+        architecture_view.get("component_objects", []),
+    )
+    interface_objects = design_view.get(
+        "interface_objects",
+        architecture_view.get("interface_objects", []),
+    )
+    runtime_boundary_objects = design_view.get(
+        "runtime_boundary_objects",
+        architecture_view.get("runtime_boundary_objects", []),
+    )
+
+    return f"""# Deployment Model
+
+## Project
+
+- Name: {project.get("name", "Unnamed Project")}
+- Domain: {project.get("domain", "Unspecified")}
+
+## Scope
+
+{project.get("system_scope", "Unspecified")}
+{_object_name_section(
+    "Components",
+    component_objects,
+    architecture_view.get("components_and_services", []),
+)}
+{_object_text_section(
+    "Interfaces and Integrations",
+    interface_objects,
+    architecture_view.get("interfaces_and_integrations", []),
+)}
+{_object_text_section(
+    "Runtime Boundaries",
+    runtime_boundary_objects,
+    architecture_view.get("runtime_boundaries", []),
+)}
+"""
+
+
 def render_state_model(model: dict[str, Any]) -> str:
     """Render the formal state-model artifact.
 
@@ -630,6 +683,7 @@ def render_all(model: dict[str, Any]) -> dict[str, str]:
         "use-case-model.md": render_use_case_model(model),
         "domain-model.md": render_domain_model(model),
         "interaction-model.md": render_interaction_model(model),
+        "deployment-model.md": render_deployment_model(model),
         "state-model.md": render_state_model(model),
         "ucp-estimate.md": render_ucp_markdown(model, ucp_results),
     }

--- a/tests/test_readiness.py
+++ b/tests/test_readiness.py
@@ -183,7 +183,35 @@ class ReadinessTests(unittest.TestCase):
 
         self.assertEqual(
             stale,
-            ["interaction-model.md", "requirements-spec.md", "use-case-model.md"],
+            [
+                "deployment-model.md",
+                "interaction-model.md",
+                "requirements-spec.md",
+                "use-case-model.md",
+            ],
+        )
+
+    def test_identify_stale_artifacts_marks_deployment_model_for_architecture_updates(self) -> None:
+        """Architecture updates should mark the formal deployment-model artifact stale."""
+        stale = identify_stale_artifacts(
+            [
+                {
+                    "round": 7,
+                    "responses": [
+                        {"key": "runtime_boundaries", "answer": "Rewards API runs separately from the UI"},
+                    ],
+                },
+            ]
+        )
+
+        self.assertEqual(
+            stale,
+            [
+                "deployment-model.md",
+                "interaction-model.md",
+                "requirements-spec.md",
+                "use-case-model.md",
+            ],
         )
 
     def test_evaluate_traceability_reports_missing_links(self) -> None:

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -8,6 +8,7 @@ from specops_tools.discovery import normalize_replay_to_model
 from specops_tools.interview import replay_session
 from specops_tools.render import (
     render_all,
+    render_deployment_model,
     render_domain_model,
     render_interaction_model,
     render_requirements_spec,
@@ -464,9 +465,11 @@ class RenderTests(unittest.TestCase):
         """Primary rendering should emit the formal state-model artifact."""
         outputs = render_all(build_model())
 
+        self.assertIn("deployment-model.md", outputs)
         self.assertIn("domain-model.md", outputs)
         self.assertIn("interaction-model.md", outputs)
         self.assertIn("state-model.md", outputs)
+        self.assertTrue(outputs["deployment-model.md"].startswith("# Deployment Model"))
         self.assertTrue(outputs["domain-model.md"].startswith("# Domain Model"))
         self.assertTrue(outputs["interaction-model.md"].startswith("# Interaction Model"))
         self.assertTrue(outputs["state-model.md"].startswith("# State Model"))
@@ -552,6 +555,85 @@ class RenderTests(unittest.TestCase):
 
         self.assertIn("Redeem Reward", rendered)
         self.assertIn("Member App -> Rewards API", rendered)
+
+    def test_deployment_model_render_includes_components_and_boundaries(self) -> None:
+        """Deployment-model rendering should surface components, interfaces, and boundaries."""
+        model = build_model()
+        model["design_view"] = {
+            "component_objects": [
+                {
+                    "id": "component-member-app",
+                    "name": "Member App",
+                    "trace": {"source_round": 7, "source_key": "components_and_services"},
+                }
+            ],
+            "interface_objects": [
+                {
+                    "id": "interface-1",
+                    "description": "Member App calls Rewards API",
+                    "trace": {"source_round": 7, "source_key": "interfaces_and_integrations"},
+                }
+            ],
+            "runtime_boundary_objects": [
+                {
+                    "id": "runtime-boundary-1",
+                    "description": "Rewards API runs separately from the UI",
+                    "trace": {"source_round": 7, "source_key": "runtime_boundaries"},
+                }
+            ],
+        }
+
+        rendered = render_deployment_model(model)
+
+        self.assertIn("# Deployment Model", rendered)
+        self.assertIn("## Components", rendered)
+        self.assertIn("`component-member-app` Member App", rendered)
+        self.assertIn("## Interfaces and Integrations", rendered)
+        self.assertIn("Member App calls Rewards API", rendered)
+        self.assertIn("## Runtime Boundaries", rendered)
+        self.assertIn("Rewards API runs separately from the UI", rendered)
+
+    def test_end_to_end_deployment_model_pipeline_from_replay(self) -> None:
+        """Replay normalization should be able to produce the formal deployment-model artifact."""
+        replay = replay_session(
+            [
+                {
+                    "round": 1,
+                    "responses": [
+                        {"key": "idea", "answer": "Rewards system"},
+                        {"key": "problem", "answer": "Deployment structure is unclear"},
+                        {"key": "in_scope", "answer": "Component and deployment view"},
+                    ],
+                },
+                {
+                    "round": 2,
+                    "responses": [
+                        {"key": "outcomes", "answer": "Clearer deployment understanding"},
+                    ],
+                },
+                {
+                    "round": 7,
+                    "responses": [
+                        {"key": "components_and_services", "answer": ["Member App", "Rewards API"]},
+                        {
+                            "key": "interfaces_and_integrations",
+                            "answer": ["Member App calls Rewards API"],
+                        },
+                        {
+                            "key": "runtime_boundaries",
+                            "answer": ["Rewards API runs separately from the UI"],
+                        },
+                    ],
+                },
+            ]
+        )
+
+        model = normalize_replay_to_model(replay)
+        rendered = render_deployment_model(model)
+
+        self.assertIn("Member App", rendered)
+        self.assertIn("Rewards API", rendered)
+        self.assertIn("Rewards API runs separately from the UI", rendered)
 
     def test_end_to_end_state_model_pipeline_from_replay(self) -> None:
         """Replay normalization should be able to produce the formal state-model artifact."""


### PR DESCRIPTION
## Summary
- add `deployment-model.md` as the first V2 component/deployment artifact path
- wire architecture updates so replay marks `deployment-model.md` stale when deployment inputs change
- document and test the end-to-end architecture-view to deployment-model rendering path

Closes #12