### PR TITLE
Define template-driven model extensions

### DIFF
--- a/docs/github-issue-map.md
+++ b/docs/github-issue-map.md
@@ -88,6 +88,7 @@ These themes now shape the completed bridge into V1.6 hardening work.
 ## Open Epics
 
 - `#7` `EPIC: SpecOps V2 integrations and productization`
+- `#123` `EPIC: Add template-driven system, use-case, and scenario document suite`
 - `#65` `Add document ingestion and hybrid document-to-spec workflow`
 
 See also: [V2 Go/No-Go Decision](v2-go-no-go-decision.md)
@@ -105,6 +106,8 @@ See also: [Document Ingestion Future Direction](document-ingestion-future.md)
   epics
 - the initial V2 UML/formal translation epic is complete and establishes the first broader formal
   artifact family on top of the stricter V1.6 baseline
+- the template-driven document-suite epic extends the canonical model toward concrete appendix-style
+  deliverables for system, use-case, and scenario documents
 - the remaining V2 work is now expansion and productization rather than foundational translation
 
 ## Labels To Use

--- a/docs/rup-artifact-coverage-matrix.md
+++ b/docs/rup-artifact-coverage-matrix.md
@@ -24,6 +24,9 @@ to make the current gap visible between:
 | Vision / scope | problem, stakeholders, business goals, scope | `partial` | `project`, `business_goals`, `success_criteria`, rendered in `requirements-spec.md` | no standalone vision artifact yet |
 | Supplementary requirements | non-functional requirements, constraints, quality attributes | `partial` | `requirements.non_functional`, `requirements-spec.md` | stronger fit criteria and broader formal structure still needed |
 | Use-case model | actors, goals, scenarios, extensions | `full` | `use-case-model.md`, canonical actors/use cases | could deepen, but already credible |
+| Template-driven system/subsystem document | overview, risks, system-level use cases, architecture, subsystem descriptions | `missing` | partial inputs across `project`, `design_view`, `architecture_view` | `#123` template-driven document suite |
+| Template-driven use-case document | per-use-case status, priorities, flows, secondary scenarios, UI, related artifacts | `partial` | canonical use cases, interaction/process/design views | `#123` template-driven document suite |
+| Template-driven scenario document | scenario-level flow, sequence/activity views, artifact references | `missing` | scenario content is implicit inside use cases rather than first-class | `#123` template-driven document suite |
 | Analysis model: domain / logical view | domain concepts, relationships, rules | `full` | `domain-model.md`, `analysis_view`, `logical_view`, Mermaid `classDiagram` output | deeper domain semantics and product polish, not a missing artifact family |
 | Analysis model: state / process view | states, transitions, triggers, approvals | `full` | `state-model.md`, `analysis_view`, `process_view` | broader V2 state breadth in `#15` |
 | Analysis model: interaction view | realization of use cases as messages/interactions | `full` | `interaction-model.md`, `interaction_view`, Mermaid `sequenceDiagram` output | deeper semantics and publication polish, not a missing artifact family |
@@ -75,5 +78,6 @@ The repo is now best described as:
 The strongest next work is no longer another missing core artifact family. It is:
 
 - productization of the existing formal and Mermaid outputs under `#7`
+- template-driven system, use-case, and scenario documents under `#123`
 - document ingestion and hybrid workflows under `#65`
 - cleanup of remaining standalone vision/supplementary specification gaps

--- a/skills/rupify/references/rupify-model.md
+++ b/skills/rupify/references/rupify-model.md
@@ -11,6 +11,15 @@ The canonical project model is `rupify-model.yaml`.
   - `system_scope`
 - `business_goals`
 - `success_criteria`
+- `risks` (compatibility mirror derived from `analysis_view.risk_objects`)
+  - `id`
+  - `name`
+  - `description`
+  - `priority`
+  - `status`
+  - `mitigation`
+  - `model_layer`: `analysis`
+  - `trace`
 - `actors` (compatibility mirror derived from `analysis_view.actors`)
   - `id`
   - `name`
@@ -31,9 +40,35 @@ The canonical project model is `rupify-model.yaml`.
   - `trigger`
   - `preconditions`
   - `postconditions`
+  - `priority`
+  - `status`
   - `complexity`: `simple`, `average`, or `complex`
   - `main_success_scenario`
   - `extensions`
+  - `extension_points`
+  - `used_use_case_ids`
+  - `subordinate_use_case_ids`
+  - `ui_notes`
+  - `participating_analysis_object_ids`
+  - `other_artifact_refs`
+  - `other_requirement_ids`
+  - `scenario_ids`
+- `scenarios` (compatibility mirror derived from `analysis_view.scenario_objects`)
+  - `id`
+  - `name`
+  - `use_case_id`
+  - `use_case_name`
+  - `model_layer`: `analysis`
+  - `summary`
+  - `priority`
+  - `status`
+  - `flow_of_events`
+  - `activity_notes`
+  - `sequence_notes`
+  - `other_artifact_refs`
+  - `participating_analysis_object_ids`
+  - `other_requirement_ids`
+  - `trace`
 - `requirements`
   - `functional`
   - `functional_objects`
@@ -58,6 +93,8 @@ The canonical project model is `rupify-model.yaml`.
 - `analysis_view` (authoritative source for analysis-layer objects)
   - `actors`
   - `use_cases`
+  - `scenario_objects`
+  - `risk_objects`
   - `requirement_objects`
   - `domain_entity_objects`
   - `relationship_objects`
@@ -67,6 +104,8 @@ The canonical project model is `rupify-model.yaml`.
   - `trigger_objects`
   - `actor_ids`
   - `use_case_ids`
+  - `scenario_ids`
+  - `risk_ids`
   - `requirement_ids`
   - `domain_entity_ids`
   - `relationship_ids`
@@ -74,6 +113,31 @@ The canonical project model is `rupify-model.yaml`.
   - `state_entity_ids`
   - `state_transition_ids`
   - `trigger_ids`
+  - `scenario_objects`
+    - `id`
+    - `name`
+    - `use_case_id`
+    - `use_case_name`
+    - `model_layer`: `analysis`
+    - `summary`
+    - `priority`
+    - `status`
+    - `flow_of_events`
+    - `activity_notes`
+    - `sequence_notes`
+    - `other_artifact_refs`
+    - `participating_analysis_object_ids`
+    - `other_requirement_ids`
+    - `trace`
+  - `risk_objects`
+    - `id`
+    - `name`
+    - `description`
+    - `priority`
+    - `status`
+    - `mitigation`
+    - `model_layer`: `analysis`
+    - `trace`
 - `traceability`
   - `requirement_to_use_case`
     - `id`
@@ -270,6 +334,9 @@ For V1.5+ work, the same model should also have stable places to hold:
 - logical-view discovery
 - process/state-view discovery
 - architecture/deployment-view discovery
+- template-driven system/subsystem document fields
+- template-driven use-case document fields
+- template-driven scenario document fields
 
 For the V1.6 proof artifact, `state-model.md` is generated from the canonical process semantics:
 

--- a/src/rupify_tools/discovery.py
+++ b/src/rupify_tools/discovery.py
@@ -621,9 +621,19 @@ def _normalize_use_cases(items: list[str]) -> list[dict[str, Any]]:
                 "trigger": "",
                 "preconditions": [],
                 "postconditions": [],
+                "priority": "",
+                "status": "",
                 "complexity": "unclassified",
                 "main_success_scenario": [],
                 "extensions": [],
+                "extension_points": [],
+                "used_use_case_ids": [],
+                "subordinate_use_case_ids": [],
+                "ui_notes": [],
+                "participating_analysis_object_ids": [],
+                "other_artifact_refs": [],
+                "other_requirement_ids": [],
+                "scenario_ids": [],
                 "trace": {},
             }
         )
@@ -723,6 +733,37 @@ def _build_trace_links(
         "use_case_to_analysis": use_case_to_analysis,
         "analysis_to_design": analysis_to_design,
     }
+
+
+def _bind_use_case_supporting_links(
+    use_cases: list[dict[str, Any]],
+    requirement_objects: list[dict[str, Any]],
+    traceability: dict[str, list[dict[str, Any]]],
+) -> None:
+    """Populate deterministic supporting links on use cases from derived trace data."""
+    linked_requirements_by_use_case: dict[str, list[str]] = {}
+    for requirement in requirement_objects:
+        requirement_id = requirement.get("id", "")
+        if not requirement_id:
+            continue
+        for use_case_id in requirement.get("linked_use_case_ids", []):
+            linked_requirements_by_use_case.setdefault(use_case_id, []).append(requirement_id)
+
+    participating_analysis_ids_by_use_case: dict[str, list[str]] = {}
+    for link in traceability.get("use_case_to_analysis", []):
+        use_case_id = str(link.get("from_id", "")).strip()
+        analysis_id = str(link.get("to_id", "")).strip()
+        if not use_case_id or not analysis_id:
+            continue
+        participating_analysis_ids_by_use_case.setdefault(use_case_id, []).append(analysis_id)
+
+    for use_case in use_cases:
+        use_case_id = use_case.get("id", "")
+        use_case["other_requirement_ids"] = linked_requirements_by_use_case.get(use_case_id, [])
+        use_case["participating_analysis_object_ids"] = participating_analysis_ids_by_use_case.get(
+            use_case_id,
+            [],
+        )
 
 
 def _build_artifact_lineage(
@@ -1089,9 +1130,13 @@ def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
     analysis_view = {
         "actor_ids": [item["id"] for item in normalized_actors],
         "use_case_ids": [item["id"] for item in normalized_use_cases],
+        "scenario_ids": [],
+        "risk_ids": [],
         "requirement_ids": [item["id"] for item in all_requirement_objects],
         "actors": normalized_actors,
         "use_cases": normalized_use_cases,
+        "scenario_objects": [],
+        "risk_objects": [],
         "requirement_objects": all_requirement_objects,
         "domain_entity_objects": domain_entity_objects,
         "relationship_objects": relationship_objects,
@@ -1129,6 +1174,11 @@ def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
         state_entity_objects,
         component_objects,
     )
+    _bind_use_case_supporting_links(
+        normalized_use_cases,
+        all_requirement_objects,
+        traceability,
+    )
     traceability["artifact_lineage"] = _build_artifact_lineage(
         all_requirement_objects,
         normalized_use_cases,
@@ -1154,8 +1204,10 @@ def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
         },
         "business_goals": _ensure_list(round_2.get("outcomes")),
         "success_criteria": _ensure_list(round_2.get("success_criteria")),
+        "risks": [],
         "actors": normalized_actors,
         "use_cases": normalized_use_cases,
+        "scenarios": [],
         "requirements": {
             "functional": _requirement_statements_by_kind(all_requirement_objects, "functional"),
             "functional_objects": functional_requirement_objects,

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -256,6 +256,10 @@ class DiscoveryTests(unittest.TestCase):
         self.assertEqual(model["process_view"]["state_entity_objects"], [])
         self.assertEqual(model["architecture_view"]["components_and_services"], [])
         self.assertEqual(model["architecture_view"]["component_objects"], [])
+        self.assertEqual(model["analysis_view"]["scenario_objects"], [])
+        self.assertEqual(model["analysis_view"]["risk_objects"], [])
+        self.assertEqual(model["scenarios"], [])
+        self.assertEqual(model["risks"], [])
         self.assertEqual(model["actors"], [])
         self.assertEqual(model["use_cases"], [])
 
@@ -298,10 +302,26 @@ class DiscoveryTests(unittest.TestCase):
         self.assertEqual(model["use_cases"][0]["trigger"], "")
         self.assertEqual(model["use_cases"][0]["preconditions"], [])
         self.assertEqual(model["use_cases"][0]["postconditions"], [])
+        self.assertEqual(model["use_cases"][0]["priority"], "")
+        self.assertEqual(model["use_cases"][0]["status"], "")
+        self.assertEqual(model["use_cases"][0]["extension_points"], [])
+        self.assertEqual(model["use_cases"][0]["used_use_case_ids"], [])
+        self.assertEqual(model["use_cases"][0]["subordinate_use_case_ids"], [])
+        self.assertEqual(model["use_cases"][0]["ui_notes"], [])
+        self.assertEqual(model["use_cases"][0]["participating_analysis_object_ids"], [])
+        self.assertEqual(model["use_cases"][0]["other_artifact_refs"], [])
+        self.assertEqual(model["use_cases"][0]["other_requirement_ids"], [])
+        self.assertEqual(model["use_cases"][0]["scenario_ids"], [])
         self.assertEqual(model["use_cases"][0]["trace"]["source_key"], "use_cases")
         self.assertEqual(model["use_cases"][1]["complexity"], "unclassified")
         self.assertEqual(model["analysis_view"]["actor_ids"][0], "operations-manager")
         self.assertEqual(model["analysis_view"]["use_case_ids"][0], "browse-rewards")
+        self.assertEqual(model["analysis_view"]["scenario_ids"], [])
+        self.assertEqual(model["analysis_view"]["risk_ids"], [])
+        self.assertEqual(model["analysis_view"]["scenario_objects"], [])
+        self.assertEqual(model["analysis_view"]["risk_objects"], [])
+        self.assertEqual(model["scenarios"], [])
+        self.assertEqual(model["risks"], [])
         self.assertEqual(model["analysis_view"]["actors"][0]["id"], "operations-manager")
         self.assertEqual(model["analysis_view"]["use_cases"][0]["id"], "browse-rewards")
         self.assertEqual(model["actors"], model["analysis_view"]["actors"])
@@ -551,8 +571,16 @@ class DiscoveryTests(unittest.TestCase):
             ["approve-system"],
         )
         self.assertEqual(
+            model["use_cases"][0]["other_requirement_ids"],
+            ["functional-requirement-1"],
+        )
+        self.assertEqual(
             model["traceability"]["use_case_to_analysis"][0]["to_id"],
             "entity-system",
+        )
+        self.assertEqual(
+            model["use_cases"][0]["participating_analysis_object_ids"],
+            ["entity-system"],
         )
         self.assertEqual(
             model["traceability"]["analysis_to_design"][0]["to_id"],


### PR DESCRIPTION
## Summary
- add first-class canonical model homes for risks, scenarios, and richer use-case metadata
- derive supporting use-case links for related requirements and participating analysis objects
- update the model contract and coverage/issue-map docs for the new template-driven document epic

## Testing
- uv run python -m unittest tests.test_discovery
- uv run python -m unittest

Closes #129
Part of #123
