### PR TITLE
Add Mermaid domain diagram rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ uv run python -m unittest
 uv run python -m specops_tools.ucp_cli --model examples/loyalty-platform/specops-model.json
 uv run python -m specops_tools.render_cli --model examples/loyalty-platform/specops-model.json --output-dir /tmp/specops-out
 uv run python -m specops_tools.render_cli --model examples/loyalty-platform/specops-model.json --output-dir /tmp/specops-formal --artifact-family formal
+uv run python -m specops_tools.render_cli --model examples/it-systems-inventory/specops-model.json --output-dir /tmp/specops-mermaid --artifact-family domain-mermaid
 uv run python -m specops_tools.interview_to_formal_cli --input tests/fixtures/it_systems_inventory_session.json --output-dir /tmp/specops-from-interview --write-model /tmp/specops-from-interview/specops-model.json
 ```
 

--- a/src/specops_tools/render.py
+++ b/src/specops_tools/render.py
@@ -592,6 +592,81 @@ def render_domain_model(model: dict[str, Any]) -> str:
 """
 
 
+def _mermaid_class_name(name: str, fallback_id: str) -> str:
+    """Return a Mermaid-safe class identifier."""
+    candidate = "".join(char if char.isalnum() else "_" for char in name.strip())
+    if not candidate.strip("_"):
+        candidate = "".join(char if char.isalnum() else "_" for char in fallback_id)
+    if candidate and candidate[0].isdigit():
+        candidate = f"Entity_{candidate}"
+    return candidate or "Entity"
+
+
+def _mermaid_relationship_line(
+    relationship: dict[str, Any],
+    entity_class_names: dict[str, str],
+) -> str | None:
+    """Render one Mermaid class relationship when source and target are known."""
+    source_id = relationship.get("source_entity_id", "")
+    target_id = relationship.get("target_entity_id", "")
+    if not source_id or not target_id:
+        return None
+
+    source_class = entity_class_names.get(source_id)
+    target_class = entity_class_names.get(target_id)
+    if not source_class or not target_class:
+        return None
+
+    source_multiplicity = relationship.get("source_multiplicity", "") or '"1"'
+    target_multiplicity = relationship.get("target_multiplicity", "") or '"1"'
+    relationship_label = relationship.get("relationship_type", "") or relationship.get("description", "")
+    relationship_label = relationship_label.replace('"', "'")
+    return (
+        f'{source_class} "{source_multiplicity}" --> "{target_multiplicity}" '
+        f'{target_class} : {relationship_label}'
+    )
+
+
+def render_domain_mermaid(model: dict[str, Any]) -> str:
+    """Render a Mermaid class diagram from the canonical domain model.
+
+    Args:
+        model: Canonical SpecOps model.
+
+    Returns:
+        Mermaid classDiagram text.
+    """
+    analysis_view = model.get("analysis_view", {})
+    logical_view = model.get("logical_view", {})
+    domain_entity_objects = analysis_view.get(
+        "domain_entity_objects",
+        logical_view.get("domain_entity_objects", []),
+    )
+    relationship_objects = analysis_view.get(
+        "relationship_objects",
+        logical_view.get("relationship_objects", []),
+    )
+
+    lines = ["classDiagram"]
+    entity_class_names: dict[str, str] = {}
+
+    for entity in domain_entity_objects:
+        entity_id = entity.get("id", "")
+        class_name = _mermaid_class_name(entity.get("name", ""), entity_id)
+        entity_class_names[entity_id] = class_name
+        lines.append(f"class {class_name} {{")
+        for attribute in entity.get("attributes", []):
+            lines.append(f"  +{attribute}")
+        lines.append("}")
+
+    for relationship in relationship_objects:
+        relationship_line = _mermaid_relationship_line(relationship, entity_class_names)
+        if relationship_line:
+            lines.append(relationship_line)
+
+    return "\n".join(lines)
+
+
 def render_interaction_model(model: dict[str, Any]) -> str:
     """Render the formal interaction-model artifact.
 
@@ -859,7 +934,7 @@ def render_artifact_family(model: dict[str, Any], artifact_family: str) -> dict[
 
     Args:
         model: Canonical SpecOps model.
-        artifact_family: One of `all`, `formal`, or `ucp`.
+        artifact_family: One of `all`, `formal`, `ucp`, or `domain-mermaid`.
 
     Returns:
         Mapping of filename to rendered content.
@@ -873,4 +948,8 @@ def render_artifact_family(model: dict[str, Any], artifact_family: str) -> dict[
         return render_formal_artifacts(model)
     if artifact_family == "ucp":
         return render_ucp_artifact(model)
+    if artifact_family == "domain-mermaid":
+        return {
+            "domain-model.mmd": render_domain_mermaid(model),
+        }
     raise ValueError(f"Unsupported artifact family '{artifact_family}'.")

--- a/src/specops_tools/render_cli.py
+++ b/src/specops_tools/render_cli.py
@@ -20,7 +20,7 @@ def main() -> int:
     parser.add_argument("--output-dir", required=True, help="Output directory for rendered files.")
     parser.add_argument(
         "--artifact-family",
-        choices=("all", "formal", "ucp"),
+        choices=("all", "formal", "ucp", "domain-mermaid"),
         default="all",
         help="Artifact family to render. Use 'formal' to skip strict UCP output.",
     )

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -16,6 +16,7 @@ from specops_tools.render import (
     render_artifact_family,
     render_deployment_model,
     render_domain_model,
+    render_domain_mermaid,
     render_formal_artifacts,
     render_interaction_model,
     render_requirements_spec,
@@ -515,6 +516,42 @@ class RenderTests(unittest.TestCase):
         self.assertIn("## Artifact Lineage", rendered)
         self.assertIn("entity-member -> domain-model.md#domain entities", rendered)
 
+    def test_render_domain_mermaid_outputs_class_diagram(self) -> None:
+        """Domain Mermaid rendering should emit a deterministic class diagram."""
+        model = build_model()
+        model["analysis_view"] = {
+            "domain_entity_objects": [
+                {
+                    "id": "entity-member",
+                    "name": "Member",
+                    "attributes": ["id", "email"],
+                },
+                {
+                    "id": "entity-reward",
+                    "name": "Reward",
+                    "attributes": ["id", "pointsCost"],
+                },
+            ],
+            "relationship_objects": [
+                {
+                    "id": "relationship-1",
+                    "relationship_type": "has_many",
+                    "source_entity_id": "entity-member",
+                    "target_entity_id": "entity-reward",
+                    "source_multiplicity": "1",
+                    "target_multiplicity": "*",
+                }
+            ],
+        }
+
+        rendered = render_domain_mermaid(model)
+
+        self.assertTrue(rendered.startswith("classDiagram"))
+        self.assertIn("class Member {", rendered)
+        self.assertIn("+id", rendered)
+        self.assertIn("class Reward {", rendered)
+        self.assertIn('Member "1" --> "*" Reward : has_many', rendered)
+
     def test_render_all_includes_state_model_artifact(self) -> None:
         """Primary rendering should emit the formal state-model artifact."""
         outputs = render_all(build_model())
@@ -587,6 +624,58 @@ class RenderTests(unittest.TestCase):
             self.assertTrue((output_dir / "deployment-model.md").exists())
             self.assertTrue((output_dir / "state-model.md").exists())
             self.assertFalse((output_dir / "ucp-estimate.md").exists())
+
+    def test_render_cli_supports_domain_mermaid_artifact_family(self) -> None:
+        """The renderer CLI should support Mermaid domain diagram output."""
+        model = build_model()
+        model["analysis_view"] = {
+            "domain_entity_objects": [
+                {
+                    "id": "entity-member",
+                    "name": "Member",
+                    "attributes": ["id", "email"],
+                }
+            ],
+            "relationship_objects": [],
+        }
+
+        with TemporaryDirectory() as temp_dir:
+            model_path = Path(temp_dir) / "model.json"
+            output_dir = Path(temp_dir) / "out"
+            model_path.write_text(json.dumps(model), encoding="utf-8")
+
+            with patch(
+                "sys.argv",
+                [
+                    "render_cli",
+                    "--model",
+                    str(model_path),
+                    "--output-dir",
+                    str(output_dir),
+                    "--artifact-family",
+                    "domain-mermaid",
+                ],
+            ):
+                exit_code = render_cli_main()
+
+            self.assertEqual(exit_code, 0)
+            self.assertTrue((output_dir / "domain-model.mmd").exists())
+            self.assertFalse((output_dir / "ucp-estimate.md").exists())
+
+    def test_render_artifact_family_supports_domain_mermaid_selection(self) -> None:
+        """Artifact-family rendering should allow explicit Mermaid domain selection."""
+        model = build_model()
+        model["analysis_view"] = {
+            "domain_entity_objects": [
+                {"id": "entity-member", "name": "Member", "attributes": []}
+            ],
+            "relationship_objects": [],
+        }
+
+        outputs = render_artifact_family(model, "domain-mermaid")
+
+        self.assertEqual(set(outputs), {"domain-model.mmd"})
+        self.assertTrue(outputs["domain-model.mmd"].startswith("classDiagram"))
 
     def test_render_all_supports_real_cmdb_fixture(self) -> None:
         """The checked-in CMDB fixture should render the full current bundle, including UCP."""


### PR DESCRIPTION
Closes #94

## Summary
- add deterministic Mermaid class-diagram rendering from canonical domain entities and relationships
- expose Mermaid domain output through the render CLI as the `domain-mermaid` artifact family
- document and test the Mermaid domain render path

## Verification
- uv run python -m unittest tests.test_render
- uv run python -m unittest