### PR TITLE
Extend interview and normalization for template-driven documents

### DIFF
--- a/skills/rupify-interview/references/interview-rounds.md
+++ b/skills/rupify-interview/references/interview-rounds.md
@@ -235,6 +235,50 @@ analyst capability:
 ...
 ```
 
+## Round 12: Risks
+
+Ask at most 1 focused prompt.
+
+Preferred answer shape:
+
+```text
+Risks:
+- Risk name | priority: high/medium/low | status: open/mitigated/accepted | mitigation: ...
+```
+
+Collect:
+
+- the major risks that materially affect scope, delivery, architecture, compliance, or data quality
+- priority and current status where known
+- short mitigation notes when they are already clear
+
+Keep this list short and decision-relevant.
+
+## Round 13: Use-Case and Scenario Details
+
+Ask at most 3 prompts.
+
+Preferred answer shape:
+
+```text
+Use-case details:
+- Use Case | priority: high/medium/low | status: drafted/in progress/confirmed
+Scenarios:
+- Use Case | Scenario Name | summary | priority: high/medium/low | status: drafted/in progress/confirmed
+UI notes:
+- Use Case | note
+```
+
+Collect:
+
+- per-use-case priority and status
+- used/subordinate use-case relationships when they are known
+- named scenarios that deserve first-class scenario documents
+- UI or storyboard notes for human-facing use cases where they materially matter
+
+Keep this round concise and document-oriented. Do not explode it into long scenario prose unless the
+user explicitly wants to go deeper.
+
 ## Stopping Rule
 
 If the user cannot answer a round comfortably, do one of these:

--- a/src/rupify_tools/discovery.py
+++ b/src/rupify_tools/discovery.py
@@ -666,6 +666,192 @@ def _normalize_requirement_objects(
     return objects
 
 
+def _split_structured_parts(item: str) -> list[str]:
+    """Split a pipe-delimited structured answer into trimmed parts."""
+    return [part.strip() for part in item.split("|") if part.strip()]
+
+
+def _normalize_risks(items: list[str]) -> list[dict[str, Any]]:
+    """Convert structured risk strings into explicit risk objects."""
+    risk_objects = []
+    for index, item in enumerate(items, 1):
+        parts = _split_structured_parts(item)
+        if not parts:
+            continue
+        name = parts[0]
+        description = name
+        if ":" in name:
+            name_part, description_part = name.split(":", 1)
+            name = name_part.strip()
+            description = description_part.strip() or name
+
+        priority = ""
+        status = ""
+        mitigation = ""
+        for part in parts[1:]:
+            if ":" not in part:
+                continue
+            key, value = part.split(":", 1)
+            normalized_key = _slugify(key).replace("-", "_")
+            normalized_value = value.strip()
+            if normalized_key == "priority":
+                priority = normalized_value.lower()
+            elif normalized_key == "status":
+                status = normalized_value.lower()
+            elif normalized_key == "mitigation":
+                mitigation = normalized_value
+
+        risk_objects.append(
+            {
+                "id": f"risk-{_slugify(name) or index}",
+                "name": name,
+                "description": description,
+                "priority": priority,
+                "status": status,
+                "mitigation": mitigation,
+                "model_layer": "analysis",
+                "trace": {},
+            }
+        )
+
+    return risk_objects
+
+
+def _apply_use_case_details(
+    use_cases: list[dict[str, Any]],
+    items: list[str],
+) -> None:
+    """Apply structured use-case detail answers to canonical use cases in place."""
+    for item in items:
+        parts = _split_structured_parts(item)
+        if not parts:
+            continue
+
+        match = _best_name_match(parts[0], use_cases)
+        if match is None:
+            continue
+
+        for part in parts[1:]:
+            if ":" not in part:
+                continue
+            key, value = part.split(":", 1)
+            normalized_key = _slugify(key).replace("-", "_")
+            normalized_value = value.strip()
+            if normalized_key == "priority":
+                match["priority"] = normalized_value.lower()
+            elif normalized_key == "status":
+                match["status"] = normalized_value.lower()
+            elif normalized_key == "used":
+                used_ids = []
+                for name in [segment.strip() for segment in normalized_value.split(";") if segment.strip()]:
+                    linked_use_case = _best_name_match(name, use_cases)
+                    if linked_use_case is not None:
+                        used_ids.append(linked_use_case["id"])
+                match["used_use_case_ids"] = used_ids
+            elif normalized_key == "subordinate":
+                subordinate_ids = []
+                for name in [segment.strip() for segment in normalized_value.split(";") if segment.strip()]:
+                    linked_use_case = _best_name_match(name, use_cases)
+                    if linked_use_case is not None:
+                        subordinate_ids.append(linked_use_case["id"])
+                match["subordinate_use_case_ids"] = subordinate_ids
+            elif normalized_key == "extension_points":
+                match["extension_points"] = [
+                    segment.strip() for segment in normalized_value.split(";") if segment.strip()
+                ]
+
+
+def _normalize_scenarios(
+    items: list[str],
+    use_cases: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Convert structured scenario strings into explicit scenario objects."""
+    scenario_objects = []
+    for index, item in enumerate(items, 1):
+        parts = _split_structured_parts(item)
+        if len(parts) < 3:
+            continue
+
+        use_case_name = parts[0]
+        scenario_name = parts[1]
+        summary = parts[2]
+        use_case_match = _best_name_match(use_case_name, use_cases)
+        use_case_id = use_case_match["id"] if use_case_match else ""
+        resolved_use_case_name = use_case_match["name"] if use_case_match else use_case_name
+
+        priority = ""
+        status = ""
+        flow_of_events: list[str] = []
+        for part in parts[3:]:
+            if ":" not in part:
+                continue
+            key, value = part.split(":", 1)
+            normalized_key = _slugify(key).replace("-", "_")
+            normalized_value = value.strip()
+            if normalized_key == "priority":
+                priority = normalized_value.lower()
+            elif normalized_key == "status":
+                status = normalized_value.lower()
+            elif normalized_key == "flow":
+                flow_of_events = [
+                    segment.strip() for segment in normalized_value.split(";") if segment.strip()
+                ]
+
+        scenario_objects.append(
+            {
+                "id": f"scenario-{_slugify(scenario_name) or index}",
+                "name": scenario_name,
+                "use_case_id": use_case_id,
+                "use_case_name": resolved_use_case_name,
+                "model_layer": "analysis",
+                "summary": summary,
+                "priority": priority,
+                "status": status,
+                "flow_of_events": flow_of_events,
+                "activity_notes": [],
+                "sequence_notes": [],
+                "other_artifact_refs": [],
+                "participating_analysis_object_ids": [],
+                "other_requirement_ids": [],
+                "trace": {},
+            }
+        )
+
+    return scenario_objects
+
+
+def _apply_ui_notes(
+    use_cases: list[dict[str, Any]],
+    items: list[str],
+) -> None:
+    """Attach structured UI notes to the matching use cases."""
+    for item in items:
+        parts = _split_structured_parts(item)
+        if len(parts) < 2:
+            continue
+        match = _best_name_match(parts[0], use_cases)
+        if match is None:
+            continue
+        match["ui_notes"].append(" | ".join(parts[1:]))
+
+
+def _bind_scenario_links(
+    use_cases: list[dict[str, Any]],
+    scenario_objects: list[dict[str, Any]],
+) -> None:
+    """Attach scenario ids back onto their parent use cases."""
+    scenario_ids_by_use_case: dict[str, list[str]] = {}
+    for scenario in scenario_objects:
+        use_case_id = scenario.get("use_case_id", "")
+        scenario_id = scenario.get("id", "")
+        if not use_case_id or not scenario_id:
+            continue
+        scenario_ids_by_use_case.setdefault(use_case_id, []).append(scenario_id)
+
+    for use_case in use_cases:
+        use_case["scenario_ids"] = scenario_ids_by_use_case.get(use_case.get("id", ""), [])
+
+
 def _build_trace_links(
     requirement_objects: list[dict[str, Any]],
     use_cases: list[dict[str, Any]],
@@ -1018,6 +1204,8 @@ def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
     round_9 = merged_answers.get("round_9", {})
     round_10 = merged_answers.get("round_10", {})
     round_11 = merged_answers.get("round_11", {})
+    round_12 = merged_answers.get("round_12", {})
+    round_13 = merged_answers.get("round_13", {})
     constraints = _ensure_list(round_2.get("constraints"))
     normalized_actors = _with_trace(_normalize_actors(_ensure_list(round_3.get("actors"))), 3, "actors")
     normalized_use_cases = _with_trace(
@@ -1075,6 +1263,11 @@ def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
                 "non_functional_requirements",
             )
         )
+    risk_objects = _with_trace(
+        _normalize_risks(_ensure_list(round_12.get("risks"))),
+        12,
+        "risks",
+    )
 
     domain_entity_objects = _with_trace(
         _normalize_domain_entities(_ensure_list(round_5.get("domain_entities"))),
@@ -1126,17 +1319,34 @@ def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
         7,
         "runtime_boundaries",
     )
+    _apply_use_case_details(
+        normalized_use_cases,
+        _ensure_list(round_13.get("use_case_details")),
+    )
+    scenario_objects = _with_trace(
+        _normalize_scenarios(_ensure_list(round_13.get("scenarios")), normalized_use_cases),
+        13,
+        "scenarios",
+    )
+    _apply_ui_notes(
+        normalized_use_cases,
+        _ensure_list(round_13.get("ui_notes")),
+    )
+    _bind_scenario_links(
+        normalized_use_cases,
+        scenario_objects,
+    )
     all_requirement_objects = functional_requirement_objects + non_functional_requirement_objects
     analysis_view = {
         "actor_ids": [item["id"] for item in normalized_actors],
         "use_case_ids": [item["id"] for item in normalized_use_cases],
-        "scenario_ids": [],
-        "risk_ids": [],
+        "scenario_ids": [item["id"] for item in scenario_objects],
+        "risk_ids": [item["id"] for item in risk_objects],
         "requirement_ids": [item["id"] for item in all_requirement_objects],
         "actors": normalized_actors,
         "use_cases": normalized_use_cases,
-        "scenario_objects": [],
-        "risk_objects": [],
+        "scenario_objects": scenario_objects,
+        "risk_objects": risk_objects,
         "requirement_objects": all_requirement_objects,
         "domain_entity_objects": domain_entity_objects,
         "relationship_objects": relationship_objects,
@@ -1204,10 +1414,10 @@ def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
         },
         "business_goals": _ensure_list(round_2.get("outcomes")),
         "success_criteria": _ensure_list(round_2.get("success_criteria")),
-        "risks": [],
+        "risks": risk_objects,
         "actors": normalized_actors,
         "use_cases": normalized_use_cases,
-        "scenarios": [],
+        "scenarios": scenario_objects,
         "requirements": {
             "functional": _requirement_statements_by_kind(all_requirement_objects, "functional"),
             "functional_objects": functional_requirement_objects,

--- a/src/rupify_tools/interview.py
+++ b/src/rupify_tools/interview.py
@@ -429,6 +429,78 @@ ROUND_DEFINITIONS: list[InterviewRound] = [
             ),
         ),
     ),
+    InterviewRound(
+        number=12,
+        title="Risks",
+        prompt="Capture the major project or system risks that should appear in the document set.",
+        template="Risks:\n- Risk name | priority: high/medium/low | status: open/mitigated/accepted | mitigation: ...\n",
+        guidance=(
+            "Capture the major risks that materially affect scope, delivery, architecture, compliance, or data quality.",
+            "Keep the list short and concrete. Do not turn minor uncertainties into fake precision.",
+        ),
+        questions=(
+            InterviewQuestion(
+                "risks",
+                "Risks",
+                "What are the main risks and how should they be prioritized?",
+                guidance=(
+                    "Use one line per risk with a short name and optional priority, status, and mitigation.",
+                    "Example format: Data quality gaps | priority: high | status: open | mitigation: add onboarding validation",
+                ),
+                example="- Data quality gaps | priority: high | status: open | mitigation: add onboarding validation",
+            ),
+        ),
+    ),
+    InterviewRound(
+        number=13,
+        title="Use-Case and Scenario Details",
+        prompt=(
+            "Capture use-case priority/status plus explicit scenario and UI notes needed for the "
+            "template-driven document set."
+        ),
+        template=(
+            "Use-case details:\n"
+            "- Use Case | priority: high/medium/low | status: drafted/in progress/confirmed\n"
+            "Scenarios:\n"
+            "- Use Case | Scenario Name | summary | priority: high/medium/low | status: drafted/in progress/confirmed\n"
+            "UI notes:\n"
+            "- Use Case | note\n"
+        ),
+        guidance=(
+            "Keep these entries concise and document-oriented rather than expanding into a long narrative.",
+            "Only add UI notes for use cases where a human-facing interaction materially matters.",
+        ),
+        questions=(
+            InterviewQuestion(
+                "use_case_details",
+                "Use-case details",
+                "Which use cases need explicit priority, status, or relationships?",
+                guidance=(
+                    "Use one line per use case.",
+                    "You can also include used or subordinate use-case links: used: Validate owner; subordinate: Review risk",
+                ),
+                example="- Approve deprecation | priority: high | status: drafted | used: Validate owner | subordinate: Review risk",
+            ),
+            InterviewQuestion(
+                "scenarios",
+                "Scenarios",
+                "What named scenarios should become first-class scenario documents?",
+                guidance=(
+                    "Each line should name the parent use case, scenario, and a short summary.",
+                ),
+                example="- Approve deprecation | Happy path approval | Primary approval flow from submission to approval | priority: high | status: drafted",
+            ),
+            InterviewQuestion(
+                "ui_notes",
+                "UI notes",
+                "Where do we need explicit UI or storyboard notes?",
+                guidance=(
+                    "Use one line per use case when the human interaction materially affects the document set.",
+                ),
+                example="- Approve deprecation | Show risk summary, approver comments, and decision history",
+            ),
+        ),
+    ),
 ]
 
 

--- a/src/rupify_tools/readiness.py
+++ b/src/rupify_tools/readiness.py
@@ -8,11 +8,18 @@ from typing import Any
 VIEW_GATES = {
     "discovery": {
         "required": ("idea", "problem", "in_scope", "outcomes"),
-        "supporting": ("users", "out_of_scope", "success_criteria", "required_data", "constraints"),
+        "supporting": ("users", "out_of_scope", "success_criteria", "required_data", "constraints", "risks"),
     },
     "use_case": {
         "required": ("actors", "use_cases", "workflow_scope"),
-        "supporting": ("integrations", "metadata_fields", "non_functional_requirements"),
+        "supporting": (
+            "integrations",
+            "metadata_fields",
+            "non_functional_requirements",
+            "use_case_details",
+            "scenarios",
+            "ui_notes",
+        ),
     },
     "logical": {
         "required": ("domain_entities", "relationships"),

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -410,6 +410,76 @@ class DiscoveryTests(unittest.TestCase):
         self.assertEqual(model["ucp"]["environmental_factors"]["familiar_with_process"], 4)
         self.assertEqual(model["ucp"]["environmental_factors"]["part_time_staff"], 1)
 
+    def test_normalize_replay_to_model_maps_risks_and_document_detail_fields(self) -> None:
+        """Template-driven rounds should populate risks, use-case metadata, scenarios, and UI notes."""
+        replay = replay_session(
+            [
+                {
+                    "round": 3,
+                    "responses": [
+                        {"key": "use_cases", "answer": ["Approve deprecation", "Validate owner"]},
+                    ],
+                },
+                {
+                    "round": 12,
+                    "responses": [
+                        {
+                            "key": "risks",
+                            "answer": [
+                                "Data quality gaps | priority: high | status: open | mitigation: add onboarding validation",
+                            ],
+                        }
+                    ],
+                },
+                {
+                    "round": 13,
+                    "responses": [
+                        {
+                            "key": "use_case_details",
+                            "answer": [
+                                "Approve deprecation | priority: high | status: drafted | used: Validate owner",
+                            ],
+                        },
+                        {
+                            "key": "scenarios",
+                            "answer": [
+                                "Approve deprecation | Happy path approval | Primary approval flow | priority: high | status: drafted",
+                            ],
+                        },
+                        {
+                            "key": "ui_notes",
+                            "answer": [
+                                "Approve deprecation | Show risk summary and approver comments",
+                            ],
+                        },
+                    ],
+                },
+            ]
+        )
+
+        model = normalize_replay_to_model(replay)
+
+        self.assertEqual(model["risks"][0]["name"], "Data quality gaps")
+        self.assertEqual(model["risks"][0]["priority"], "high")
+        self.assertEqual(model["risks"][0]["status"], "open")
+        self.assertEqual(model["risks"][0]["mitigation"], "add onboarding validation")
+        self.assertEqual(model["analysis_view"]["risk_ids"], ["risk-data-quality-gaps"])
+
+        self.assertEqual(model["use_cases"][0]["priority"], "high")
+        self.assertEqual(model["use_cases"][0]["status"], "drafted")
+        self.assertEqual(model["use_cases"][0]["used_use_case_ids"], ["validate-owner"])
+        self.assertEqual(
+            model["use_cases"][0]["ui_notes"],
+            ["Show risk summary and approver comments"],
+        )
+        self.assertEqual(model["use_cases"][0]["scenario_ids"], ["scenario-happy-path-approval"])
+
+        self.assertEqual(model["scenarios"][0]["name"], "Happy path approval")
+        self.assertEqual(model["scenarios"][0]["use_case_id"], "approve-deprecation")
+        self.assertEqual(model["scenarios"][0]["priority"], "high")
+        self.assertEqual(model["scenarios"][0]["status"], "drafted")
+        self.assertEqual(model["analysis_view"]["scenario_ids"], ["scenario-happy-path-approval"])
+
     def test_normalize_replay_to_model_keeps_semantic_fields_explicit_when_unparsed(self) -> None:
         """Hardening should expose semantic fields even when deterministic parsing finds no structure."""
         replay = replay_session(

--- a/tests/test_interview.py
+++ b/tests/test_interview.py
@@ -227,6 +227,26 @@ class InterviewHarnessTests(unittest.TestCase):
         self.assertEqual(round_definition.questions[1].key, "interfaces_and_integrations")
         self.assertEqual(round_definition.questions[2].key, "runtime_boundaries")
 
+    def test_risk_round_exposes_template_driven_risk_guidance(self) -> None:
+        """Round 12 should capture explicit risks for the document suite."""
+        round_definition = get_round(12)
+
+        self.assertIn(
+            "Capture the major project or system risks that should appear in the document set.",
+            round_definition.prompt,
+        )
+        self.assertEqual(round_definition.questions[0].key, "risks")
+        self.assertIn("priority: high", round_definition.questions[0].example)
+
+    def test_use_case_detail_round_exposes_scenario_and_ui_fields(self) -> None:
+        """Round 13 should gather use-case detail, scenarios, and UI notes."""
+        round_definition = get_round(13)
+
+        self.assertEqual(round_definition.questions[0].key, "use_case_details")
+        self.assertEqual(round_definition.questions[1].key, "scenarios")
+        self.assertEqual(round_definition.questions[2].key, "ui_notes")
+        self.assertIn("Only add UI notes", round_definition.guidance[1])
+
     def test_ucp_actor_round_exposes_inversion_guidance(self) -> None:
         """Round 8 should explain the common actor complexity intuition mismatch."""
         round_definition = get_round(8)
@@ -332,7 +352,7 @@ class InterviewHarnessTests(unittest.TestCase):
 
         payload = json.loads(completed.stdout)
         self.assertEqual(payload["last_round"], 11)
-        self.assertIsNone(payload["next_round"])
+        self.assertEqual(payload["next_round"]["number"], 12)
         self.assertEqual(
             payload["transcript"][0]["responses"][0]["label"],
             "Idea",

--- a/tests/test_readiness.py
+++ b/tests/test_readiness.py
@@ -123,6 +123,30 @@ class ReadinessTests(unittest.TestCase):
             ["requirements-spec.md", "ucp-estimate.md"],
         )
 
+    def test_identify_stale_artifacts_marks_documents_for_template_round_updates(self) -> None:
+        """Template-driven document updates should still mark the dependent use-case and requirements artifacts stale."""
+        stale = identify_stale_artifacts(
+            [
+                {
+                    "round": 12,
+                    "responses": [
+                        {"key": "risks", "answer": "Data quality gaps"},
+                    ],
+                },
+                {
+                    "round": 13,
+                    "responses": [
+                        {"key": "scenarios", "answer": "Approve deprecation | Happy path"},
+                    ],
+                },
+            ]
+        )
+
+        self.assertEqual(
+            stale,
+            ["interaction-model.md", "requirements-spec.md", "use-case-model.md"],
+        )
+
     def test_identify_stale_artifacts_marks_state_model_for_process_updates(self) -> None:
         """Process-view updates should mark the formal state-model artifact stale."""
         stale = identify_stale_artifacts(


### PR DESCRIPTION
## Summary
- add template-driven interview rounds for risks and use-case/scenario details
- normalize risk, scenario, use-case detail, and UI note answers into the canonical model
- update readiness gates and tests for the new interview coverage

## Testing
- uv run python -m unittest tests.test_interview tests.test_discovery tests.test_readiness
- uv run python -m unittest

Closes #126