### PR TITLE
Broaden V2 state model semantics

### DIFF
--- a/skills/specops/references/specops-model.md
+++ b/skills/specops/references/specops-model.md
@@ -169,6 +169,9 @@ The canonical project model is `specops-model.yaml`.
     - `from_state`
     - `to_state`
     - `trigger`
+    - `is_exception_flow`
+    - `is_terminal_transition`
+    - `constraint`
     - `trace`
   - `triggers_and_approvals`
   - `trigger_objects`
@@ -178,6 +181,8 @@ The canonical project model is `specops-model.yaml`.
     - `description`
     - `model_layer`: `analysis`
     - `approval_required`
+    - `constraint_type`
+    - `exceptional_behavior`
     - `trace`
 - `design_view` (authoritative source for design-layer objects)
   - `component_objects`

--- a/src/specops_tools/discovery.py
+++ b/src/specops_tools/discovery.py
@@ -272,39 +272,88 @@ def _normalize_state_entities(items: list[str]) -> list[dict[str, Any]]:
     return entities
 
 
+def _parse_state_transition_prefix(text: str) -> tuple[str, str]:
+    """Split a transition string into optional entity prefix and transition body."""
+    if ":" not in text:
+        return "", text
+    prefix, remainder = text.split(":", 1)
+    if "->" not in remainder:
+        return "", text
+    return prefix.strip(), remainder.strip()
+
+
+def _is_exception_state(state_name: str) -> bool:
+    """Return whether a state label clearly represents an exceptional path."""
+    normalized = _slugify(state_name)
+    return normalized in {
+        "rejected",
+        "cancelled",
+        "canceled",
+        "failed",
+        "error",
+        "exception",
+        "escalated",
+    }
+
+
+def _is_terminal_state(state_name: str) -> bool:
+    """Return whether a state label clearly represents a terminal lifecycle state."""
+    normalized = _slugify(state_name)
+    return normalized in {
+        "approved",
+        "fulfilled",
+        "completed",
+        "closed",
+        "cancelled",
+        "canceled",
+        "rejected",
+        "failed",
+        "inactive",
+        "archived",
+    }
+
+
 def _normalize_state_transitions(items: list[str]) -> list[dict[str, Any]]:
     """Convert transition strings into structured transition objects."""
     transitions = []
     for item in items:
         text = item.strip()
-        if "->" not in text:
+        entity_name, transition_text = _parse_state_transition_prefix(text)
+        if "->" not in transition_text:
             transitions.append(
                 {
                     "id": f"state-transition-{len(transitions) + 1}",
                     "description": text,
                     "model_layer": "analysis",
-                    "state_entity_id": "",
-                    "state_entity_name": "",
+                    "state_entity_id": f"state-entity-{_slugify(entity_name)}" if entity_name else "",
+                    "state_entity_name": entity_name,
                     "from_state": "",
                     "to_state": "",
                     "trigger": "",
+                    "is_exception_flow": False,
+                    "is_terminal_transition": False,
+                    "constraint": "",
                     "trace": {},
                 }
             )
             continue
 
-        states = [part.strip() for part in text.split("->") if part.strip()]
+        states = [part.strip() for part in transition_text.split("->") if part.strip()]
         for source_state, target_state in zip(states, states[1:]):
+            is_last_transition = target_state == states[-1]
             transitions.append(
                 {
                     "id": f"state-transition-{len(transitions) + 1}",
                     "description": text,
                     "model_layer": "analysis",
-                    "state_entity_id": "",
-                    "state_entity_name": "",
+                    "state_entity_id": f"state-entity-{_slugify(entity_name)}" if entity_name else "",
+                    "state_entity_name": entity_name,
                     "from_state": source_state,
                     "to_state": target_state,
                     "trigger": "",
+                    "is_exception_flow": _is_exception_state(target_state),
+                    "is_terminal_transition": is_last_transition and _is_terminal_state(target_state),
+                    "constraint": "",
                     "trace": {},
                 }
             )
@@ -331,6 +380,11 @@ def _normalize_triggers(items: list[str]) -> list[dict[str, Any]]:
                 "description": text,
                 "model_layer": "analysis",
                 "approval_required": "approval" in normalized,
+                "constraint_type": "approval" if "approval" in normalized else "event",
+                "exceptional_behavior": any(
+                    marker in normalized
+                    for marker in ("reject", "cancel", "fail", "error", "exception", "escalat")
+                ),
                 "trace": {},
             }
         )
@@ -799,6 +853,52 @@ def _build_interaction_view(
     }
 
 
+def _bind_state_semantics(
+    state_entity_objects: list[dict[str, Any]],
+    state_transition_objects: list[dict[str, Any]],
+    trigger_objects: list[dict[str, Any]],
+) -> None:
+    """Link transitions to explicit lifecycle owners and derive entity state lists."""
+    entity_id_by_name = {
+        _match_slug(item.get("name", "")): item.get("id", "")
+        for item in state_entity_objects
+        if item.get("name") and item.get("id")
+    }
+
+    for transition in state_transition_objects:
+        state_entity_name = transition.get("state_entity_name", "")
+        if state_entity_name and not transition.get("state_entity_id"):
+            transition["state_entity_id"] = entity_id_by_name.get(_match_slug(state_entity_name), "")
+
+        if not transition.get("state_entity_id") and len(state_entity_objects) == 1:
+            transition["state_entity_id"] = state_entity_objects[0]["id"]
+            transition["state_entity_name"] = state_entity_objects[0]["name"]
+
+        trigger_text = " ".join(
+            part for part in (transition.get("description", ""), transition.get("constraint", "")) if part
+        )
+        normalized_trigger_text = trigger_text.lower()
+        for trigger in trigger_objects:
+            event_name = trigger.get("event_name", "")
+            if event_name and event_name.lower() in normalized_trigger_text:
+                transition["trigger"] = event_name
+                break
+
+    states_by_entity_id: dict[str, list[str]] = {
+        item.get("id", ""): [] for item in state_entity_objects if item.get("id")
+    }
+    for transition in state_transition_objects:
+        entity_id = transition.get("state_entity_id", "")
+        if not entity_id or entity_id not in states_by_entity_id:
+            continue
+        for state_name in (transition.get("from_state", ""), transition.get("to_state", "")):
+            if state_name and state_name not in states_by_entity_id[entity_id]:
+                states_by_entity_id[entity_id].append(state_name)
+
+    for entity in state_entity_objects:
+        entity["states"] = states_by_entity_id.get(entity.get("id", ""), [])
+
+
 def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
     """Normalize replay output into a canonical SpecOps model shape.
 
@@ -910,6 +1010,11 @@ def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
         _normalize_triggers(_ensure_list(round_6.get("triggers_and_approvals"))),
         6,
         "triggers_and_approvals",
+    )
+    _bind_state_semantics(
+        state_entity_objects,
+        state_transition_objects,
+        trigger_objects,
     )
     component_objects = _with_trace(
         _normalize_components(_ensure_list(round_7.get("components_and_services"))),

--- a/src/specops_tools/render.py
+++ b/src/specops_tools/render.py
@@ -75,6 +75,8 @@ def _object_name_section(
             line = f"- `{item.get('id', 'item')}` {item.get('name', 'Unnamed')}"
             if item.get("attributes"):
                 line = f"{line} [{', '.join(item['attributes'])}]"
+            if item.get("states"):
+                line = f"{line} {{states: {', '.join(item['states'])}}}"
             if item.get("description"):
                 line = f"{line}: {item['description']}"
             if trace := item.get("trace"):
@@ -158,6 +160,95 @@ def _relationship_section(
                     f"roles: {item.get('source_role_name', '')} / {item.get('target_role_name', '')}"
                 )
             line = f"- `{item.get('id', 'item')}` {item.get('description', '')}"
+            if semantic_bits:
+                line = f"{line} ({'; '.join(semantic_bits)})"
+            if trace := item.get("trace"):
+                line = (
+                    f"{line} [source: round {trace.get('source_round')} "
+                    f"{trace.get('source_key')}]"
+                )
+            rendered.append(line)
+        return f"""
+## {title}
+
+{"\n".join(rendered)}
+"""
+    return _named_section(title, fallback)
+
+
+def _state_transition_section(
+    title: str,
+    items: list[dict[str, Any]],
+    fallback: list[str],
+) -> str:
+    """Render transitions with richer state-machine semantics when present."""
+    if items:
+        rendered = []
+        for item in items:
+            from_state = item.get("from_state", "")
+            to_state = item.get("to_state", "")
+            if from_state or to_state:
+                line = (
+                    f"- `{item.get('id', 'item')}` {from_state or '?'} -> {to_state or '?'}"
+                )
+            else:
+                text = item.get("description") or item.get("text") or ""
+                line = f"- `{item.get('id', 'item')}` {text}"
+
+            semantic_bits = []
+            if item.get("state_entity_name"):
+                semantic_bits.append(f"entity: {item['state_entity_name']}")
+            if item.get("trigger"):
+                semantic_bits.append(f"trigger: {item['trigger']}")
+            if item.get("constraint"):
+                semantic_bits.append(f"constraint: {item['constraint']}")
+            if item.get("is_exception_flow"):
+                semantic_bits.append("exception flow")
+            if item.get("is_terminal_transition"):
+                semantic_bits.append("terminal transition")
+            if semantic_bits:
+                line = f"{line} ({'; '.join(semantic_bits)})"
+
+            if trace := item.get("trace"):
+                line = (
+                    f"{line} [source: round {trace.get('source_round')} "
+                    f"{trace.get('source_key')}]"
+                )
+            rendered.append(line)
+        return f"""
+## {title}
+
+{"\n".join(rendered)}
+"""
+    return _named_section(title, fallback)
+
+
+def _trigger_section(
+    title: str,
+    items: list[dict[str, Any]],
+    fallback: list[str],
+) -> str:
+    """Render lifecycle constraints and triggers with explicit process semantics."""
+    if items:
+        rendered = []
+        for item in items:
+            text = (
+                item.get("description")
+                or item.get("text")
+                or item.get("outcome")
+                or item.get("event_name")
+                or ""
+            )
+            line = f"- `{item.get('id', 'item')}` {text}"
+            semantic_bits = []
+            if item.get("event_name"):
+                semantic_bits.append(f"event: {item['event_name']}")
+            if item.get("constraint_type"):
+                semantic_bits.append(f"type: {item['constraint_type']}")
+            if item.get("approval_required"):
+                semantic_bits.append("approval required")
+            if item.get("exceptional_behavior"):
+                semantic_bits.append("exceptional behavior")
             if semantic_bits:
                 line = f"{line} ({'; '.join(semantic_bits)})"
             if trace := item.get("trace"):
@@ -644,12 +735,12 @@ def render_state_model(model: dict[str, Any]) -> str:
     state_entity_objects,
     process_view.get("state_entities", []),
 )}
-{_object_text_section(
+{_state_transition_section(
     "State Transitions",
     state_transition_objects,
     process_view.get("states_and_transitions", []),
 )}
-{_object_text_section(
+{_trigger_section(
     "Triggers and Approvals",
     trigger_objects,
     process_view.get("triggers_and_approvals", []),

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -164,8 +164,20 @@ class DiscoveryTests(unittest.TestCase):
             "Submitted",
         )
         self.assertEqual(
+            model["process_view"]["state_transition_objects"][0]["state_entity_id"],
+            "state-entity-approval-request",
+        )
+        self.assertEqual(
+            model["process_view"]["state_entity_objects"][0]["states"],
+            ["Draft", "Submitted", "Approved"],
+        )
+        self.assertEqual(
             model["process_view"]["trigger_objects"][0]["event_name"],
             "Submission",
+        )
+        self.assertEqual(
+            model["process_view"]["trigger_objects"][0]["constraint_type"],
+            "event",
         )
         self.assertIn("Web app", model["architecture_view"]["components_and_services"])
         self.assertEqual(
@@ -568,4 +580,43 @@ class DiscoveryTests(unittest.TestCase):
         self.assertEqual(model["logical_view"]["domain_entities"], [])
         self.assertEqual(model["logical_view"]["relationship_objects"], [])
         self.assertEqual(model["process_view"]["state_entities"], [])
+
+    def test_normalize_replay_to_model_enriches_state_machine_semantics(self) -> None:
+        """State normalization should derive lifecycle semantics when the source text is explicit."""
+        replay = replay_session(
+            [
+                {
+                    "round": 6,
+                    "responses": [
+                        {"key": "state_entities", "answer": ["Approval Request"]},
+                        {
+                            "key": "states_and_transitions",
+                            "answer": [
+                                "Approval Request: Draft -> Submitted -> Approved",
+                                "Approval Request: Submitted -> Rejected",
+                            ],
+                        },
+                        {
+                            "key": "triggers_and_approvals",
+                            "answer": [
+                                "Submission requires manager approval",
+                                "Rejection event moves request to Rejected",
+                            ],
+                        },
+                    ],
+                },
+            ]
+        )
+
+        model = normalize_replay_to_model(replay)
+        transitions = model["process_view"]["state_transition_objects"]
+        triggers = model["process_view"]["trigger_objects"]
+
+        self.assertEqual(transitions[0]["state_entity_name"], "Approval Request")
+        self.assertEqual(transitions[1]["is_terminal_transition"], True)
+        self.assertEqual(transitions[2]["is_exception_flow"], True)
+        self.assertEqual(transitions[2]["is_terminal_transition"], True)
+        self.assertEqual(triggers[0]["approval_required"], True)
+        self.assertEqual(triggers[0]["constraint_type"], "approval")
+        self.assertEqual(triggers[1]["exceptional_behavior"], True)
         self.assertEqual(model["architecture_view"]["runtime_boundary_objects"], [])

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -344,20 +344,44 @@ class RenderTests(unittest.TestCase):
                 {
                     "id": "state-entity-redemption-request",
                     "name": "Redemption Request",
+                    "states": ["Requested", "Approved", "Fulfilled"],
                     "trace": {"source_round": 6, "source_key": "state_entities"},
                 }
             ],
             "state_transition_objects": [
                 {
                     "id": "state-transition-1",
-                    "text": "Requested -> Approved -> Fulfilled",
+                    "description": "Requested -> Approved -> Fulfilled",
+                    "state_entity_name": "Redemption Request",
+                    "from_state": "Requested",
+                    "to_state": "Approved",
+                    "trigger": "Approval event",
+                    "constraint": "manager approval",
+                    "is_exception_flow": False,
+                    "is_terminal_transition": False,
+                    "trace": {"source_round": 6, "source_key": "states_and_transitions"},
+                },
+                {
+                    "id": "state-transition-2",
+                    "description": "Approved -> Fulfilled",
+                    "state_entity_name": "Redemption Request",
+                    "from_state": "Approved",
+                    "to_state": "Fulfilled",
+                    "trigger": "",
+                    "constraint": "",
+                    "is_exception_flow": False,
+                    "is_terminal_transition": True,
                     "trace": {"source_round": 6, "source_key": "states_and_transitions"},
                 }
             ],
             "trigger_objects": [
                 {
                     "id": "trigger-1",
-                    "text": "Approval event moves request to Approved.",
+                    "description": "Approval event moves request to Approved.",
+                    "event_name": "Approval event",
+                    "constraint_type": "approval",
+                    "approval_required": True,
+                    "exceptional_behavior": False,
                     "trace": {"source_round": 6, "source_key": "triggers_and_approvals"},
                 }
             ],
@@ -395,8 +419,17 @@ class RenderTests(unittest.TestCase):
         self.assertIn("# State Model", rendered)
         self.assertIn("## State Entities", rendered)
         self.assertIn("`state-entity-redemption-request` Redemption Request", rendered)
+        self.assertIn("{states: Requested, Approved, Fulfilled}", rendered)
         self.assertIn("## State Transitions", rendered)
-        self.assertIn("Requested -> Approved -> Fulfilled", rendered)
+        self.assertIn("Requested -> Approved", rendered)
+        self.assertIn("entity: Redemption Request", rendered)
+        self.assertIn("trigger: Approval event", rendered)
+        self.assertIn("constraint: manager approval", rendered)
+        self.assertIn("terminal transition", rendered)
+        self.assertIn("## Triggers and Approvals", rendered)
+        self.assertIn("Approval event moves request to Approved.", rendered)
+        self.assertIn("type: approval", rendered)
+        self.assertIn("approval required", rendered)
         self.assertIn("## Use-Case To State Traceability", rendered)
         self.assertIn("`trace-uc-analysis-1` uc-redeem -> state-entity-redemption-request", rendered)
         self.assertIn("## State To Design Traceability", rendered)
@@ -692,7 +725,8 @@ class RenderTests(unittest.TestCase):
         rendered = render_state_model(model)
 
         self.assertIn("Approval Request", rendered)
-        self.assertIn("Draft -> Submitted -> Approved", rendered)
+        self.assertIn("Draft -> Submitted", rendered)
+        self.assertIn("Submitted -> Approved", rendered)
 
     def test_end_to_end_domain_model_pipeline_from_replay(self) -> None:
         """Replay normalization should be able to produce the formal domain-model artifact."""


### PR DESCRIPTION
## Summary
- broaden canonical process semantics with richer state-transition and trigger metadata
- derive lifecycle owner state lists and explicit transition semantics during normalization
- render the richer state-machine semantics directly in `state-model.md`

## Testing
- uv run python -m unittest tests.test_discovery tests.test_render
- uv run python -m unittest

Closes #15