### PR TITLE
Document Mermaid publication workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ uv sync --extra yaml
 - [V1.6 Specification Hardening](docs/v1.6-specification-hardening.md)
 - [V2 Go/No-Go Decision](docs/v2-go-no-go-decision.md)
 - [RUP Artifact Coverage Matrix](docs/rup-artifact-coverage-matrix.md)
+- [Mermaid Publication Workflows](docs/mermaid-publication-workflows.md)
 - [Document Ingestion Future Direction](docs/document-ingestion-future.md)
 - [Dogfooding Workflow](docs/dogfooding.md)
 - [GitHub Issue Map](docs/github-issue-map.md)

--- a/docs/github-issue-map.md
+++ b/docs/github-issue-map.md
@@ -92,6 +92,7 @@ These themes now shape the completed bridge into V1.6 hardening work.
 
 See also: [V2 Go/No-Go Decision](v2-go-no-go-decision.md)
 See also: [RUP Artifact Coverage Matrix](rup-artifact-coverage-matrix.md)
+See also: [Mermaid Publication Workflows](mermaid-publication-workflows.md)
 See also: [Document Ingestion Future Direction](document-ingestion-future.md)
 
 ## Relationship Model

--- a/docs/mermaid-publication-workflows.md
+++ b/docs/mermaid-publication-workflows.md
@@ -1,0 +1,90 @@
+# Mermaid Publication Workflows
+
+This document explains how SpecOps Mermaid outputs should be generated, stored, and embedded in
+GitHub and Confluence.
+
+## Supported Mermaid Outputs
+
+SpecOps currently supports these Mermaid artifact families:
+
+- `domain-mermaid` -> `domain-model.mmd`
+- `interaction-mermaid` -> `interaction-model.mmd`
+- `deployment-mermaid` -> `deployment-model.mmd`
+- `state-mermaid` -> `state-model.mmd`
+
+These outputs are generated from the canonical model through
+`python -m specops_tools.render_cli --artifact-family ...`.
+
+They are not hand-authored source artifacts. The canonical model remains the source of truth.
+
+## Generation Pattern
+
+Generate Mermaid outputs from a checked-in model:
+
+```bash
+uv run python -m specops_tools.render_cli \
+  --model examples/it-systems-inventory/specops-model.json \
+  --output-dir /tmp/specops-mermaid \
+  --artifact-family domain-mermaid
+```
+
+Repeat with `interaction-mermaid`, `deployment-mermaid`, or `state-mermaid` as needed.
+
+If the model comes from an interview fixture, first generate the normalized model or formal bundle
+through the existing interview pipeline, then render Mermaid from that model rather than editing
+diagram text directly.
+
+## GitHub Embedding
+
+GitHub renders Mermaid directly inside fenced code blocks.
+
+Example:
+
+````markdown
+```mermaid
+classDiagram
+class Member {
+  +id
+  +email
+}
+```
+````
+
+Recommended GitHub workflow:
+
+- keep the generated `.mmd` file as the canonical diagram text output
+- embed Mermaid blocks in documentation by copying the generated content into a fenced
+  `mermaid` block
+- when the model changes, regenerate the `.mmd` file and refresh any embedded copies
+
+If duplicate maintenance becomes a problem, prefer linking to the generated `.mmd` file over
+manually maintaining separate diagram text in multiple documents.
+
+## Confluence Embedding
+
+Confluence support depends on the site configuration. In practice, teams usually use either:
+
+- a Mermaid macro or plugin that accepts Mermaid text directly
+- a code block workflow where Mermaid text is copied into a supported macro
+
+Recommended Confluence workflow:
+
+- generate the `.mmd` file from the canonical model in the repo
+- paste the generated Mermaid text into the Confluence Mermaid-compatible macro
+- avoid editing the Confluence copy by hand unless the repo source is updated first
+
+Confluence should be treated as a publishing surface, not the source of truth.
+
+## Operational Rules
+
+- do not hand-edit generated Mermaid outputs as the primary source
+- do not bypass the canonical model by drawing diagrams directly in GitHub or Confluence
+- regenerate Mermaid after model changes rather than patching the diagram text manually
+- keep Mermaid publication subordinate to the model and artifact workflow already in the repo
+
+## Practical Mapping
+
+- `domain-model.mmd` uses Mermaid `classDiagram`
+- `interaction-model.mmd` uses Mermaid `sequenceDiagram`
+- `deployment-model.mmd` uses Mermaid `flowchart`
+- `state-model.mmd` uses Mermaid `stateDiagram-v2`


### PR DESCRIPTION
Closes #93

## Summary
- document the supported Mermaid artifact families and their model-driven generation path
- document GitHub and Confluence embedding expectations for generated Mermaid outputs
- link the Mermaid publication guidance from the main repo docs

## Verification
- documentation only