### PR TITLE
Make CMDB fixture full-bundle ready

### DIFF
--- a/tests/fixtures/it_systems_inventory_session.json
+++ b/tests/fixtures/it_systems_inventory_session.json
@@ -124,13 +124,34 @@
       "round": 5,
       "responses": [
         {
-          "key": "actor_complexity",
+          "key": "domain_entities",
           "answer": [
-            "IT Business Owner: Simple",
-            "Technical Owner: Simple",
-            "Enterprise Architect: Simple",
-            "Procurement / Security / Finance / Application Owner users: Simple",
-            "Downstream API consumers / external reporting systems: Complex"
+            "System",
+            "Risk Assessment",
+            "Cost Record",
+            "Capability",
+            "Contract",
+            "Integration"
+          ]
+        },
+        {
+          "key": "relationships",
+          "answer": [
+            "A System has one Business Owner",
+            "A System has one Technical Owner",
+            "A System has many Integrations",
+            "A System has many Capabilities",
+            "A System has one Contract",
+            "A System has many Risk Assessments",
+            "A System has many Cost Records"
+          ]
+        },
+        {
+          "key": "business_rules",
+          "answer": [
+            "A System must have a business owner before it becomes Active.",
+            "A System lifecycle state change requires approval for deprecation.",
+            "A System must record vendor and contract dates."
           ]
         }
       ]
@@ -139,17 +160,104 @@
       "round": 6,
       "responses": [
         {
+          "key": "state_entities",
+          "answer": [
+            "System"
+          ]
+        },
+        {
+          "key": "states_and_transitions",
+          "answer": [
+            "System: Proposed -> Active -> Retiring -> Retired",
+            "System: Active -> Deprecated"
+          ]
+        },
+        {
+          "key": "triggers_and_approvals",
+          "answer": [
+            "Deprecation approval requires enterprise architect review",
+            "Contract expiry triggers lifecycle review"
+          ]
+        }
+      ]
+    },
+    {
+      "round": 7,
+      "responses": [
+        {
+          "key": "components_and_services",
+          "answer": [
+            "System Inventory Web App",
+            "System Inventory API",
+            "Reporting Consumers"
+          ]
+        },
+        {
+          "key": "interfaces_and_integrations",
+          "answer": [
+            "System Inventory Web App calls System Inventory API",
+            "System Inventory API sends Reporting Consumers"
+          ]
+        },
+        {
+          "key": "runtime_boundaries",
+          "answer": [
+            "System Inventory API runs separately from the UI"
+          ]
+        }
+      ]
+    },
+    {
+      "round": 8,
+      "responses": [
+        {
+          "key": "actor_complexity",
+          "answer": [
+            "Business owners: Complex",
+            "technical owners: Complex",
+            "enterprise architects: Complex",
+            "procurement: Average",
+            "security: Average",
+            "finance: Average",
+            "application owners: Complex",
+            "integration system owners: Average"
+          ]
+        }
+      ]
+    },
+    {
+      "round": 9,
+      "responses": [
+        {
           "key": "use_case_complexity",
           "answer": [
-            "register a system: Simple",
+            "Register a system: Average",
             "edit metadata: Simple",
             "compare overlapping systems: Average",
-            "track lifecycle state: Simple",
-            "review risks and costs: Simple",
-            "approve deprecation / stage gates: Simple",
-            "report portfolio gaps: Simple",
-            "expose/export data by API: Complex"
+            "track lifecycle state: Average",
+            "review risks: Simple",
+            "see costs: Simple",
+            "approve deprecation: Average",
+            "report portfolio gaps: Average"
           ]
+        }
+      ]
+    },
+    {
+      "round": 10,
+      "responses": [
+        {
+          "key": "technical",
+          "answer": "distributed system: 3\nresponse time: 2\nend-user efficiency: 4\ncomplex internal processing: 2\nreusability: 3\nease of installation: 2\nease of use: 4\nportability: 2\nease of change: 4\nconcurrency: 2\nsecurity: 4\nthird-party access: 4\nspecial user training: 1"
+        }
+      ]
+    },
+    {
+      "round": 11,
+      "responses": [
+        {
+          "key": "environmental",
+          "answer": "team familiarity: 3\napplication experience: 3\narchitecture experience: 3\nanalyst capability: 4\nmotivation: 4\nrequirements stability: 3\npart-time staffing: 1\nplatform difficulty: 2"
         }
       ]
     }

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -598,9 +598,9 @@ class DiscoveryTests(unittest.TestCase):
         self.assertEqual(model["actors"][0]["name"], "Business owners")
         self.assertEqual(model["actors"][0]["type"], "human")
         self.assertEqual(model["use_cases"][0]["name"], "Register a system")
-        self.assertEqual(model["logical_view"]["domain_entities"], [])
-        self.assertEqual(model["logical_view"]["relationship_objects"], [])
-        self.assertEqual(model["process_view"]["state_entities"], [])
+        self.assertIn("System", model["logical_view"]["domain_entities"])
+        self.assertGreater(len(model["logical_view"]["relationship_objects"]), 0)
+        self.assertIn("System", model["process_view"]["state_entities"])
 
     def test_normalize_replay_to_model_enriches_state_machine_semantics(self) -> None:
         """State normalization should derive lifecycle semantics when the source text is explicit."""

--- a/tests/test_interview.py
+++ b/tests/test_interview.py
@@ -331,8 +331,8 @@ class InterviewHarnessTests(unittest.TestCase):
         )
 
         payload = json.loads(completed.stdout)
-        self.assertEqual(payload["last_round"], 9)
-        self.assertEqual(payload["next_round"]["number"], 10)
+        self.assertEqual(payload["last_round"], 11)
+        self.assertIsNone(payload["next_round"])
         self.assertEqual(
             payload["transcript"][0]["responses"][0]["label"],
             "Idea",
@@ -358,18 +358,19 @@ class InterviewHarnessTests(unittest.TestCase):
             payload["merged_answers"]["round_4"]["metadata_fields"],
         )
         self.assertIn(
-            "IT Business Owner: Simple",
+            "Business owners: Complex",
             payload["merged_answers"]["round_8"]["actor_complexity"],
         )
         self.assertIn(
-            "expose/export data by API: Complex",
+            "report portfolio gaps: Average",
             payload["merged_answers"]["round_9"]["use_case_complexity"],
         )
-        self.assertEqual(payload["readiness"]["logical"], "blocked")
-        self.assertEqual(payload["readiness"]["process"], "blocked")
-        self.assertEqual(payload["readiness"]["architecture"], "blocked")
-        self.assertIn("domain_entities", payload["readiness_details"]["logical"]["required_missing"])
-        self.assertEqual(payload["traceability_validation"]["requirement_to_use_case"]["status"], "blocked")
+        self.assertEqual(payload["readiness"]["logical"], "ready")
+        self.assertEqual(payload["readiness"]["process"], "ready")
+        self.assertEqual(payload["readiness"]["architecture"], "ready")
+        self.assertEqual(payload["readiness"]["ucp"], "ready")
+        self.assertEqual(payload["readiness_details"]["logical"]["required_missing"], [])
+        self.assertEqual(payload["traceability_validation"]["artifact_lineage"]["status"], "ready")
 
     def test_interview_to_formal_cli_renders_formal_artifacts_from_fixture(self) -> None:
         """The direct interview-to-formal CLI should render the formal artifact family."""

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -588,6 +588,23 @@ class RenderTests(unittest.TestCase):
             self.assertTrue((output_dir / "state-model.md").exists())
             self.assertFalse((output_dir / "ucp-estimate.md").exists())
 
+    def test_render_all_supports_real_cmdb_fixture(self) -> None:
+        """The checked-in CMDB fixture should render the full current bundle, including UCP."""
+        repo_root = Path(__file__).resolve().parents[1]
+        fixture_path = repo_root / "tests" / "fixtures" / "it_systems_inventory_session.json"
+        fixture = json.loads(fixture_path.read_text())
+
+        replay = replay_session(fixture["rounds"])
+        model = normalize_replay_to_model(replay)
+        outputs = render_all(model)
+
+        self.assertIn("domain-model.md", outputs)
+        self.assertIn("interaction-model.md", outputs)
+        self.assertIn("deployment-model.md", outputs)
+        self.assertIn("state-model.md", outputs)
+        self.assertIn("ucp-estimate.md", outputs)
+        self.assertTrue(outputs["ucp-estimate.md"].startswith("# UCP Estimate"))
+
     def test_interaction_model_render_includes_realizations_and_messages(self) -> None:
         """Interaction-model rendering should surface use-case realizations and message flows."""
         model = build_model()


### PR DESCRIPTION
## Summary
- upgrade the checked-in CMDB fixture to the current 11-round interview contract
- complete strict UCP classifications and factor inputs so the fixture supports the full bundle
- add regression coverage proving replay -> normalize -> render_all works from the real fixture

## Testing
- uv run python -m unittest tests.test_interview tests.test_render
- uv run python -m unittest

Closes #78