### PR TITLE
Implement V2 artifact lineage traceability

### DIFF
--- a/skills/specops/references/specops-model.md
+++ b/skills/specops/references/specops-model.md
@@ -93,6 +93,13 @@ The canonical project model is `specops-model.yaml`.
     - `to_id`
     - `link_type`
     - `basis`
+  - `artifact_lineage`
+    - `id`
+    - `from_id`
+    - `to_artifact`
+    - `artifact_section`
+    - `link_type`
+    - `basis`
 - `interaction_view`
   - `realization_objects`
     - `id`

--- a/src/specops_tools/discovery.py
+++ b/src/specops_tools/discovery.py
@@ -671,6 +671,60 @@ def _build_trace_links(
     }
 
 
+def _build_artifact_lineage(
+    requirement_objects: list[dict[str, Any]],
+    use_cases: list[dict[str, Any]],
+    domain_entity_objects: list[dict[str, Any]],
+    relationship_objects: list[dict[str, Any]],
+    business_rule_objects: list[dict[str, Any]],
+    state_entity_objects: list[dict[str, Any]],
+    state_transition_objects: list[dict[str, Any]],
+    trigger_objects: list[dict[str, Any]],
+    component_objects: list[dict[str, Any]],
+    interface_objects: list[dict[str, Any]],
+    runtime_boundary_objects: list[dict[str, Any]],
+    realization_objects: list[dict[str, Any]],
+    message_objects: list[dict[str, Any]],
+) -> list[dict[str, str]]:
+    """Build conservative lineage links from canonical objects to generated artifacts."""
+    lineage_specs = [
+        ("requirements-spec.md", "functional requirements", requirement_objects),
+        ("use-case-model.md", "use cases", use_cases),
+        ("domain-model.md", "domain entities", domain_entity_objects),
+        ("domain-model.md", "relationships", relationship_objects),
+        ("domain-model.md", "business rules", business_rule_objects),
+        ("interaction-model.md", "use-case realizations", realization_objects),
+        ("interaction-model.md", "message flows", message_objects),
+        ("deployment-model.md", "components", component_objects),
+        ("deployment-model.md", "interfaces and integrations", interface_objects),
+        ("deployment-model.md", "runtime boundaries", runtime_boundary_objects),
+        ("state-model.md", "state entities", state_entity_objects),
+        ("state-model.md", "state transitions", state_transition_objects),
+        ("state-model.md", "triggers and approvals", trigger_objects),
+    ]
+
+    artifact_lineage = []
+    for artifact_name, artifact_section, objects in lineage_specs:
+        artifact_slug = artifact_name.replace(".md", "").replace(".", "-")
+        section_slug = _slugify(artifact_section)
+        for item in objects:
+            source_id = item.get("id", "")
+            if not source_id:
+                continue
+            artifact_lineage.append(
+                {
+                    "id": f"trace-artifact-{artifact_slug}-{section_slug}-{source_id}",
+                    "from_id": source_id,
+                    "to_artifact": artifact_name,
+                    "artifact_section": artifact_section,
+                    "link_type": "artifact_lineage",
+                    "basis": f"canonical {artifact_section} object renders into {artifact_name}",
+                }
+            )
+
+    return artifact_lineage
+
+
 def _text_or_empty(value: Any) -> str:
     """Normalize a scalar answer into a string."""
     if value is None:
@@ -955,13 +1009,6 @@ def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
         "interface_ids": [item["id"] for item in interface_objects],
         "runtime_boundary_ids": [item["id"] for item in runtime_boundary_objects],
     }
-    traceability = _build_trace_links(
-        all_requirement_objects,
-        normalized_use_cases,
-        domain_entity_objects,
-        state_entity_objects,
-        component_objects,
-    )
     logical_view = _derive_logical_view(analysis_view)
     process_view = _derive_process_view(analysis_view)
     architecture_view = _derive_architecture_view(design_view)
@@ -969,6 +1016,28 @@ def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
         normalized_use_cases,
         normalized_actors,
         interface_objects,
+    )
+    traceability = _build_trace_links(
+        all_requirement_objects,
+        normalized_use_cases,
+        domain_entity_objects,
+        state_entity_objects,
+        component_objects,
+    )
+    traceability["artifact_lineage"] = _build_artifact_lineage(
+        all_requirement_objects,
+        normalized_use_cases,
+        domain_entity_objects,
+        relationship_objects,
+        business_rule_objects,
+        state_entity_objects,
+        state_transition_objects,
+        trigger_objects,
+        component_objects,
+        interface_objects,
+        runtime_boundary_objects,
+        interaction_view["realization_objects"],
+        interaction_view["message_objects"],
     )
 
     return {

--- a/src/specops_tools/readiness.py
+++ b/src/specops_tools/readiness.py
@@ -118,12 +118,15 @@ def identify_stale_artifacts(updates: list[dict[str, Any]]) -> list[str]:
     return sorted(stale_artifacts)
 
 
-def _linked_source_ids(links: list[dict[str, Any]]) -> set[str]:
+def _linked_source_ids(
+    links: list[dict[str, Any]],
+    source_key: str = "from_id",
+) -> set[str]:
     """Return source ids participating in a trace link collection."""
     return {
-        str(link.get("from_id"))
+        str(link.get(source_key))
         for link in links
-        if str(link.get("from_id", "")).strip()
+        if str(link.get(source_key, "")).strip()
     }
 
 
@@ -131,10 +134,12 @@ def _trace_family_result(
     expected_from_ids: list[str],
     links: list[dict[str, Any]],
     family: str,
+    *,
+    source_key: str = "from_id",
 ) -> dict[str, Any]:
     """Return validation details for one trace family."""
     expected = [item for item in expected_from_ids if item]
-    linked = _linked_source_ids(links)
+    linked = _linked_source_ids(links, source_key)
     missing = [item for item in expected if item not in linked]
 
     if not expected:
@@ -166,6 +171,21 @@ def evaluate_traceability(model: dict[str, Any]) -> dict[str, dict[str, Any]]:
         + model.get("process_view", {}).get("state_entity_objects", [])
     )
     design_objects = model.get("architecture_view", {}).get("component_objects", [])
+    artifact_source_objects = (
+        requirement_objects
+        + use_cases
+        + model.get("logical_view", {}).get("domain_entity_objects", [])
+        + model.get("logical_view", {}).get("relationship_objects", [])
+        + model.get("logical_view", {}).get("business_rule_objects", [])
+        + model.get("process_view", {}).get("state_entity_objects", [])
+        + model.get("process_view", {}).get("state_transition_objects", [])
+        + model.get("process_view", {}).get("trigger_objects", [])
+        + model.get("architecture_view", {}).get("component_objects", [])
+        + model.get("architecture_view", {}).get("interface_objects", [])
+        + model.get("architecture_view", {}).get("runtime_boundary_objects", [])
+        + model.get("interaction_view", {}).get("realization_objects", [])
+        + model.get("interaction_view", {}).get("message_objects", [])
+    )
 
     return {
         "requirement_to_use_case": _trace_family_result(
@@ -182,5 +202,10 @@ def evaluate_traceability(model: dict[str, Any]) -> dict[str, dict[str, Any]]:
             [item.get("id", "") for item in analysis_objects] if design_objects else [],
             traceability.get("analysis_to_design", []),
             "analysis_to_design",
+        ),
+        "artifact_lineage": _trace_family_result(
+            [item.get("id", "") for item in artifact_source_objects],
+            traceability.get("artifact_lineage", []),
+            "artifact_lineage",
         ),
     }

--- a/src/specops_tools/render.py
+++ b/src/specops_tools/render.py
@@ -139,6 +139,31 @@ def _traceability_section(
 """
 
 
+def _artifact_lineage_section(
+    title: str,
+    links: list[dict[str, Any]],
+    artifact_name: str,
+) -> str:
+    """Render artifact-lineage links for one generated artifact."""
+    relevant_links = [link for link in links if link.get("to_artifact") == artifact_name]
+    if not relevant_links:
+        return ""
+
+    rendered = []
+    for link in relevant_links:
+        rendered.append(
+            f"- `{link.get('id', 'trace')}` {link.get('from_id', 'unknown')} -> "
+            f"{link.get('to_artifact', artifact_name)}#{link.get('artifact_section', 'unspecified')} "
+            f"({link.get('basis', 'unspecified basis')})"
+        )
+
+    return f"""
+## {title}
+
+{"\n".join(rendered)}
+"""
+
+
 def _relationship_section(
     title: str,
     items: list[dict[str, Any]],
@@ -468,6 +493,11 @@ def render_domain_model(model: dict[str, Any]) -> str:
     "Use-Case To Domain Traceability",
     _filter_trace_links(traceability.get("use_case_to_analysis", []), domain_entity_ids),
 )}
+{_artifact_lineage_section(
+    "Artifact Lineage",
+    traceability.get("artifact_lineage", []),
+    "domain-model.md",
+)}
 """
 
 
@@ -482,6 +512,7 @@ def render_interaction_model(model: dict[str, Any]) -> str:
     """
     project = model.get("project", {})
     interaction_view = model.get("interaction_view", {})
+    traceability = model.get("traceability", {})
     realization_objects = interaction_view.get("realization_objects", [])
     message_objects = interaction_view.get("message_objects", [])
 
@@ -543,6 +574,11 @@ def render_interaction_model(model: dict[str, Any]) -> str:
 ## Message Flows
 
 {"\n".join(message_lines) or "- None"}
+{_artifact_lineage_section(
+    "Artifact Lineage",
+    traceability.get("artifact_lineage", []),
+    "interaction-model.md",
+)}
 """
 
 
@@ -558,6 +594,7 @@ def render_deployment_model(model: dict[str, Any]) -> str:
     project = model.get("project", {})
     design_view = model.get("design_view", {})
     architecture_view = model.get("architecture_view", {})
+    traceability = model.get("traceability", {})
     component_objects = design_view.get(
         "component_objects",
         architecture_view.get("component_objects", []),
@@ -595,6 +632,11 @@ def render_deployment_model(model: dict[str, Any]) -> str:
     "Runtime Boundaries",
     runtime_boundary_objects,
     architecture_view.get("runtime_boundaries", []),
+)}
+{_artifact_lineage_section(
+    "Artifact Lineage",
+    traceability.get("artifact_lineage", []),
+    "deployment-model.md",
 )}
 """
 
@@ -664,6 +706,11 @@ def render_state_model(model: dict[str, Any]) -> str:
         traceability.get("analysis_to_design", []),
         state_entity_ids | component_ids,
     ),
+)}
+{_artifact_lineage_section(
+    "Artifact Lineage",
+    traceability.get("artifact_lineage", []),
+    "state-model.md",
 )}
 """
 

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -546,6 +546,27 @@ class DiscoveryTests(unittest.TestCase):
             model["traceability"]["analysis_to_design"][0]["to_id"],
             "component-system-api",
         )
+        self.assertIn(
+            "domain-model.md",
+            {
+                link["to_artifact"]
+                for link in model["traceability"]["artifact_lineage"]
+            },
+        )
+        self.assertIn(
+            "interaction-model.md",
+            {
+                link["to_artifact"]
+                for link in model["traceability"]["artifact_lineage"]
+            },
+        )
+        self.assertIn(
+            "deployment-model.md",
+            {
+                link["to_artifact"]
+                for link in model["traceability"]["artifact_lineage"]
+            },
+        )
 
     def test_normalize_replay_to_model_with_real_fixture(self) -> None:
         """The checked-in interview fixture should normalize into the canonical V1.5 shape."""

--- a/tests/test_readiness.py
+++ b/tests/test_readiness.py
@@ -256,3 +256,15 @@ class ReadinessTests(unittest.TestCase):
             validation["analysis_to_design"]["missing_from_ids"],
             ["entity-system"],
         )
+        self.assertEqual(validation["artifact_lineage"]["status"], "blocked")
+        self.assertEqual(
+            validation["artifact_lineage"]["missing_from_ids"],
+            [
+                "functional-requirement-1",
+                "functional-requirement-2",
+                "approve-system",
+                "search-systems",
+                "entity-system",
+                "component-system-api",
+            ],
+        )

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -460,6 +460,20 @@ class RenderTests(unittest.TestCase):
         self.assertIn("A Member must have enough points.", rendered)
         self.assertIn("## Use-Case To Domain Traceability", rendered)
         self.assertIn("`trace-uc-analysis-1` uc-redeem -> entity-member", rendered)
+        model["traceability"]["artifact_lineage"] = [
+            {
+                "id": "trace-artifact-domain-1",
+                "from_id": "entity-member",
+                "to_artifact": "domain-model.md",
+                "artifact_section": "domain entities",
+                "basis": "canonical domain entities object renders into domain-model.md",
+            }
+        ]
+
+        rendered = render_domain_model(model)
+
+        self.assertIn("## Artifact Lineage", rendered)
+        self.assertIn("entity-member -> domain-model.md#domain entities", rendered)
 
     def test_render_all_includes_state_model_artifact(self) -> None:
         """Primary rendering should emit the formal state-model artifact."""
@@ -511,6 +525,25 @@ class RenderTests(unittest.TestCase):
         self.assertIn("## Message Flows", rendered)
         self.assertIn("Member App -> Rewards API", rendered)
         self.assertIn("(calls)", rendered)
+        model["traceability"] = {
+            "artifact_lineage": [
+                {
+                    "id": "trace-artifact-interaction-1",
+                    "from_id": "interaction-message-1",
+                    "to_artifact": "interaction-model.md",
+                    "artifact_section": "message flows",
+                    "basis": "canonical message flows object renders into interaction-model.md",
+                }
+            ]
+        }
+
+        rendered = render_interaction_model(model)
+
+        self.assertIn("## Artifact Lineage", rendered)
+        self.assertIn(
+            "interaction-message-1 -> interaction-model.md#message flows",
+            rendered,
+        )
 
     def test_end_to_end_interaction_model_pipeline_from_replay(self) -> None:
         """Replay normalization should be able to produce the formal interaction-model artifact."""
@@ -592,6 +625,25 @@ class RenderTests(unittest.TestCase):
         self.assertIn("Member App calls Rewards API", rendered)
         self.assertIn("## Runtime Boundaries", rendered)
         self.assertIn("Rewards API runs separately from the UI", rendered)
+        model["traceability"] = {
+            "artifact_lineage": [
+                {
+                    "id": "trace-artifact-deployment-1",
+                    "from_id": "component-member-app",
+                    "to_artifact": "deployment-model.md",
+                    "artifact_section": "components",
+                    "basis": "canonical components object renders into deployment-model.md",
+                }
+            ]
+        }
+
+        rendered = render_deployment_model(model)
+
+        self.assertIn("## Artifact Lineage", rendered)
+        self.assertIn(
+            "component-member-app -> deployment-model.md#components",
+            rendered,
+        )
 
     def test_end_to_end_deployment_model_pipeline_from_replay(self) -> None:
         """Replay normalization should be able to produce the formal deployment-model artifact."""


### PR DESCRIPTION
## Summary
- add canonical artifact-lineage links from normalized model objects to generated artifacts
- render artifact lineage in the formal domain, interaction, deployment, and state artifacts
- validate missing artifact lineage in replay traceability output

## Testing
- uv run python -m unittest tests.test_discovery tests.test_render tests.test_readiness
- uv run python -m unittest

Closes #13