### PR TITLE
Add interview-to-formal artifact pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ uv run python -m unittest
 uv run python -m specops_tools.ucp_cli --model examples/loyalty-platform/specops-model.json
 uv run python -m specops_tools.render_cli --model examples/loyalty-platform/specops-model.json --output-dir /tmp/specops-out
 uv run python -m specops_tools.render_cli --model examples/loyalty-platform/specops-model.json --output-dir /tmp/specops-formal --artifact-family formal
+uv run python -m specops_tools.interview_to_formal_cli --input tests/fixtures/it_systems_inventory_session.json --output-dir /tmp/specops-from-interview --write-model /tmp/specops-from-interview/specops-model.json
 ```
 
 YAML parsing is optional and intentionally not installed by default. If you want the CLI tools to

--- a/src/specops_tools/interview_to_formal_cli.py
+++ b/src/specops_tools/interview_to_formal_cli.py
@@ -1,0 +1,68 @@
+"""CLI for generating formal SpecOps artifacts directly from an interview fixture."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from .discovery import normalize_replay_to_model
+from .interview import replay_session, replay_session_with_updates
+from .render import render_artifact_family
+from .structured_io import write_text
+
+
+def _write_model(path: Path, model: dict[str, object]) -> None:
+    """Write the normalized canonical model as JSON."""
+    write_text(path, json.dumps(model, indent=2, sort_keys=True))
+
+
+def main() -> int:
+    """Run the interview-to-formal-artifacts pipeline CLI.
+
+    Returns:
+        Process exit code.
+    """
+    parser = argparse.ArgumentParser(
+        description="Replay an interview fixture and render the formal SpecOps artifacts."
+    )
+    parser.add_argument("--input", required=True, help="Path to the interview fixture JSON file.")
+    parser.add_argument(
+        "--updates",
+        help="Optional path to a JSON file containing targeted round updates.",
+    )
+    parser.add_argument("--output-dir", required=True, help="Output directory for rendered files.")
+    parser.add_argument(
+        "--write-model",
+        help="Optional path where the normalized canonical model should be written.",
+    )
+    args = parser.parse_args()
+
+    with open(args.input, "r", encoding="utf-8") as handle:
+        fixture = json.load(handle)
+
+    rounds = fixture.get("rounds", [])
+    if args.updates:
+        with open(args.updates, "r", encoding="utf-8") as handle:
+            update_fixture = json.load(handle)
+        replay = replay_session_with_updates(rounds, update_fixture.get("rounds", []))
+    else:
+        replay = replay_session(rounds)
+
+    model = normalize_replay_to_model(replay)
+    outputs = render_artifact_family(model, "formal")
+
+    output_dir = Path(args.output_dir)
+    for filename, content in outputs.items():
+        write_text(output_dir / filename, content)
+        print(output_dir / filename)
+
+    if args.write_model:
+        _write_model(Path(args.write_model), model)
+        print(Path(args.write_model))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_interview.py
+++ b/tests/test_interview.py
@@ -371,6 +371,45 @@ class InterviewHarnessTests(unittest.TestCase):
         self.assertIn("domain_entities", payload["readiness_details"]["logical"]["required_missing"])
         self.assertEqual(payload["traceability_validation"]["requirement_to_use_case"]["status"], "blocked")
 
+    def test_interview_to_formal_cli_renders_formal_artifacts_from_fixture(self) -> None:
+        """The direct interview-to-formal CLI should render the formal artifact family."""
+        repo_root = Path(__file__).resolve().parents[1]
+        fixture_path = repo_root / "tests" / "fixtures" / "it_systems_inventory_session.json"
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_dir = Path(temp_dir) / "formal-out"
+            model_path = Path(temp_dir) / "specops-model.json"
+
+            completed = subprocess.run(
+                [
+                    "uv",
+                    "run",
+                    "python",
+                    "-m",
+                    "specops_tools.interview_to_formal_cli",
+                    "--input",
+                    str(fixture_path),
+                    "--output-dir",
+                    str(output_dir),
+                    "--write-model",
+                    str(model_path),
+                ],
+                text=True,
+                capture_output=True,
+                check=True,
+                cwd=repo_root,
+            )
+
+            self.assertIn("domain-model.md", completed.stdout)
+            self.assertTrue((output_dir / "requirements-spec.md").exists())
+            self.assertTrue((output_dir / "use-case-model.md").exists())
+            self.assertTrue((output_dir / "domain-model.md").exists())
+            self.assertTrue((output_dir / "interaction-model.md").exists())
+            self.assertTrue((output_dir / "deployment-model.md").exists())
+            self.assertTrue((output_dir / "state-model.md").exists())
+            self.assertFalse((output_dir / "ucp-estimate.md").exists())
+            self.assertTrue(model_path.exists())
+
     def test_replay_cli_applies_updates_fixture(self) -> None:
         """The replay CLI should support targeted updates without replay restarts."""
         repo_root = Path(__file__).resolve().parents[1]


### PR DESCRIPTION
## Summary
- add a first-class CLI for interview fixture -> replay -> normalized model -> formal artifacts
- support optional model export from that pipeline
- add end-to-end coverage against the checked-in CMDB interview fixture

## Testing
- uv run python -m unittest tests.test_interview tests.test_render
- uv run python -m unittest

Closes #80