### PR TITLE
Productize the Rupify CLI workflow surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,21 @@ If you want YAML model support:
 uv sync --extra yaml
 ```
 
+## Quick Start
+
+Choose the workflow that matches what you already have:
+
+- Have a canonical model and want Markdown or Mermaid artifacts:
+  use `rupify-render`
+- Have a canonical model and only want the UCP estimate:
+  use `rupify-ucp`
+- Have an interview fixture and want the formal bundle plus normalized model:
+  use `rupify-interview-to-formal`
+- Have an interview fixture and want replay/readiness/staleness output only:
+  use `rupify-interview-replay`
+- Want to process a single interview round manually:
+  use `rupify-interview`
+
 ### Available CLI Entry Points
 
 After `uv sync`, the current supported commands are:
@@ -92,14 +107,9 @@ After `uv sync`, the current supported commands are:
 ```bash
 uv run rupify-interview --help
 uv run rupify-interview-replay --help
+uv run rupify-interview-to-formal --help
 uv run rupify-ucp --help
 uv run rupify-render --help
-```
-
-There is also one module-only CLI for the interview-fixture-to-formal flow:
-
-```bash
-uv run python -m rupify_tools.interview_to_formal_cli --help
 ```
 
 Common commands:
@@ -113,7 +123,7 @@ uv run python -m rupify_tools.render_cli --model examples/it-systems-inventory/r
 uv run python -m rupify_tools.render_cli --model examples/it-systems-inventory/rupify-model.json --output-dir /tmp/rupify-mermaid-state --artifact-family state-mermaid
 uv run python -m rupify_tools.render_cli --model examples/it-systems-inventory/rupify-model.json --output-dir /tmp/rupify-mermaid-interaction --artifact-family interaction-mermaid
 uv run python -m rupify_tools.render_cli --model examples/it-systems-inventory/rupify-model.json --output-dir /tmp/rupify-mermaid-deployment --artifact-family deployment-mermaid
-uv run python -m rupify_tools.interview_to_formal_cli --input tests/fixtures/it_systems_inventory_session.json --output-dir /tmp/rupify-from-interview --write-model /tmp/rupify-from-interview/rupify-model.json
+uv run rupify-interview-to-formal --input tests/fixtures/it_systems_inventory_session.json --output-dir /tmp/rupify-from-interview --write-model /tmp/rupify-from-interview/rupify-model.json
 ```
 
 YAML parsing is optional and intentionally not installed by default. If you want the CLI tools to

--- a/docs/end-to-end-usage.md
+++ b/docs/end-to-end-usage.md
@@ -2,6 +2,14 @@
 
 This document explains the supported end-to-end ways to use Rupify today.
 
+## Choose The Right Command
+
+- `rupify-render`: start from a canonical model and generate Markdown or Mermaid artifacts
+- `rupify-ucp`: start from a canonical model and calculate only the UCP estimate
+- `rupify-interview-to-formal`: start from an interview fixture and generate the normalized model plus the formal Markdown bundle
+- `rupify-interview-replay`: start from an interview fixture and inspect replay, readiness, staleness, and trace validation
+- `rupify-interview`: process one interview round directly
+
 ## Recommended Mental Model
 
 Rupify has one central rule:
@@ -85,7 +93,7 @@ Use this when you have a replayable interview fixture and want the normalized mo
 artifact bundle.
 
 ```bash
-uv run python -m rupify_tools.interview_to_formal_cli \
+uv run rupify-interview-to-formal \
   --input tests/fixtures/it_systems_inventory_session.json \
   --output-dir /tmp/rupify-from-interview \
   --write-model /tmp/rupify-from-interview/rupify-model.json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ yaml = [
 [project.scripts]
 rupify-interview = "rupify_tools.interview_cli:main"
 rupify-interview-replay = "rupify_tools.interview_replay:main"
+rupify-interview-to-formal = "rupify_tools.interview_to_formal_cli:main"
 rupify-ucp = "rupify_tools.ucp_cli:main"
 rupify-render = "rupify_tools.render_cli:main"
 


### PR DESCRIPTION
## Summary
- add a first-class rupify-interview-to-formal CLI so every supported workflow has a named command
- rewrite the top-level workflow docs around choosing the right command instead of repo-internal module paths
- keep the open-source onboarding path focused on the supported happy paths

## Verification
- uv run python -m unittest tests.test_interview

Closes #86