### PR TITLE
Refresh repo status docs and review note

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,77 @@
+# Contributing
+
+## Scope
+
+SpecOps is a model-driven specification system. Contributions should preserve that design:
+
+- interview and discovery feed the canonical model
+- the canonical model is the source of truth
+- Markdown and Mermaid artifacts are generated from the model
+- deterministic utilities own the brittle or formula-driven parts
+
+## Local Setup
+
+```bash
+uv sync
+```
+
+For YAML support:
+
+```bash
+uv sync --extra yaml
+```
+
+## Useful Commands
+
+Run the test suite:
+
+```bash
+uv run python -m unittest
+```
+
+Render formal artifacts from a model:
+
+```bash
+uv run specops-render \
+  --model examples/it-systems-inventory/specops-model.json \
+  --output-dir /tmp/specops-formal \
+  --artifact-family formal
+```
+
+Replay the checked-in interview fixture:
+
+```bash
+uv run specops-interview-replay \
+  --input tests/fixtures/it_systems_inventory_session.json
+```
+
+Generate the formal bundle directly from the fixture:
+
+```bash
+uv run python -m specops_tools.interview_to_formal_cli \
+  --input tests/fixtures/it_systems_inventory_session.json \
+  --output-dir /tmp/specops-from-interview \
+  --write-model /tmp/specops-from-interview/specops-model.json
+```
+
+## Contribution Rules
+
+- do not bypass the canonical model by treating generated artifacts as the primary source
+- do not add invented fallback paths unless the task explicitly requires them
+- prefer clear failure over silent degradation
+- keep examples and generated bundles synchronized with the current model contract
+- when model semantics change, update the checked-in example bundle as part of the same work
+
+## Pull Request Expectations
+
+- keep work tied to a GitHub issue
+- keep one issue per branch
+- include verification notes in the PR description
+- update docs when capability or workflow shape changes
+
+## Good First Areas
+
+- documentation and workflow polish
+- test coverage around example fixtures and artifact generation
+- productization work under the current open epics
+- document-ingestion groundwork that preserves the canonical model workflow

--- a/README.md
+++ b/README.md
@@ -50,6 +50,16 @@ V2 has now started and the first formal artifact breadth is delivered on top of 
 The remaining roadmap is now follow-on V2 expansion plus integrations/productization rather than
 foundational UML readiness work.
 
+## Open Source Readiness
+
+This repository is usable as an open-source, model-driven specification toolkit today, with some
+important scope boundaries:
+
+- the Python tooling and example workflows are executable locally
+- the skill pack is designed for Codex-style environments where local skills are available
+- the canonical model and generated artifacts are the supported interoperability surface
+- productization and document-ingestion work are still active roadmap items
+
 ## Repository Layout
 
 - `docs/`: implementation plan, architecture, dogfooding workflow, and GitHub issue map
@@ -69,6 +79,42 @@ foundational UML readiness work.
 ## Python Workflow
 
 Python in this repo is managed with `uv`.
+
+## Installation
+
+### Prerequisites
+
+- Python `3.12+`
+- [`uv`](https://docs.astral.sh/uv/)
+
+### Install Local Tooling
+
+```bash
+uv sync
+```
+
+If you want YAML model support:
+
+```bash
+uv sync --extra yaml
+```
+
+### Available CLI Entry Points
+
+After `uv sync`, the current supported commands are:
+
+```bash
+uv run specops-interview --help
+uv run specops-interview-replay --help
+uv run specops-ucp --help
+uv run specops-render --help
+```
+
+There is also one module-only CLI for the interview-fixture-to-formal flow:
+
+```bash
+uv run python -m specops_tools.interview_to_formal_cli --help
+```
 
 Common commands:
 
@@ -93,6 +139,7 @@ uv sync --extra yaml
 
 ## Primary Documents
 
+- [End-to-End Usage](docs/end-to-end-usage.md)
 - [Implementation Plan](docs/implementation-plan.md)
 - [Solution Architecture](docs/solution-architecture.md)
 - [V1.5 Interview Readiness](docs/v1.5-interview-readiness.md)
@@ -105,6 +152,7 @@ uv sync --extra yaml
 - [Dogfooding Workflow](docs/dogfooding.md)
 - [GitHub Issue Map](docs/github-issue-map.md)
 - [SpecKit Constitution](.specify/memory/constitution.md)
+- [Contributing](CONTRIBUTING.md)
 
 ## Dogfooding Example
 
@@ -113,3 +161,10 @@ SpecOps:
 
 - [Example Model](/Volumes/Data/GitHub/Peterbb148/specops/examples/it-systems-inventory/specops-model.yaml)
 - [Example Feedback](/Volumes/Data/GitHub/Peterbb148/specops/examples/it-systems-inventory/specops-feedback.md)
+
+## Current Limitations
+
+- the main end-to-end skill workflow assumes a Codex-style environment with local skill support
+- there is not yet a standalone vision artifact or supplementary specification artifact
+- Mermaid outputs are practical publication artifacts, not strict UML interchange files
+- document ingestion is planned but not yet implemented as a product workflow

--- a/README.md
+++ b/README.md
@@ -1,13 +1,19 @@
 # SpecOps
 
-SpecOps is a Codex-native skill pack for software requirements discovery. It is designed to
-interview a stakeholder, normalize the answers into a canonical project model, and generate
-first-class artifacts from the same source of truth:
+SpecOps is a Codex-native, model-driven specification system for software and system requirements.
+It interviews a stakeholder, normalizes the answers into a canonical project model, and generates
+first-class specification artifacts and diagrams from that shared source of truth.
+
+Current first-class outputs include:
 
 - `requirements-spec.md`
 - `use-case-model.md`
+- `domain-model.md`
+- `interaction-model.md`
+- `deployment-model.md`
 - `state-model.md`
 - `ucp-estimate.md`
+- Mermaid diagram bundles for domain, interaction, deployment, and state views
 
 The interview step can be invoked directly as the `$specops-interview` skill.
 
@@ -39,6 +45,7 @@ V2 has now started and the first formal artifact breadth is delivered on top of 
 - `deployment-model.md`
 - broadened `state-model.md`
 - richer artifact lineage and cross-view traceability
+- Mermaid outputs for domain, interaction, deployment, and state publication
 
 The remaining roadmap is now follow-on V2 expansion plus integrations/productization rather than
 foundational UML readiness work.
@@ -92,6 +99,7 @@ uv sync --extra yaml
 - [V1.6 Specification Hardening](docs/v1.6-specification-hardening.md)
 - [V2 Go/No-Go Decision](docs/v2-go-no-go-decision.md)
 - [RUP Artifact Coverage Matrix](docs/rup-artifact-coverage-matrix.md)
+- [Repo Review](docs/repo-review-2026-04.md)
 - [Mermaid Publication Workflows](docs/mermaid-publication-workflows.md)
 - [Document Ingestion Future Direction](docs/document-ingestion-future.md)
 - [Dogfooding Workflow](docs/dogfooding.md)

--- a/docs/end-to-end-usage.md
+++ b/docs/end-to-end-usage.md
@@ -1,0 +1,181 @@
+# End-to-End Usage
+
+This document explains the supported end-to-end ways to use SpecOps today.
+
+## Recommended Mental Model
+
+SpecOps has one central rule:
+
+- the canonical model is the source of truth
+
+Everything else hangs off that:
+
+- interviews produce structured replay output
+- replay output normalizes into the canonical model
+- formal Markdown artifacts render from the canonical model
+- Mermaid diagrams render from the canonical model
+- UCP estimation renders from the canonical model
+
+Do not treat raw interview text, copied Markdown, or Mermaid files as the primary editing surface.
+
+## Workflow 1: Model To Artifacts
+
+Use this when you already have a canonical model.
+
+### Formal Markdown Artifacts
+
+```bash
+uv run specops-render \
+  --model examples/it-systems-inventory/specops-model.json \
+  --output-dir /tmp/specops-formal \
+  --artifact-family formal
+```
+
+This renders:
+
+- `requirements-spec.md`
+- `use-case-model.md`
+- `domain-model.md`
+- `interaction-model.md`
+- `deployment-model.md`
+- `state-model.md`
+
+### UCP Estimate
+
+```bash
+uv run specops-ucp --model examples/it-systems-inventory/specops-model.json
+```
+
+Or through the renderer:
+
+```bash
+uv run specops-render \
+  --model examples/it-systems-inventory/specops-model.json \
+  --output-dir /tmp/specops-ucp \
+  --artifact-family ucp
+```
+
+### Mermaid Outputs
+
+```bash
+uv run specops-render \
+  --model examples/it-systems-inventory/specops-model.json \
+  --output-dir /tmp/specops-mermaid-domain \
+  --artifact-family domain-mermaid
+
+uv run specops-render \
+  --model examples/it-systems-inventory/specops-model.json \
+  --output-dir /tmp/specops-mermaid-interaction \
+  --artifact-family interaction-mermaid
+
+uv run specops-render \
+  --model examples/it-systems-inventory/specops-model.json \
+  --output-dir /tmp/specops-mermaid-deployment \
+  --artifact-family deployment-mermaid
+
+uv run specops-render \
+  --model examples/it-systems-inventory/specops-model.json \
+  --output-dir /tmp/specops-mermaid-state \
+  --artifact-family state-mermaid
+```
+
+## Workflow 2: Interview Fixture To Formal Artifacts
+
+Use this when you have a replayable interview fixture and want the normalized model plus the formal
+artifact bundle.
+
+```bash
+uv run python -m specops_tools.interview_to_formal_cli \
+  --input tests/fixtures/it_systems_inventory_session.json \
+  --output-dir /tmp/specops-from-interview \
+  --write-model /tmp/specops-from-interview/specops-model.json
+```
+
+This does three things:
+
+1. replay the interview fixture
+2. normalize the replay into the canonical model
+3. render the formal Markdown artifact family
+
+## Workflow 3: Replay Or Update An Existing Interview Fixture
+
+Use this when new information arrives later and you want to update an existing interview session
+without starting over.
+
+### Replay Existing Fixture
+
+```bash
+uv run specops-interview-replay \
+  --input tests/fixtures/it_systems_inventory_session.json
+```
+
+### Replay With Targeted Updates
+
+```bash
+uv run specops-interview-replay \
+  --input tests/fixtures/it_systems_inventory_session.json \
+  --updates path/to/updates.json
+```
+
+The replay result includes:
+
+- merged interview answers
+- readiness by view
+- stale downstream artifacts
+- traceability validation
+
+## Workflow 4: Process One Interview Round
+
+Use this for low-level testing or skill development.
+
+```bash
+uv run specops-interview --round 3 --input path/to/answers.txt
+```
+
+You can also pipe text through stdin:
+
+```bash
+cat path/to/answers.txt | uv run specops-interview --round 3
+```
+
+## Skill Usage
+
+The repo also ships local skills intended for Codex-style environments:
+
+- `$specops`
+- `$specops-interview`
+- `$specops-discovery`
+- `$specops-use-cases`
+- `$specops-ucp`
+
+Recommended skill-level flow:
+
+1. start with `$specops-interview` or `$specops`
+2. normalize with `$specops-discovery`
+3. refine actors/use cases with `$specops-use-cases`
+4. estimate with `$specops-ucp`
+
+These skills are repo-local assets, not a standalone published package format by themselves.
+
+## Recommended Public Demo Flow
+
+For a concrete example, use the IT systems inventory fixture and model under
+`examples/it-systems-inventory/`.
+
+Suggested public demo order:
+
+1. replay the fixture
+2. generate the normalized model
+3. render the formal Markdown bundle
+4. render the Mermaid bundle
+5. inspect the checked-in example outputs
+
+## Failure Expectations
+
+SpecOps does not silently invent fallback values for missing model fields.
+
+In practice this means:
+
+- UCP rendering can fail if required estimate inputs are missing
+- YAML input support fails clearly unless the optional dependency is installed
+- incomplete views should remain partial or blocked instead of being silently fabricated

--- a/docs/github-issue-map.md
+++ b/docs/github-issue-map.md
@@ -92,6 +92,7 @@ These themes now shape the completed bridge into V1.6 hardening work.
 
 See also: [V2 Go/No-Go Decision](v2-go-no-go-decision.md)
 See also: [RUP Artifact Coverage Matrix](rup-artifact-coverage-matrix.md)
+See also: [Repo Review: April 2026](repo-review-2026-04.md)
 See also: [Mermaid Publication Workflows](mermaid-publication-workflows.md)
 See also: [Document Ingestion Future Direction](document-ingestion-future.md)
 

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -8,9 +8,11 @@ while later work expands UML/formalization and integration support.
 
 ## Objective
 
-Deliver a reusable Codex-native skill pack for software requirements discovery. The first release
-must capture requirements through an interview, persist them in one canonical model, and generate a
-requirements spec, use-case model, and UCP estimate from that shared model.
+Deliver a reusable Codex-native, model-driven specification system. The original first release
+captured requirements through an interview, persisted them in one canonical model, and generated a
+requirements spec, use-case model, and UCP estimate from that shared model. The current system now
+extends that baseline with formal domain, interaction, deployment, and state artifacts plus Mermaid
+publication outputs generated from the same model.
 
 ## Workstreams
 
@@ -88,7 +90,12 @@ V1.6 focuses on:
 
 Reference: [V1.6 Specification Hardening](v1.6-specification-hardening.md)
 
-## Remaining Roadmap After V1.6
+## Remaining Roadmap After Initial V2 Delivery
 
-- V2 UML and formal specification translation at broader artifact breadth
+The initial V2 UML/formal translation breadth is now delivered on `main`.
+
+Remaining roadmap:
+
 - V2 integrations and productization
+- document-ingestion and hybrid document-to-spec workflows
+- broader publication and workflow polish around the delivered formal and Mermaid outputs

--- a/docs/repo-review-2026-04.md
+++ b/docs/repo-review-2026-04.md
@@ -1,0 +1,67 @@
+# Repo Review: April 2026
+
+## Purpose
+
+This note records a high-level review of the repo after V1, V1.5, V1.6, initial V2 formal
+translation, and Mermaid publication support were delivered.
+
+## Completed As Planned
+
+- interview-driven requirements capture
+- canonical model as the source of truth
+- deterministic UCP calculation
+- deterministic Markdown artifact rendering
+- replayable fixtures and regression tests
+- dogfooding through GitHub issue-driven work
+
+These were the core promises of the original repository plan, and they are delivered.
+
+## Expanded Correctly
+
+The repo expanded beyond the original V1 plan, but mostly in the right way:
+
+- `V1.5` added iterative interview support, ambiguity handling, provenance, readiness, and staleness
+- `V1.6` hardened the model semantics, cross-view traceability, and analysis/design separation
+- initial `V2` delivered broader formal artifact families:
+  - `domain-model.md`
+  - `interaction-model.md`
+  - `deployment-model.md`
+  - broadened `state-model.md`
+- Mermaid publication paths now exist for domain, interaction, deployment, and state outputs
+
+This is good expansion because it preserved the original architecture rather than bypassing it.
+
+## What Is Solid
+
+- the canonical model remains the center of gravity
+- deterministic tooling still owns the brittle parts
+- interview, normalization, rendering, and estimation remain separated
+- analysis and design concerns are no longer collapsed into one layer
+- traceability and readiness are explicit instead of implied
+
+The repo is now materially more than a requirements discovery tool. It is a model-driven
+specification system.
+
+## What Is Still Inconsistent
+
+- top-level docs have lagged behind delivered capability
+- example bundles have occasionally lagged behind model evolution
+- the repo still lacks standalone vision and supplementary specification artifacts
+- productization and workflow polish lag behind the capability already in the engine
+
+None of these are foundational design failures. They are synchronization and product-surface gaps.
+
+## Recommended Next Fixes
+
+1. Keep the example bundles current whenever the canonical model evolves.
+2. Tighten publishing and workflow UX under `#7`.
+3. Advance document ingestion and hybrid model-building under `#65`.
+4. Fill the remaining standalone specification gaps for vision and supplementary requirements.
+
+## Bottom Line
+
+Directionally, the repo is correct.
+
+Compared with the original plan, the system is ahead in capability and still coherent in
+architecture. The main risk now is not that the engine is wrong. It is that examples, docs, and
+workflow polish drift behind the engine.

--- a/docs/rup-artifact-coverage-matrix.md
+++ b/docs/rup-artifact-coverage-matrix.md
@@ -24,11 +24,11 @@ to make the current gap visible between:
 | Vision / scope | problem, stakeholders, business goals, scope | `partial` | `project`, `business_goals`, `success_criteria`, rendered in `requirements-spec.md` | no standalone vision artifact yet |
 | Supplementary requirements | non-functional requirements, constraints, quality attributes | `partial` | `requirements.non_functional`, `requirements-spec.md` | stronger fit criteria and broader formal structure still needed |
 | Use-case model | actors, goals, scenarios, extensions | `full` | `use-case-model.md`, canonical actors/use cases | could deepen, but already credible |
-| Analysis model: domain / logical view | domain concepts, relationships, rules | `partial` | `analysis_view`, `logical_view`, rendered in `requirements-spec.md` | `#11` domain and class modeling |
+| Analysis model: domain / logical view | domain concepts, relationships, rules | `full` | `domain-model.md`, `analysis_view`, `logical_view`, Mermaid `classDiagram` output | deeper domain semantics and product polish, not a missing artifact family |
 | Analysis model: state / process view | states, transitions, triggers, approvals | `full` | `state-model.md`, `analysis_view`, `process_view` | broader V2 state breadth in `#15` |
-| Analysis model: interaction view | realization of use cases as messages/interactions | `missing` | trace links and use cases only | `#14` interaction diagram support |
-| Design model: component view | components, interfaces, responsibilities | `partial` | `design_view`, `architecture_view`, rendered sections in existing artifacts | `#12` component and deployment modeling |
-| Design model: deployment / physical view | nodes, runtime boundaries, deployment placement | `partial` | `runtime_boundary_objects`, architecture sections | `#12` component and deployment modeling |
+| Analysis model: interaction view | realization of use cases as messages/interactions | `full` | `interaction-model.md`, `interaction_view`, Mermaid `sequenceDiagram` output | deeper semantics and publication polish, not a missing artifact family |
+| Design model: component view | components, interfaces, responsibilities | `full` | `deployment-model.md`, `design_view`, Mermaid deployment/architecture output | stronger deployment semantics and productization remain |
+| Design model: deployment / physical view | nodes, runtime boundaries, deployment placement | `full` | `deployment-model.md`, `runtime_boundary_objects`, Mermaid deployment/architecture output | stronger physical/deployment semantics remain |
 | Cross-artifact traceability | requirement -> use case -> analysis -> design | `partial` | canonical `traceability` plus validation and rendered trace sections | `#13` broader RUP traceability layer |
 | Estimate / planning support | size and effort estimation | `full` | `ucp-estimate.md` | not a classic RUP core artifact, but implemented |
 
@@ -51,11 +51,11 @@ architecture workflow.
 
 The main gaps are:
 
-- no standalone domain/class model artifact
-- no interaction artifact family
-- no formal component/deployment artifact family
-- traceability is real, but not yet broad enough to count as a full RUP trace layer
-- no standalone vision or supplementary specification artifact set
+- no standalone vision artifact
+- no standalone supplementary specification artifact
+- traceability is real, but still narrower than a complete RUP trace suite
+- deployment output is practical and publishable, but not yet a UML-pure deployment interchange path
+- productization and publishing workflows still lag behind the underlying specification engine
 
 ## Bottom Line
 
@@ -67,11 +67,13 @@ If the question is:
 
 The repo is now best described as:
 
-> a RUP-aligned canonical model and partial artifact system, not yet a full RUP artifact suite
+> a RUP-aligned canonical model and materially broader artifact system, but not yet a full RUP
+> artifact suite
 
 ## Recommended Next Move
 
-If V2 proceeds, the strongest next artifact family is still `#11` domain and class modeling.
+The strongest next work is no longer another missing core artifact family. It is:
 
-That closes the largest visible gap after the V1.6 `state-model.md` proof and moves SpecOps closer
-to a genuinely broader RUP-style specification set.
+- productization of the existing formal and Mermaid outputs under `#7`
+- document ingestion and hybrid workflows under `#65`
+- cleanup of remaining standalone vision/supplementary specification gaps


### PR DESCRIPTION
Closes #105

## Summary
- update the top-level repo positioning to match the current specification-system scope
- correct stale planning and RUP coverage statements that still described delivered V2 breadth as future or missing
- add a short repo review note summarizing what was completed as planned, what expanded correctly, and what still needs tightening

## Verification
- documentation only