### PR TITLE
Add Mermaid deployment diagram rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ uv run python -m specops_tools.render_cli --model examples/loyalty-platform/spec
 uv run python -m specops_tools.render_cli --model examples/it-systems-inventory/specops-model.json --output-dir /tmp/specops-mermaid --artifact-family domain-mermaid
 uv run python -m specops_tools.render_cli --model examples/it-systems-inventory/specops-model.json --output-dir /tmp/specops-mermaid-state --artifact-family state-mermaid
 uv run python -m specops_tools.render_cli --model examples/it-systems-inventory/specops-model.json --output-dir /tmp/specops-mermaid-interaction --artifact-family interaction-mermaid
+uv run python -m specops_tools.render_cli --model examples/it-systems-inventory/specops-model.json --output-dir /tmp/specops-mermaid-deployment --artifact-family deployment-mermaid
 uv run python -m specops_tools.interview_to_formal_cli --input tests/fixtures/it_systems_inventory_session.json --output-dir /tmp/specops-from-interview --write-model /tmp/specops-from-interview/specops-model.json
 ```
 

--- a/src/specops_tools/render.py
+++ b/src/specops_tools/render.py
@@ -874,6 +874,57 @@ def render_deployment_model(model: dict[str, Any]) -> str:
 """
 
 
+def render_deployment_mermaid(model: dict[str, Any]) -> str:
+    """Render a Mermaid deployment/architecture diagram from the canonical design model.
+
+    Args:
+        model: Canonical SpecOps model.
+
+    Returns:
+        Mermaid flowchart text.
+    """
+    design_view = model.get("design_view", {})
+    architecture_view = model.get("architecture_view", {})
+    component_objects = design_view.get(
+        "component_objects",
+        architecture_view.get("component_objects", []),
+    )
+    interface_objects = design_view.get(
+        "interface_objects",
+        architecture_view.get("interface_objects", []),
+    )
+    runtime_boundary_objects = design_view.get(
+        "runtime_boundary_objects",
+        architecture_view.get("runtime_boundary_objects", []),
+    )
+
+    lines = ["flowchart LR"]
+    component_ids: dict[str, str] = {}
+
+    for component in component_objects:
+        component_name = component.get("name", "Component")
+        component_id = _mermaid_class_name(component_name, component.get("id", "component"))
+        component_ids[component_name] = component_id
+        lines.append(f'{component_id}["{component_name}"]')
+
+    for interface in interface_objects:
+        source_name = interface.get("source_name", "") or interface.get("source_component_name", "")
+        target_name = interface.get("target_name", "") or interface.get("target_component_name", "")
+        if not source_name or not target_name:
+            continue
+        source_id = component_ids.get(source_name, _mermaid_class_name(source_name, source_name))
+        target_id = component_ids.get(target_name, _mermaid_class_name(target_name, target_name))
+        description = interface.get("description", "") or "integrates with"
+        lines.append(f'{source_id} -->|"{description}"| {target_id}')
+
+    for index, runtime_boundary in enumerate(runtime_boundary_objects, 1):
+        boundary_id = f"RuntimeBoundary_{index}"
+        description = runtime_boundary.get("description", "") or runtime_boundary.get("text", "")
+        lines.append(f'{boundary_id}["{description or "Runtime boundary"}"]')
+
+    return "\n".join(lines)
+
+
 def render_state_model(model: dict[str, Any]) -> str:
     """Render the formal state-model artifact.
 
@@ -1091,7 +1142,7 @@ def render_artifact_family(model: dict[str, Any], artifact_family: str) -> dict[
 
     Args:
         model: Canonical SpecOps model.
-        artifact_family: One of `all`, `formal`, `ucp`, `domain-mermaid`, `state-mermaid`, or `interaction-mermaid`.
+        artifact_family: One of `all`, `formal`, `ucp`, `domain-mermaid`, `state-mermaid`, `interaction-mermaid`, or `deployment-mermaid`.
 
     Returns:
         Mapping of filename to rendered content.
@@ -1116,5 +1167,9 @@ def render_artifact_family(model: dict[str, Any], artifact_family: str) -> dict[
     if artifact_family == "interaction-mermaid":
         return {
             "interaction-model.mmd": render_interaction_mermaid(model),
+        }
+    if artifact_family == "deployment-mermaid":
+        return {
+            "deployment-model.mmd": render_deployment_mermaid(model),
         }
     raise ValueError(f"Unsupported artifact family '{artifact_family}'.")

--- a/src/specops_tools/render_cli.py
+++ b/src/specops_tools/render_cli.py
@@ -27,6 +27,7 @@ def main() -> int:
             "domain-mermaid",
             "state-mermaid",
             "interaction-mermaid",
+            "deployment-mermaid",
         ),
         default="all",
         help="Artifact family to render. Use 'formal' to skip strict UCP output.",

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -15,6 +15,7 @@ from specops_tools.render import (
     render_all,
     render_artifact_family,
     render_deployment_model,
+    render_deployment_mermaid,
     render_domain_model,
     render_domain_mermaid,
     render_formal_artifacts,
@@ -628,6 +629,38 @@ class RenderTests(unittest.TestCase):
         self.assertIn("Customer->>Rewards_API: Customer selects reward.", rendered)
         self.assertIn("Member_App->>Rewards_API: Member App calls Rewards API", rendered)
 
+    def test_render_deployment_mermaid_outputs_flowchart(self) -> None:
+        """Deployment Mermaid rendering should emit a deterministic flowchart."""
+        model = build_model()
+        model["design_view"] = {
+            "component_objects": [
+                {"id": "component-member-app", "name": "Member App"},
+                {"id": "component-rewards-api", "name": "Rewards API"},
+            ],
+            "interface_objects": [
+                {
+                    "id": "interface-1",
+                    "source_name": "Member App",
+                    "target_name": "Rewards API",
+                    "description": "Member App calls Rewards API",
+                }
+            ],
+            "runtime_boundary_objects": [
+                {
+                    "id": "runtime-boundary-1",
+                    "description": "Rewards API runs as a separate service.",
+                }
+            ],
+        }
+
+        rendered = render_deployment_mermaid(model)
+
+        self.assertTrue(rendered.startswith("flowchart LR"))
+        self.assertIn('Member_App["Member App"]', rendered)
+        self.assertIn('Rewards_API["Rewards API"]', rendered)
+        self.assertIn('Member_App -->|"Member App calls Rewards API"| Rewards_API', rendered)
+        self.assertIn('RuntimeBoundary_1["Rewards API runs as a separate service."]', rendered)
+
     def test_render_all_includes_state_model_artifact(self) -> None:
         """Primary rendering should emit the formal state-model artifact."""
         outputs = render_all(build_model())
@@ -823,6 +856,40 @@ class RenderTests(unittest.TestCase):
             self.assertTrue((output_dir / "interaction-model.mmd").exists())
             self.assertFalse((output_dir / "ucp-estimate.md").exists())
 
+    def test_render_cli_supports_deployment_mermaid_artifact_family(self) -> None:
+        """The renderer CLI should support Mermaid deployment diagram output."""
+        model = build_model()
+        model["design_view"] = {
+            "component_objects": [
+                {"id": "component-member-app", "name": "Member App"}
+            ],
+            "interface_objects": [],
+            "runtime_boundary_objects": [],
+        }
+
+        with TemporaryDirectory() as temp_dir:
+            model_path = Path(temp_dir) / "model.json"
+            output_dir = Path(temp_dir) / "out"
+            model_path.write_text(json.dumps(model), encoding="utf-8")
+
+            with patch(
+                "sys.argv",
+                [
+                    "render_cli",
+                    "--model",
+                    str(model_path),
+                    "--output-dir",
+                    str(output_dir),
+                    "--artifact-family",
+                    "deployment-mermaid",
+                ],
+            ):
+                exit_code = render_cli_main()
+
+            self.assertEqual(exit_code, 0)
+            self.assertTrue((output_dir / "deployment-model.mmd").exists())
+            self.assertFalse((output_dir / "ucp-estimate.md").exists())
+
     def test_render_artifact_family_supports_domain_mermaid_selection(self) -> None:
         """Artifact-family rendering should allow explicit Mermaid domain selection."""
         model = build_model()
@@ -865,6 +932,20 @@ class RenderTests(unittest.TestCase):
 
         self.assertEqual(set(outputs), {"interaction-model.mmd"})
         self.assertTrue(outputs["interaction-model.mmd"].startswith("sequenceDiagram"))
+
+    def test_render_artifact_family_supports_deployment_mermaid_selection(self) -> None:
+        """Artifact-family rendering should allow explicit Mermaid deployment selection."""
+        model = build_model()
+        model["design_view"] = {
+            "component_objects": [],
+            "interface_objects": [],
+            "runtime_boundary_objects": [],
+        }
+
+        outputs = render_artifact_family(model, "deployment-mermaid")
+
+        self.assertEqual(set(outputs), {"deployment-model.mmd"})
+        self.assertTrue(outputs["deployment-model.mmd"].startswith("flowchart LR"))
 
     def test_render_all_supports_real_cmdb_fixture(self) -> None:
         """The checked-in CMDB fixture should render the full current bundle, including UCP."""


### PR DESCRIPTION
Closes #91

## Summary
- add deterministic Mermaid architecture/deployment `flowchart` rendering from canonical design semantics
- expose Mermaid deployment output through the render CLI as the `deployment-mermaid` artifact family
- document and test the Mermaid deployment render path

## Verification
- uv run python -m unittest tests.test_render
- uv run python -m unittest