### PR TITLE
Add CI and CodeQL workflows for public release

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,48 @@
+name: codeql
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  schedule:
+    - cron: "0 4 * * 1"
+
+jobs:
+  analyze:
+    name: codeql-analyze
+    if: github.event.repository.private == false
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - python
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install project
+        run: uv sync --extra yaml
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install project
+        run: uv sync --extra yaml
+
+      - name: Run test suite
+        run: uv run python -m unittest

--- a/docs/public-release-checklist.md
+++ b/docs/public-release-checklist.md
@@ -32,7 +32,11 @@ Recommended minimum settings:
 At minimum, protect the repository with the automated verification that proves the packaged CLI and
 rendering workflow still work:
 
-- Python test suite
+- `test`
+
+Once the repository is public and CodeQL can run, also require:
+
+- `codeql-analyze`
 
 If CI is later expanded, keep branch protection aligned with the actual required checks instead of
 leaving settings stale.
@@ -42,6 +46,7 @@ leaving settings stale.
 - rename the repository to `rupify`
 - confirm the default branch is `main`
 - confirm branch protection is active on `main`
+- confirm `test` is required before merge
 - enable issues
 - enable pull requests
 - disable force pushes to protected branches
@@ -57,6 +62,7 @@ Before making the repository public, verify:
 - no private/internal-only references remain in the main documentation
 - archived historical planning material is clearly separated from active docs
 - the chosen license is present and correct
+- the `test` workflow has run successfully at least once on GitHub
 
 ## Post-Rename Follow-Up
 
@@ -65,3 +71,5 @@ After renaming the repository:
 - confirm links in the README and docs still resolve
 - confirm open PR and issue references still render correctly
 - confirm package install and `uv run` workflows still work from a fresh clone
+- enable CodeQL code scanning if it is not already active
+- add `codeql-analyze` to the required checks on `main`


### PR DESCRIPTION
## Summary
- add a GitHub Actions test workflow for pull requests and pushes to main
- add a CodeQL workflow that becomes active once the repository is public
- document the exact required check names in the public release checklist

## Verification
- uv run python -m unittest

Closes #114