### PR TITLE
Refresh template document examples and docs

### DIFF
--- a/docs/dogfooding.md
+++ b/docs/dogfooding.md
@@ -48,3 +48,9 @@ Current dogfooding example:
 
 - `examples/it-systems-inventory/`
 - `examples/it-systems-inventory/rupify-feedback.md`
+
+The checked-in IT systems inventory bundle should now demonstrate both layers of the formal output:
+
+- overview artifacts such as `requirements-spec.md`, `use-case-model.md`, and `deployment-model.md`
+- compiled template-driven documents such as `system-document.md`, `use-case-documents.md`, and
+  `scenario-documents.md`

--- a/examples/it-systems-inventory/rupify-feedback.md
+++ b/examples/it-systems-inventory/rupify-feedback.md
@@ -8,8 +8,20 @@ Rupify itself.
 ## What This Example Validates
 
 - The interview flow can capture a credible enterprise software problem statement.
-- The current V1 model is strong enough for requirements, use-case, and UCP-oriented outputs.
+- The current model is strong enough for overview artifacts plus the template-driven system and
+  use-case document families.
 - The existing renderer and deterministic UCP path can turn one model into consistent artifacts.
+
+The current checked-in bundle now includes:
+
+- overview artifacts like `requirements-spec.md`, `use-case-model.md`, `domain-model.md`, and
+  `deployment-model.md`
+- template-driven artifacts like `system-document.md`, `use-case-documents.md`, and
+  `scenario-documents.md`
+
+In this specific example, `scenario-documents.md` is currently empty because the model does not yet
+carry explicit named scenario objects for the IT systems inventory case. That is an honest example
+of current coverage, not a rendering failure.
 
 ## What This Example Exposes About Rupify
 

--- a/examples/it-systems-inventory/scenario-documents.md
+++ b/examples/it-systems-inventory/scenario-documents.md
@@ -1,0 +1,3 @@
+# Scenario Documents
+
+No scenarios documented.

--- a/examples/it-systems-inventory/system-document.md
+++ b/examples/it-systems-inventory/system-document.md
@@ -1,0 +1,56 @@
+# System / Subsystem Document
+
+## System Name
+
+A system to manage inventory of IT Systems themselves.
+
+## Brief Description
+
+We have many IT Systems and some overlap, some are free, some are expensive, all are slightly different.
+
+All IT systems
+
+## Risk Factors
+
+- None
+
+## System-Level Use Cases
+
+- `register-a-system` Register a system (actor: Unspecified): Register a system
+- `edit-metadata` edit metadata (actor: Unspecified): edit metadata
+- `compare-overlapping-systems` compare overlapping systems (actor: Unspecified): compare overlapping systems
+- `track-lifecycle-state` track lifecycle state (actor: Unspecified): track lifecycle state
+- `review-risks` review risks (actor: Unspecified): review risks
+- `see-costs` see costs (actor: Unspecified): see costs
+- `approve-deprecation` approve deprecation (actor: Unspecified): approve deprecation
+- `report-portfolio-gaps` report portfolio gaps (actor: Unspecified): report portfolio gaps
+
+## System-Level Diagram References
+
+- `use-case-model.md` for the detailed system-level use-case view
+- `deployment-model.md` for the detailed architecture and runtime view
+
+
+## Architecture Overview
+
+- `component-system-inventory-web-app` System Inventory Web App [source: round 7 components_and_services]
+- `component-system-inventory-api` System Inventory API [source: round 7 components_and_services]
+- `component-reporting-consumers` Reporting Consumers [source: round 7 components_and_services]
+
+
+## Interfaces and Integrations
+
+- `interface-1` System Inventory Web App calls System Inventory API [source: round 7 interfaces_and_integrations]
+- `interface-2` System Inventory API sends Reporting Consumers [source: round 7 interfaces_and_integrations]
+
+
+## Runtime Boundaries
+
+- `runtime-boundary-1` System Inventory API runs separately from the UI [source: round 7 runtime_boundaries]
+
+## Subsystem Descriptions
+
+- `component-system-inventory-web-app` System Inventory Web App [source: round 7 components_and_services]
+- `component-system-inventory-api` System Inventory API [source: round 7 components_and_services]
+- `component-reporting-consumers` Reporting Consumers [source: round 7 components_and_services]
+

--- a/examples/it-systems-inventory/ucp-estimate.md
+++ b/examples/it-systems-inventory/ucp-estimate.md
@@ -2,36 +2,29 @@
 
 ## Project
 
-IT Systems Inventory and Lifecycle Management
+A system to manage inventory of IT Systems themselves.
 
 ## Summary
 
-- `UAW`: 12.00
-- `UUCW`: 90.00
-- `UUCP`: 102.00
-- `TCF`: 1.060
-- `EF`: 0.965
-- `UCP`: 104.336
-- `Effort Hours`: 2086.72
+- `UAW`: 20.00
+- `UUCW`: 65.00
+- `UUCP`: 85.00
+- `TCF`: 0.990
+- `EF`: 0.860
+- `UCP`: 72.369
+- `Effort Hours`: 1447.38
 
 ## Inputs
 
-- Technical factor weighted sum: 46.00
-- Environmental factor weighted sum: 14.50
+- Technical factor weighted sum: 39.00
+- Environmental factor weighted sum: 18.00
 - Productivity hours per UCP: 20.00
 
 ## Assumptions
 
-- The system acts as the CMDB for IT applications and systems, excluding OT systems.
-- API consumers include downstream reporting systems and AI agents.
-- Lifecycle states are configurable even though an initial default set exists.
-- V1 includes workflow support for approvals and stage gates, not just passive inventory.
-- The UCP inputs were estimated using defaults for a similar internal enterprise system at a company of about 1000 people.
+- None
 
 ## Open Questions
 
-- Did performance mean page rendering should be less than 1 second rather than greater than 1 second?
-- Are integrations/interfaces first-class inventory objects or only metadata on systems?
-- Should procurement, security, finance, and application owners have distinct roles and workflows in V1?
-- What exact approval workflows and stage-gate states are required in V1?
-- What data model is required for overlap analysis and portfolio gap reporting?
+- None
+

--- a/examples/it-systems-inventory/use-case-documents.md
+++ b/examples/it-systems-inventory/use-case-documents.md
@@ -1,0 +1,636 @@
+# Use-Case Documents
+
+## Register a system
+
+- ID: `register-a-system`
+- Primary Actor: Unspecified
+- Supporting Actors: None
+- Priority: Unspecified
+- Status: Unspecified
+- Complexity: average
+- Goal: Register a system
+- Trigger: Unspecified
+- Source: round 3 use_cases
+
+### Brief Description
+
+Register a system
+
+### Preconditions
+
+- None
+
+### Postconditions
+
+- None
+
+### Extension Points
+
+- None
+
+### Used Use Cases
+
+- None
+
+### Subordinate Use Cases
+
+- None
+
+### Flow of Events
+
+1. No main success scenario documented.
+
+### Extensions
+
+- None
+
+### Secondary Scenarios
+
+No named scenarios documented.
+
+### User Interface
+
+- None
+
+### View of Participating Classes
+
+- None
+
+### Sequence and Interaction Notes
+
+#### Register a system
+
+- Participants: Unspecified
+
+##### Realization Steps
+
+1. No realization steps documented.
+
+
+### Linked Requirements
+
+- None
+
+### Other Artifacts
+
+- None
+
+
+## Use-Case To Analysis Traceability
+
+- `trace-uc-analysis-1` register-a-system -> entity-system (use-case text references analysis object name)
+- `trace-uc-analysis-2` register-a-system -> state-entity-system (use-case text references analysis object name)
+
+
+
+## edit metadata
+
+- ID: `edit-metadata`
+- Primary Actor: Unspecified
+- Supporting Actors: None
+- Priority: Unspecified
+- Status: Unspecified
+- Complexity: simple
+- Goal: edit metadata
+- Trigger: Unspecified
+- Source: round 3 use_cases
+
+### Brief Description
+
+edit metadata
+
+### Preconditions
+
+- None
+
+### Postconditions
+
+- None
+
+### Extension Points
+
+- None
+
+### Used Use Cases
+
+- None
+
+### Subordinate Use Cases
+
+- None
+
+### Flow of Events
+
+1. No main success scenario documented.
+
+### Extensions
+
+- None
+
+### Secondary Scenarios
+
+No named scenarios documented.
+
+### User Interface
+
+- None
+
+### View of Participating Classes
+
+- None
+
+### Sequence and Interaction Notes
+
+#### edit metadata
+
+- Participants: Unspecified
+
+##### Realization Steps
+
+1. No realization steps documented.
+
+
+### Linked Requirements
+
+- None
+
+### Other Artifacts
+
+- None
+
+
+
+
+## compare overlapping systems
+
+- ID: `compare-overlapping-systems`
+- Primary Actor: Unspecified
+- Supporting Actors: None
+- Priority: Unspecified
+- Status: Unspecified
+- Complexity: average
+- Goal: compare overlapping systems
+- Trigger: Unspecified
+- Source: round 3 use_cases
+
+### Brief Description
+
+compare overlapping systems
+
+### Preconditions
+
+- None
+
+### Postconditions
+
+- None
+
+### Extension Points
+
+- None
+
+### Used Use Cases
+
+- None
+
+### Subordinate Use Cases
+
+- None
+
+### Flow of Events
+
+1. No main success scenario documented.
+
+### Extensions
+
+- None
+
+### Secondary Scenarios
+
+No named scenarios documented.
+
+### User Interface
+
+- None
+
+### View of Participating Classes
+
+- None
+
+### Sequence and Interaction Notes
+
+#### compare overlapping systems
+
+- Participants: Unspecified
+
+##### Realization Steps
+
+1. No realization steps documented.
+
+
+### Linked Requirements
+
+- None
+
+### Other Artifacts
+
+- None
+
+
+## Use-Case To Analysis Traceability
+
+- `trace-uc-analysis-3` compare-overlapping-systems -> entity-system (use-case text references analysis object name)
+- `trace-uc-analysis-4` compare-overlapping-systems -> state-entity-system (use-case text references analysis object name)
+
+
+
+## track lifecycle state
+
+- ID: `track-lifecycle-state`
+- Primary Actor: Unspecified
+- Supporting Actors: None
+- Priority: Unspecified
+- Status: Unspecified
+- Complexity: average
+- Goal: track lifecycle state
+- Trigger: Unspecified
+- Source: round 3 use_cases
+
+### Brief Description
+
+track lifecycle state
+
+### Preconditions
+
+- None
+
+### Postconditions
+
+- None
+
+### Extension Points
+
+- None
+
+### Used Use Cases
+
+- None
+
+### Subordinate Use Cases
+
+- None
+
+### Flow of Events
+
+1. No main success scenario documented.
+
+### Extensions
+
+- None
+
+### Secondary Scenarios
+
+No named scenarios documented.
+
+### User Interface
+
+- None
+
+### View of Participating Classes
+
+- None
+
+### Sequence and Interaction Notes
+
+#### track lifecycle state
+
+- Participants: Unspecified
+
+##### Realization Steps
+
+1. No realization steps documented.
+
+
+### Linked Requirements
+
+- None
+
+### Other Artifacts
+
+- None
+
+
+
+
+## review risks
+
+- ID: `review-risks`
+- Primary Actor: Unspecified
+- Supporting Actors: None
+- Priority: Unspecified
+- Status: Unspecified
+- Complexity: simple
+- Goal: review risks
+- Trigger: Unspecified
+- Source: round 3 use_cases
+
+### Brief Description
+
+review risks
+
+### Preconditions
+
+- None
+
+### Postconditions
+
+- None
+
+### Extension Points
+
+- None
+
+### Used Use Cases
+
+- None
+
+### Subordinate Use Cases
+
+- None
+
+### Flow of Events
+
+1. No main success scenario documented.
+
+### Extensions
+
+- None
+
+### Secondary Scenarios
+
+No named scenarios documented.
+
+### User Interface
+
+- None
+
+### View of Participating Classes
+
+- None
+
+### Sequence and Interaction Notes
+
+#### review risks
+
+- Participants: Unspecified
+
+##### Realization Steps
+
+1. No realization steps documented.
+
+
+### Linked Requirements
+
+- None
+
+### Other Artifacts
+
+- None
+
+
+
+
+## see costs
+
+- ID: `see-costs`
+- Primary Actor: Unspecified
+- Supporting Actors: None
+- Priority: Unspecified
+- Status: Unspecified
+- Complexity: simple
+- Goal: see costs
+- Trigger: Unspecified
+- Source: round 3 use_cases
+
+### Brief Description
+
+see costs
+
+### Preconditions
+
+- None
+
+### Postconditions
+
+- None
+
+### Extension Points
+
+- None
+
+### Used Use Cases
+
+- None
+
+### Subordinate Use Cases
+
+- None
+
+### Flow of Events
+
+1. No main success scenario documented.
+
+### Extensions
+
+- None
+
+### Secondary Scenarios
+
+No named scenarios documented.
+
+### User Interface
+
+- None
+
+### View of Participating Classes
+
+- None
+
+### Sequence and Interaction Notes
+
+#### see costs
+
+- Participants: Unspecified
+
+##### Realization Steps
+
+1. No realization steps documented.
+
+
+### Linked Requirements
+
+- None
+
+### Other Artifacts
+
+- None
+
+
+
+
+## approve deprecation
+
+- ID: `approve-deprecation`
+- Primary Actor: Unspecified
+- Supporting Actors: None
+- Priority: Unspecified
+- Status: Unspecified
+- Complexity: average
+- Goal: approve deprecation
+- Trigger: Unspecified
+- Source: round 3 use_cases
+
+### Brief Description
+
+approve deprecation
+
+### Preconditions
+
+- None
+
+### Postconditions
+
+- None
+
+### Extension Points
+
+- None
+
+### Used Use Cases
+
+- None
+
+### Subordinate Use Cases
+
+- None
+
+### Flow of Events
+
+1. No main success scenario documented.
+
+### Extensions
+
+- None
+
+### Secondary Scenarios
+
+No named scenarios documented.
+
+### User Interface
+
+- None
+
+### View of Participating Classes
+
+- None
+
+### Sequence and Interaction Notes
+
+#### approve deprecation
+
+- Participants: Unspecified
+
+##### Realization Steps
+
+1. No realization steps documented.
+
+
+### Linked Requirements
+
+- None
+
+### Other Artifacts
+
+- None
+
+
+
+
+## report portfolio gaps
+
+- ID: `report-portfolio-gaps`
+- Primary Actor: Unspecified
+- Supporting Actors: None
+- Priority: Unspecified
+- Status: Unspecified
+- Complexity: average
+- Goal: report portfolio gaps
+- Trigger: Unspecified
+- Source: round 3 use_cases
+
+### Brief Description
+
+report portfolio gaps
+
+### Preconditions
+
+- None
+
+### Postconditions
+
+- None
+
+### Extension Points
+
+- None
+
+### Used Use Cases
+
+- None
+
+### Subordinate Use Cases
+
+- None
+
+### Flow of Events
+
+1. No main success scenario documented.
+
+### Extensions
+
+- None
+
+### Secondary Scenarios
+
+No named scenarios documented.
+
+### User Interface
+
+- None
+
+### View of Participating Classes
+
+- None
+
+### Sequence and Interaction Notes
+
+#### report portfolio gaps
+
+- Participants: Unspecified
+
+##### Realization Steps
+
+1. No realization steps documented.
+
+
+### Linked Requirements
+
+- None
+
+### Other Artifacts
+
+- None
+
+
+
+

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1334,6 +1334,27 @@ class RenderTests(unittest.TestCase):
         self.assertIn("ucp-estimate.md", outputs)
         self.assertTrue(outputs["ucp-estimate.md"].startswith("# UCP Estimate"))
 
+    def test_checked_in_it_systems_inventory_example_bundle_includes_template_documents(self) -> None:
+        """The checked-in example bundle should stay aligned with the current formal output family."""
+        repo_root = Path(__file__).resolve().parents[1]
+        example_dir = repo_root / "examples" / "it-systems-inventory"
+
+        self.assertTrue((example_dir / "system-document.md").exists())
+        self.assertTrue((example_dir / "use-case-documents.md").exists())
+        self.assertTrue((example_dir / "scenario-documents.md").exists())
+        self.assertIn(
+            "# System / Subsystem Document",
+            (example_dir / "system-document.md").read_text(encoding="utf-8"),
+        )
+        self.assertIn(
+            "# Use-Case Documents",
+            (example_dir / "use-case-documents.md").read_text(encoding="utf-8"),
+        )
+        self.assertIn(
+            "# Scenario Documents",
+            (example_dir / "scenario-documents.md").read_text(encoding="utf-8"),
+        )
+
     def test_interaction_model_render_includes_realizations_and_messages(self) -> None:
         """Interaction-model rendering should surface use-case realizations and message flows."""
         model = build_model()


### PR DESCRIPTION
## Summary
- regenerate the checked-in IT systems inventory example bundle to include the template-driven document family
- add regression coverage to keep the example bundle aligned with the formal renderer outputs
- tighten dogfooding docs and example feedback to explain the relationship between overview artifacts and compiled document families

## Testing
- uv run python -m unittest tests.test_render
- uv run python -m unittest

Closes #128