### PR TITLE
Add Mermaid interaction diagram rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ uv run python -m specops_tools.render_cli --model examples/loyalty-platform/spec
 uv run python -m specops_tools.render_cli --model examples/loyalty-platform/specops-model.json --output-dir /tmp/specops-formal --artifact-family formal
 uv run python -m specops_tools.render_cli --model examples/it-systems-inventory/specops-model.json --output-dir /tmp/specops-mermaid --artifact-family domain-mermaid
 uv run python -m specops_tools.render_cli --model examples/it-systems-inventory/specops-model.json --output-dir /tmp/specops-mermaid-state --artifact-family state-mermaid
+uv run python -m specops_tools.render_cli --model examples/it-systems-inventory/specops-model.json --output-dir /tmp/specops-mermaid-interaction --artifact-family interaction-mermaid
 uv run python -m specops_tools.interview_to_formal_cli --input tests/fixtures/it_systems_inventory_session.json --output-dir /tmp/specops-from-interview --write-model /tmp/specops-from-interview/specops-model.json
 ```
 

--- a/src/specops_tools/render.py
+++ b/src/specops_tools/render.py
@@ -748,6 +748,73 @@ def render_interaction_model(model: dict[str, Any]) -> str:
 """
 
 
+def render_interaction_mermaid(model: dict[str, Any]) -> str:
+    """Render a Mermaid sequence diagram from the canonical interaction model.
+
+    Args:
+        model: Canonical SpecOps model.
+
+    Returns:
+        Mermaid sequenceDiagram text.
+    """
+    interaction_view = model.get("interaction_view", {})
+    realization_objects = interaction_view.get("realization_objects", [])
+    message_objects = interaction_view.get("message_objects", [])
+
+    lines = ["sequenceDiagram"]
+    participant_names: list[str] = []
+
+    def add_participant(name: str) -> None:
+        if name and name not in participant_names:
+            participant_names.append(name)
+
+    for realization in realization_objects:
+        for participant_name in realization.get("participant_names", []):
+            add_participant(participant_name)
+    for message in message_objects:
+        add_participant(message.get("source_name", ""))
+        add_participant(message.get("target_name", ""))
+
+    for participant_name in participant_names:
+        safe_name = _mermaid_class_name(participant_name, participant_name)
+        lines.append(f'participant {safe_name} as "{participant_name}"')
+
+    for realization in realization_objects:
+        participant_ids = [
+            _mermaid_class_name(name, name) for name in realization.get("participant_names", [])
+        ]
+        if participant_ids:
+            lines.append(
+                f"Note over {', '.join(participant_ids)}: "
+                f"{realization.get('use_case_name', 'Unnamed Use Case')}"
+            )
+        if len(participant_ids) >= 2:
+            source = participant_ids[0]
+            target = participant_ids[1]
+            for step in realization.get("steps", []):
+                lines.append(f"{source}->>{target}: {step}")
+        elif len(participant_ids) == 1:
+            participant = participant_ids[0]
+            for step in realization.get("steps", []):
+                lines.append(f"{participant}->>{participant}: {step}")
+
+    for message in message_objects:
+        source_name = message.get("source_name", "")
+        target_name = message.get("target_name", "")
+        if not source_name or not target_name:
+            continue
+        source = _mermaid_class_name(source_name, source_name)
+        target = _mermaid_class_name(target_name, target_name)
+        description = (
+            message.get("description", "")
+            or message.get("interaction_verb", "")
+            or "message"
+        )
+        lines.append(f"{source}->>{target}: {description}")
+
+    return "\n".join(lines)
+
+
 def render_deployment_model(model: dict[str, Any]) -> str:
     """Render the formal deployment-model artifact.
 
@@ -1024,7 +1091,7 @@ def render_artifact_family(model: dict[str, Any], artifact_family: str) -> dict[
 
     Args:
         model: Canonical SpecOps model.
-        artifact_family: One of `all`, `formal`, `ucp`, `domain-mermaid`, or `state-mermaid`.
+        artifact_family: One of `all`, `formal`, `ucp`, `domain-mermaid`, `state-mermaid`, or `interaction-mermaid`.
 
     Returns:
         Mapping of filename to rendered content.
@@ -1045,5 +1112,9 @@ def render_artifact_family(model: dict[str, Any], artifact_family: str) -> dict[
     if artifact_family == "state-mermaid":
         return {
             "state-model.mmd": render_state_mermaid(model),
+        }
+    if artifact_family == "interaction-mermaid":
+        return {
+            "interaction-model.mmd": render_interaction_mermaid(model),
         }
     raise ValueError(f"Unsupported artifact family '{artifact_family}'.")

--- a/src/specops_tools/render_cli.py
+++ b/src/specops_tools/render_cli.py
@@ -20,7 +20,14 @@ def main() -> int:
     parser.add_argument("--output-dir", required=True, help="Output directory for rendered files.")
     parser.add_argument(
         "--artifact-family",
-        choices=("all", "formal", "ucp", "domain-mermaid", "state-mermaid"),
+        choices=(
+            "all",
+            "formal",
+            "ucp",
+            "domain-mermaid",
+            "state-mermaid",
+            "interaction-mermaid",
+        ),
         default="all",
         help="Artifact family to render. Use 'formal' to skip strict UCP output.",
     )

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -18,6 +18,7 @@ from specops_tools.render import (
     render_domain_model,
     render_domain_mermaid,
     render_formal_artifacts,
+    render_interaction_mermaid,
     render_interaction_model,
     render_requirements_spec,
     render_state_mermaid,
@@ -596,6 +597,37 @@ class RenderTests(unittest.TestCase):
         self.assertIn("Requested --> Approved : Approval event | manager approval", rendered)
         self.assertIn("Requested --> Rejected : Validation failure | exception | terminal", rendered)
 
+    def test_render_interaction_mermaid_outputs_sequence_diagram(self) -> None:
+        """Interaction Mermaid rendering should emit a deterministic sequence diagram."""
+        model = build_model()
+        model["interaction_view"] = {
+            "realization_objects": [
+                {
+                    "id": "interaction-realization-1",
+                    "use_case_name": "Redeem Reward",
+                    "participant_names": ["Customer", "Rewards API"],
+                    "steps": ["Customer selects reward.", "System validates points."],
+                }
+            ],
+            "message_objects": [
+                {
+                    "id": "interaction-message-1",
+                    "source_name": "Member App",
+                    "target_name": "Rewards API",
+                    "description": "Member App calls Rewards API",
+                }
+            ],
+        }
+
+        rendered = render_interaction_mermaid(model)
+
+        self.assertTrue(rendered.startswith("sequenceDiagram"))
+        self.assertIn('participant Customer as "Customer"', rendered)
+        self.assertIn('participant Rewards_API as "Rewards API"', rendered)
+        self.assertIn("Note over Customer, Rewards_API: Redeem Reward", rendered)
+        self.assertIn("Customer->>Rewards_API: Customer selects reward.", rendered)
+        self.assertIn("Member_App->>Rewards_API: Member App calls Rewards API", rendered)
+
     def test_render_all_includes_state_model_artifact(self) -> None:
         """Primary rendering should emit the formal state-model artifact."""
         outputs = render_all(build_model())
@@ -753,6 +785,44 @@ class RenderTests(unittest.TestCase):
             self.assertTrue((output_dir / "state-model.mmd").exists())
             self.assertFalse((output_dir / "ucp-estimate.md").exists())
 
+    def test_render_cli_supports_interaction_mermaid_artifact_family(self) -> None:
+        """The renderer CLI should support Mermaid interaction diagram output."""
+        model = build_model()
+        model["interaction_view"] = {
+            "realization_objects": [
+                {
+                    "id": "interaction-realization-1",
+                    "use_case_name": "Redeem Reward",
+                    "participant_names": ["Customer", "Rewards API"],
+                    "steps": ["Customer selects reward."],
+                }
+            ],
+            "message_objects": [],
+        }
+
+        with TemporaryDirectory() as temp_dir:
+            model_path = Path(temp_dir) / "model.json"
+            output_dir = Path(temp_dir) / "out"
+            model_path.write_text(json.dumps(model), encoding="utf-8")
+
+            with patch(
+                "sys.argv",
+                [
+                    "render_cli",
+                    "--model",
+                    str(model_path),
+                    "--output-dir",
+                    str(output_dir),
+                    "--artifact-family",
+                    "interaction-mermaid",
+                ],
+            ):
+                exit_code = render_cli_main()
+
+            self.assertEqual(exit_code, 0)
+            self.assertTrue((output_dir / "interaction-model.mmd").exists())
+            self.assertFalse((output_dir / "ucp-estimate.md").exists())
+
     def test_render_artifact_family_supports_domain_mermaid_selection(self) -> None:
         """Artifact-family rendering should allow explicit Mermaid domain selection."""
         model = build_model()
@@ -782,6 +852,19 @@ class RenderTests(unittest.TestCase):
 
         self.assertEqual(set(outputs), {"state-model.mmd"})
         self.assertTrue(outputs["state-model.mmd"].startswith("stateDiagram-v2"))
+
+    def test_render_artifact_family_supports_interaction_mermaid_selection(self) -> None:
+        """Artifact-family rendering should allow explicit Mermaid interaction selection."""
+        model = build_model()
+        model["interaction_view"] = {
+            "realization_objects": [],
+            "message_objects": [],
+        }
+
+        outputs = render_artifact_family(model, "interaction-mermaid")
+
+        self.assertEqual(set(outputs), {"interaction-model.mmd"})
+        self.assertTrue(outputs["interaction-model.mmd"].startswith("sequenceDiagram"))
 
     def test_render_all_supports_real_cmdb_fixture(self) -> None:
         """The checked-in CMDB fixture should render the full current bundle, including UCP."""


### PR DESCRIPTION
Closes #90

## Summary
- add deterministic Mermaid `sequenceDiagram` rendering from canonical interaction semantics
- expose Mermaid interaction output through the render CLI as the `interaction-mermaid` artifact family
- document and test the Mermaid interaction render path

## Verification
- uv run python -m unittest tests.test_render
- uv run python -m unittest