### PR TITLE
Add Mermaid state diagram rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ uv run python -m specops_tools.ucp_cli --model examples/loyalty-platform/specops
 uv run python -m specops_tools.render_cli --model examples/loyalty-platform/specops-model.json --output-dir /tmp/specops-out
 uv run python -m specops_tools.render_cli --model examples/loyalty-platform/specops-model.json --output-dir /tmp/specops-formal --artifact-family formal
 uv run python -m specops_tools.render_cli --model examples/it-systems-inventory/specops-model.json --output-dir /tmp/specops-mermaid --artifact-family domain-mermaid
+uv run python -m specops_tools.render_cli --model examples/it-systems-inventory/specops-model.json --output-dir /tmp/specops-mermaid-state --artifact-family state-mermaid
 uv run python -m specops_tools.interview_to_formal_cli --input tests/fixtures/it_systems_inventory_session.json --output-dir /tmp/specops-from-interview --write-model /tmp/specops-from-interview/specops-model.json
 ```
 

--- a/src/specops_tools/render.py
+++ b/src/specops_tools/render.py
@@ -881,6 +881,96 @@ def render_state_model(model: dict[str, Any]) -> str:
 """
 
 
+def render_state_mermaid(model: dict[str, Any]) -> str:
+    """Render a Mermaid state diagram from the canonical state model.
+
+    Args:
+        model: Canonical SpecOps model.
+
+    Returns:
+        Mermaid stateDiagram-v2 text.
+    """
+    analysis_view = model.get("analysis_view", {})
+    process_view = model.get("process_view", {})
+    state_entity_objects = analysis_view.get(
+        "state_entity_objects",
+        process_view.get("state_entity_objects", []),
+    )
+    state_transition_objects = analysis_view.get(
+        "state_transition_objects",
+        process_view.get("state_transition_objects", []),
+    )
+
+    lines = ["stateDiagram-v2"]
+    if not state_transition_objects and not state_entity_objects:
+        return "\n".join(lines)
+
+    if len(state_entity_objects) == 1:
+        state_entity = state_entity_objects[0]
+        entity_name = state_entity.get("name", "State Entity")
+        lines.append(f'state "{entity_name}" as lifecycle {{')
+
+        for state_name in state_entity.get("states", []):
+            safe_state = _mermaid_class_name(state_name, state_name)
+            lines.append(f'  state "{state_name}" as {safe_state}')
+
+        for transition in state_transition_objects:
+            from_state = transition.get("from_state", "")
+            to_state = transition.get("to_state", "")
+            if not from_state or not to_state:
+                continue
+
+            safe_from = _mermaid_class_name(from_state, from_state)
+            safe_to = _mermaid_class_name(to_state, to_state)
+            label_bits = []
+            if transition.get("trigger"):
+                label_bits.append(transition["trigger"])
+            if transition.get("constraint"):
+                label_bits.append(transition["constraint"])
+            if transition.get("is_exception_flow"):
+                label_bits.append("exception")
+            if transition.get("is_terminal_transition"):
+                label_bits.append("terminal")
+
+            if label_bits:
+                lines.append(f"  {safe_from} --> {safe_to} : {' | '.join(label_bits)}")
+            else:
+                lines.append(f"  {safe_from} --> {safe_to}")
+
+        lines.append("}")
+        return "\n".join(lines)
+
+    for transition in state_transition_objects:
+        from_state = transition.get("from_state", "")
+        to_state = transition.get("to_state", "")
+        if not from_state or not to_state:
+            continue
+
+        safe_from = _mermaid_class_name(from_state, from_state)
+        safe_to = _mermaid_class_name(to_state, to_state)
+        lines.append(f'state "{from_state}" as {safe_from}')
+        lines.append(f'state "{to_state}" as {safe_to}')
+
+        label_bits = []
+        if transition.get("state_entity_name"):
+            label_bits.append(transition["state_entity_name"])
+        if transition.get("trigger"):
+            label_bits.append(transition["trigger"])
+        if transition.get("constraint"):
+            label_bits.append(transition["constraint"])
+        if transition.get("is_exception_flow"):
+            label_bits.append("exception")
+        if transition.get("is_terminal_transition"):
+            label_bits.append("terminal")
+
+        if label_bits:
+            lines.append(f"{safe_from} --> {safe_to} : {' | '.join(label_bits)}")
+        else:
+            lines.append(f"{safe_from} --> {safe_to}")
+
+    return "\n".join(lines)
+
+
 def render_all(model: dict[str, Any]) -> dict[str, str]:
     """Render all primary artifacts for a model.
 
@@ -934,7 +1024,7 @@ def render_artifact_family(model: dict[str, Any], artifact_family: str) -> dict[
 
     Args:
         model: Canonical SpecOps model.
-        artifact_family: One of `all`, `formal`, `ucp`, or `domain-mermaid`.
+        artifact_family: One of `all`, `formal`, `ucp`, `domain-mermaid`, or `state-mermaid`.
 
     Returns:
         Mapping of filename to rendered content.
@@ -951,5 +1041,9 @@ def render_artifact_family(model: dict[str, Any], artifact_family: str) -> dict[
     if artifact_family == "domain-mermaid":
         return {
             "domain-model.mmd": render_domain_mermaid(model),
+        }
+    if artifact_family == "state-mermaid":
+        return {
+            "state-model.mmd": render_state_mermaid(model),
         }
     raise ValueError(f"Unsupported artifact family '{artifact_family}'.")

--- a/src/specops_tools/render_cli.py
+++ b/src/specops_tools/render_cli.py
@@ -20,7 +20,7 @@ def main() -> int:
     parser.add_argument("--output-dir", required=True, help="Output directory for rendered files.")
     parser.add_argument(
         "--artifact-family",
-        choices=("all", "formal", "ucp", "domain-mermaid"),
+        choices=("all", "formal", "ucp", "domain-mermaid", "state-mermaid"),
         default="all",
         help="Artifact family to render. Use 'formal' to skip strict UCP output.",
     )

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -20,6 +20,7 @@ from specops_tools.render import (
     render_formal_artifacts,
     render_interaction_model,
     render_requirements_spec,
+    render_state_mermaid,
     render_state_model,
 )
 from specops_tools.ucp import calculate_ucp, render_ucp_markdown
@@ -552,6 +553,49 @@ class RenderTests(unittest.TestCase):
         self.assertIn("class Reward {", rendered)
         self.assertIn('Member "1" --> "*" Reward : has_many', rendered)
 
+    def test_render_state_mermaid_outputs_state_diagram(self) -> None:
+        """State Mermaid rendering should emit a deterministic state diagram."""
+        model = build_model()
+        model["analysis_view"] = {
+            "state_entity_objects": [
+                {
+                    "id": "state-entity-redemption-request",
+                    "name": "Redemption Request",
+                    "states": ["Requested", "Approved", "Rejected"],
+                }
+            ],
+            "state_transition_objects": [
+                {
+                    "id": "state-transition-1",
+                    "state_entity_name": "Redemption Request",
+                    "from_state": "Requested",
+                    "to_state": "Approved",
+                    "trigger": "Approval event",
+                    "constraint": "manager approval",
+                    "is_exception_flow": False,
+                    "is_terminal_transition": False,
+                },
+                {
+                    "id": "state-transition-2",
+                    "state_entity_name": "Redemption Request",
+                    "from_state": "Requested",
+                    "to_state": "Rejected",
+                    "trigger": "Validation failure",
+                    "constraint": "",
+                    "is_exception_flow": True,
+                    "is_terminal_transition": True,
+                },
+            ],
+        }
+
+        rendered = render_state_mermaid(model)
+
+        self.assertTrue(rendered.startswith("stateDiagram-v2"))
+        self.assertIn('state "Redemption Request" as lifecycle {', rendered)
+        self.assertIn('state "Requested" as Requested', rendered)
+        self.assertIn("Requested --> Approved : Approval event | manager approval", rendered)
+        self.assertIn("Requested --> Rejected : Validation failure | exception | terminal", rendered)
+
     def test_render_all_includes_state_model_artifact(self) -> None:
         """Primary rendering should emit the formal state-model artifact."""
         outputs = render_all(build_model())
@@ -662,6 +706,53 @@ class RenderTests(unittest.TestCase):
             self.assertTrue((output_dir / "domain-model.mmd").exists())
             self.assertFalse((output_dir / "ucp-estimate.md").exists())
 
+    def test_render_cli_supports_state_mermaid_artifact_family(self) -> None:
+        """The renderer CLI should support Mermaid state diagram output."""
+        model = build_model()
+        model["analysis_view"] = {
+            "state_entity_objects": [
+                {
+                    "id": "state-entity-redemption-request",
+                    "name": "Redemption Request",
+                    "states": ["Requested", "Approved"],
+                }
+            ],
+            "state_transition_objects": [
+                {
+                    "id": "state-transition-1",
+                    "from_state": "Requested",
+                    "to_state": "Approved",
+                    "trigger": "Approval event",
+                    "constraint": "",
+                    "is_exception_flow": False,
+                    "is_terminal_transition": False,
+                }
+            ],
+        }
+
+        with TemporaryDirectory() as temp_dir:
+            model_path = Path(temp_dir) / "model.json"
+            output_dir = Path(temp_dir) / "out"
+            model_path.write_text(json.dumps(model), encoding="utf-8")
+
+            with patch(
+                "sys.argv",
+                [
+                    "render_cli",
+                    "--model",
+                    str(model_path),
+                    "--output-dir",
+                    str(output_dir),
+                    "--artifact-family",
+                    "state-mermaid",
+                ],
+            ):
+                exit_code = render_cli_main()
+
+            self.assertEqual(exit_code, 0)
+            self.assertTrue((output_dir / "state-model.mmd").exists())
+            self.assertFalse((output_dir / "ucp-estimate.md").exists())
+
     def test_render_artifact_family_supports_domain_mermaid_selection(self) -> None:
         """Artifact-family rendering should allow explicit Mermaid domain selection."""
         model = build_model()
@@ -676,6 +767,21 @@ class RenderTests(unittest.TestCase):
 
         self.assertEqual(set(outputs), {"domain-model.mmd"})
         self.assertTrue(outputs["domain-model.mmd"].startswith("classDiagram"))
+
+    def test_render_artifact_family_supports_state_mermaid_selection(self) -> None:
+        """Artifact-family rendering should allow explicit Mermaid state selection."""
+        model = build_model()
+        model["analysis_view"] = {
+            "state_entity_objects": [
+                {"id": "state-entity-redemption-request", "name": "Redemption Request", "states": []}
+            ],
+            "state_transition_objects": [],
+        }
+
+        outputs = render_artifact_family(model, "state-mermaid")
+
+        self.assertEqual(set(outputs), {"state-model.mmd"})
+        self.assertTrue(outputs["state-model.mmd"].startswith("stateDiagram-v2"))
 
     def test_render_all_supports_real_cmdb_fixture(self) -> None:
         """The checked-in CMDB fixture should render the full current bundle, including UCP."""


### PR DESCRIPTION
Closes #92

## Summary
- add deterministic Mermaid `stateDiagram-v2` rendering from canonical state semantics
- expose Mermaid state output through the render CLI as the `state-mermaid` artifact family
- document and test the Mermaid state render path

## Verification
- uv run python -m unittest tests.test_render
- uv run python -m unittest