### PR TITLE
Support formal artifact rendering without UCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Common commands:
 uv run python -m unittest
 uv run python -m specops_tools.ucp_cli --model examples/loyalty-platform/specops-model.json
 uv run python -m specops_tools.render_cli --model examples/loyalty-platform/specops-model.json --output-dir /tmp/specops-out
+uv run python -m specops_tools.render_cli --model examples/loyalty-platform/specops-model.json --output-dir /tmp/specops-formal --artifact-family formal
 ```
 
 YAML parsing is optional and intentionally not installed by default. If you want the CLI tools to

--- a/src/specops_tools/render.py
+++ b/src/specops_tools/render.py
@@ -815,7 +815,20 @@ def render_all(model: dict[str, Any]) -> dict[str, str]:
     Returns:
         Mapping of filename to rendered content.
     """
-    ucp_results = calculate_ucp(model)
+    outputs = render_formal_artifacts(model)
+    outputs.update(render_ucp_artifact(model))
+    return outputs
+
+
+def render_formal_artifacts(model: dict[str, Any]) -> dict[str, str]:
+    """Render the formal artifact family without UCP output.
+
+    Args:
+        model: Canonical SpecOps model.
+
+    Returns:
+        Mapping of filename to rendered content.
+    """
     return {
         "requirements-spec.md": render_requirements_spec(model),
         "use-case-model.md": render_use_case_model(model),
@@ -823,5 +836,41 @@ def render_all(model: dict[str, Any]) -> dict[str, str]:
         "interaction-model.md": render_interaction_model(model),
         "deployment-model.md": render_deployment_model(model),
         "state-model.md": render_state_model(model),
+    }
+
+
+def render_ucp_artifact(model: dict[str, Any]) -> dict[str, str]:
+    """Render only the strict UCP estimate artifact.
+
+    Args:
+        model: Canonical SpecOps model.
+
+    Returns:
+        Mapping of filename to rendered content.
+    """
+    ucp_results = calculate_ucp(model)
+    return {
         "ucp-estimate.md": render_ucp_markdown(model, ucp_results),
     }
+
+
+def render_artifact_family(model: dict[str, Any], artifact_family: str) -> dict[str, str]:
+    """Render one explicit artifact family.
+
+    Args:
+        model: Canonical SpecOps model.
+        artifact_family: One of `all`, `formal`, or `ucp`.
+
+    Returns:
+        Mapping of filename to rendered content.
+
+    Raises:
+        ValueError: If the requested family is unsupported.
+    """
+    if artifact_family == "all":
+        return render_all(model)
+    if artifact_family == "formal":
+        return render_formal_artifacts(model)
+    if artifact_family == "ucp":
+        return render_ucp_artifact(model)
+    raise ValueError(f"Unsupported artifact family '{artifact_family}'.")

--- a/src/specops_tools/render_cli.py
+++ b/src/specops_tools/render_cli.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-from .render import render_all
+from .render import render_artifact_family
 from .structured_io import load_model, write_text
 
 
@@ -18,10 +18,16 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="Render SpecOps Markdown artifacts from a model.")
     parser.add_argument("--model", required=True, help="Path to the model file.")
     parser.add_argument("--output-dir", required=True, help="Output directory for rendered files.")
+    parser.add_argument(
+        "--artifact-family",
+        choices=("all", "formal", "ucp"),
+        default="all",
+        help="Artifact family to render. Use 'formal' to skip strict UCP output.",
+    )
     args = parser.parse_args()
 
     model = load_model(args.model)
-    outputs = render_all(model)
+    outputs = render_artifact_family(model, args.artifact_family)
 
     output_dir = Path(args.output_dir)
     for filename, content in outputs.items():
@@ -32,4 +38,3 @@ def main() -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -2,14 +2,21 @@
 
 from __future__ import annotations
 
+import json
 import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
 
 from specops_tools.discovery import normalize_replay_to_model
 from specops_tools.interview import replay_session
+from specops_tools.render_cli import main as render_cli_main
 from specops_tools.render import (
     render_all,
+    render_artifact_family,
     render_deployment_model,
     render_domain_model,
+    render_formal_artifacts,
     render_interaction_model,
     render_requirements_spec,
     render_state_model,
@@ -520,6 +527,66 @@ class RenderTests(unittest.TestCase):
         self.assertTrue(outputs["domain-model.md"].startswith("# Domain Model"))
         self.assertTrue(outputs["interaction-model.md"].startswith("# Interaction Model"))
         self.assertTrue(outputs["state-model.md"].startswith("# State Model"))
+
+    def test_render_formal_artifacts_skips_ucp_output(self) -> None:
+        """Formal rendering should not require or emit the strict UCP artifact."""
+        model = build_model()
+        model["actors"][0]["complexity"] = "unclassified"
+
+        outputs = render_formal_artifacts(model)
+
+        self.assertIn("domain-model.md", outputs)
+        self.assertIn("interaction-model.md", outputs)
+        self.assertIn("deployment-model.md", outputs)
+        self.assertIn("state-model.md", outputs)
+        self.assertNotIn("ucp-estimate.md", outputs)
+
+    def test_render_artifact_family_supports_formal_selection(self) -> None:
+        """Artifact-family rendering should allow explicit formal-only selection."""
+        model = build_model()
+        model["actors"][0]["complexity"] = "unclassified"
+
+        outputs = render_artifact_family(model, "formal")
+
+        self.assertEqual(set(outputs), {
+            "requirements-spec.md",
+            "use-case-model.md",
+            "domain-model.md",
+            "interaction-model.md",
+            "deployment-model.md",
+            "state-model.md",
+        })
+
+    def test_render_cli_supports_formal_artifact_family(self) -> None:
+        """The renderer CLI should support formal-only output without UCP rendering."""
+        model = build_model()
+        model["actors"][0]["complexity"] = "unclassified"
+
+        with TemporaryDirectory() as temp_dir:
+            model_path = Path(temp_dir) / "model.json"
+            output_dir = Path(temp_dir) / "out"
+            model_path.write_text(json.dumps(model), encoding="utf-8")
+
+            with patch(
+                "sys.argv",
+                [
+                    "render_cli",
+                    "--model",
+                    str(model_path),
+                    "--output-dir",
+                    str(output_dir),
+                    "--artifact-family",
+                    "formal",
+                ],
+            ):
+                exit_code = render_cli_main()
+
+            self.assertEqual(exit_code, 0)
+            self.assertTrue((output_dir / "domain-model.md").exists())
+            self.assertTrue((output_dir / "interaction-model.md").exists())
+            self.assertTrue((output_dir / "deployment-model.md").exists())
+            self.assertTrue((output_dir / "state-model.md").exists())
+            self.assertFalse((output_dir / "ucp-estimate.md").exists())
 
     def test_interaction_model_render_includes_realizations_and_messages(self) -> None:
         """Interaction-model rendering should surface use-case realizations and message flows."""


### PR DESCRIPTION
## Summary
- add explicit artifact-family rendering so the formal artifacts can be rendered without 
- keep the strict UCP path separate rather than inventing fallback classifications
- expose artifact-family selection in the renderer CLI and document the formal-only command

## Testing
- uv run python -m unittest tests.test_render
- uv run python -m unittest

Closes #79