### PR TITLE
Add step and rule traceability links

### DIFF
--- a/skills/rupify/references/rupify-model.md
+++ b/skills/rupify/references/rupify-model.md
@@ -63,6 +63,16 @@ The canonical project model is `rupify-model.yaml`.
   - `other_artifact_refs`
   - `other_requirement_ids`
   - `scenario_ids`
+- `analysis_view` (authoritative source for analysis-layer objects)
+  - `use_case_step_objects`
+    - `id`
+    - `use_case_id`
+    - `use_case_name`
+    - `step_index`
+    - `step_kind`
+    - `text`
+    - `model_layer`: `analysis`
+    - `trace`
 - `scenarios` (compatibility mirror derived from `analysis_view.scenario_objects`)
   - `id`
   - `name`
@@ -88,6 +98,7 @@ The canonical project model is `rupify-model.yaml`.
     - `quality_attribute`
     - `model_layer`: `analysis`
     - `linked_use_case_ids`
+    - `linked_step_ids`
     - `fit_criterion`
     - `trace`
   - `non_functional`
@@ -98,11 +109,13 @@ The canonical project model is `rupify-model.yaml`.
     - `quality_attribute`
     - `model_layer`: `analysis`
     - `linked_use_case_ids`
+    - `linked_step_ids`
     - `fit_criterion`
     - `trace`
 - `analysis_view` (authoritative source for analysis-layer objects)
   - `actors`
   - `use_cases`
+  - `use_case_step_objects`
   - `scenario_objects`
   - `risk_objects`
   - `requirement_objects`
@@ -114,6 +127,7 @@ The canonical project model is `rupify-model.yaml`.
   - `trigger_objects`
   - `actor_ids`
   - `use_case_ids`
+  - `use_case_step_ids`
   - `scenario_ids`
   - `risk_ids`
   - `requirement_ids`
@@ -155,7 +169,31 @@ The canonical project model is `rupify-model.yaml`.
     - `to_id`
     - `link_type`
     - `basis`
+  - `requirement_to_step`
+    - `id`
+    - `from_id`
+    - `to_id`
+    - `link_type`
+    - `basis`
   - `use_case_to_analysis`
+    - `id`
+    - `from_id`
+    - `to_id`
+    - `link_type`
+    - `basis`
+  - `step_to_interaction`
+    - `id`
+    - `from_id`
+    - `to_id`
+    - `link_type`
+    - `basis`
+  - `step_to_transition`
+    - `id`
+    - `from_id`
+    - `to_id`
+    - `link_type`
+    - `basis`
+  - `business_rule_to_transition`
     - `id`
     - `from_id`
     - `to_id`
@@ -182,6 +220,14 @@ The canonical project model is `rupify-model.yaml`.
     - `participant_ids`
     - `participant_names`
     - `steps`
+    - `step_objects`
+      - `id`
+      - `use_case_id`
+      - `use_case_name`
+      - `step_index`
+      - `text`
+      - `model_layer`: `analysis`
+      - `trace`
     - `model_layer`: `analysis`
     - `trace`
   - `message_objects`

--- a/src/rupify_tools/discovery.py
+++ b/src/rupify_tools/discovery.py
@@ -91,6 +91,11 @@ def _text_matches_name(text: str, name: str) -> bool:
     return phrase in joined
 
 
+def _texts_overlap(left: str, right: str) -> bool:
+    """Return whether two text values explicitly reference one another."""
+    return _text_matches_name(left, right) or _text_matches_name(right, left)
+
+
 def _ensure_list(value: Any) -> list[str]:
     """Normalize a scalar or list answer into a clean string list."""
     def _clean(item: Any) -> str:
@@ -761,6 +766,22 @@ def _apply_use_case_details(
                 match["extension_points"] = [
                     segment.strip() for segment in normalized_value.split(";") if segment.strip()
                 ]
+            elif normalized_key == "flow":
+                match["main_success_scenario"] = [
+                    segment.strip() for segment in normalized_value.split(";") if segment.strip()
+                ]
+            elif normalized_key == "extensions":
+                match["extensions"] = [
+                    segment.strip() for segment in normalized_value.split(";") if segment.strip()
+                ]
+            elif normalized_key == "preconditions":
+                match["preconditions"] = [
+                    segment.strip() for segment in normalized_value.split(";") if segment.strip()
+                ]
+            elif normalized_key == "postconditions":
+                match["postconditions"] = [
+                    segment.strip() for segment in normalized_value.split(";") if segment.strip()
+                ]
 
 
 def _normalize_scenarios(
@@ -854,16 +875,58 @@ def _bind_scenario_links(
         use_case["scenario_ids"] = scenario_ids_by_use_case.get(use_case.get("id", ""), [])
 
 
+def _build_use_case_step_objects(use_cases: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Build first-class step objects from use-case main and extension flows."""
+    step_objects = []
+    for use_case in use_cases:
+        use_case_id = use_case.get("id", "")
+        for index, step_text in enumerate(use_case.get("main_success_scenario", []), 1):
+            step_objects.append(
+                {
+                    "id": f"{use_case_id}-step-{index}",
+                    "use_case_id": use_case_id,
+                    "use_case_name": use_case.get("name", ""),
+                    "step_index": index,
+                    "step_kind": "main_success",
+                    "text": step_text,
+                    "model_layer": "analysis",
+                    "trace": use_case.get("trace", {}),
+                }
+            )
+        for index, step_text in enumerate(use_case.get("extensions", []), 1):
+            step_objects.append(
+                {
+                    "id": f"{use_case_id}-extension-{index}",
+                    "use_case_id": use_case_id,
+                    "use_case_name": use_case.get("name", ""),
+                    "step_index": index,
+                    "step_kind": "extension",
+                    "text": step_text,
+                    "model_layer": "analysis",
+                    "trace": use_case.get("trace", {}),
+                }
+            )
+    return step_objects
+
+
 def _build_trace_links(
     requirement_objects: list[dict[str, Any]],
     use_cases: list[dict[str, Any]],
+    use_case_step_objects: list[dict[str, Any]],
     domain_entities: list[dict[str, Any]],
+    business_rules: list[dict[str, Any]],
     state_entities: list[dict[str, Any]],
+    state_transitions: list[dict[str, Any]],
     components: list[dict[str, Any]],
+    interaction_messages: list[dict[str, Any]],
 ) -> dict[str, list[dict[str, Any]]]:
     """Build conservative cross-view trace links from explicit textual references."""
     requirement_to_use_case = []
+    requirement_to_step = []
     use_case_to_analysis = []
+    step_to_interaction = []
+    step_to_transition = []
+    business_rule_to_transition = []
     analysis_to_design = []
 
     for requirement in requirement_objects:
@@ -880,7 +943,21 @@ def _build_trace_links(
                     }
                 )
                 linked_use_case_ids.append(use_case["id"])
+        linked_step_ids = []
+        for step_object in use_case_step_objects:
+            if _texts_overlap(requirement["statement"], step_object["text"]):
+                requirement_to_step.append(
+                    {
+                        "id": f"trace-req-step-{len(requirement_to_step) + 1}",
+                        "from_id": requirement["id"],
+                        "to_id": step_object["id"],
+                        "link_type": "requirement_to_step",
+                        "basis": "requirement statement references use-case step text",
+                    }
+                )
+                linked_step_ids.append(step_object["id"])
         requirement["linked_use_case_ids"] = linked_use_case_ids
+        requirement["linked_step_ids"] = linked_step_ids
 
     analysis_candidates = domain_entities + state_entities
     for use_case in use_cases:
@@ -916,9 +993,92 @@ def _build_trace_links(
                     }
                 )
 
+    for step_object in use_case_step_objects:
+        step_text = step_object.get("text", "")
+        for message in interaction_messages:
+            message_text = " ".join(
+                [
+                    message.get("description", ""),
+                    message.get("interaction_verb", ""),
+                    message.get("source_name", ""),
+                    message.get("target_name", ""),
+                ]
+            ).strip()
+            if step_text and _texts_overlap(step_text, message_text):
+                step_to_interaction.append(
+                    {
+                        "id": f"trace-step-interaction-{len(step_to_interaction) + 1}",
+                        "from_id": step_object["id"],
+                        "to_id": message["id"],
+                        "link_type": "step_to_interaction",
+                        "basis": "use-case step text references interaction message text",
+                    }
+                )
+        for transition in state_transitions:
+            transition_text = " ".join(
+                [
+                    transition.get("description", ""),
+                    transition.get("from_state", ""),
+                    transition.get("to_state", ""),
+                    transition.get("trigger", ""),
+                    transition.get("constraint", ""),
+                ]
+            ).strip()
+            if step_text and _texts_overlap(step_text, transition_text):
+                step_to_transition.append(
+                    {
+                        "id": f"trace-step-transition-{len(step_to_transition) + 1}",
+                        "from_id": step_object["id"],
+                        "to_id": transition["id"],
+                        "link_type": "step_to_transition",
+                        "basis": "use-case step text references state transition text",
+                    }
+                )
+
+    for business_rule in business_rules:
+        rule_text = business_rule.get("rule_text", "")
+        rule_scope = business_rule.get("scope", "")
+        for transition in state_transitions:
+            transition_text = " ".join(
+                [
+                    transition.get("description", ""),
+                    transition.get("from_state", ""),
+                    transition.get("to_state", ""),
+                    transition.get("trigger", ""),
+                    transition.get("constraint", ""),
+                ]
+            ).strip()
+            if not transition_text:
+                continue
+            if rule_text and _texts_overlap(rule_text, transition_text):
+                business_rule_to_transition.append(
+                    {
+                        "id": f"trace-rule-transition-{len(business_rule_to_transition) + 1}",
+                        "from_id": business_rule["id"],
+                        "to_id": transition["id"],
+                        "link_type": "business_rule_to_transition",
+                        "basis": "business rule text references state transition text",
+                    }
+                )
+                continue
+            if rule_scope and _texts_overlap(rule_scope, transition_text):
+                business_rule_to_transition.append(
+                    {
+                        "id": f"trace-rule-transition-{len(business_rule_to_transition) + 1}",
+                        "from_id": business_rule["id"],
+                        "to_id": transition["id"],
+                        "link_type": "business_rule_to_transition",
+                        "basis": "business rule scope references state transition text",
+                    }
+                )
+
     return {
         "requirement_to_use_case": requirement_to_use_case,
+        "requirement_to_step": requirement_to_step,
         "use_case_to_analysis": use_case_to_analysis,
+        "step_to_interaction": step_to_interaction,
+        "step_to_transition": step_to_transition,
+        "business_rule_to_transition": business_rule_to_transition,
         "analysis_to_design": analysis_to_design,
     }
 
@@ -1190,6 +1350,20 @@ def _build_interaction_view(
             if actor_id and actor_id not in participant_ids:
                 participant_ids.append(actor_id)
 
+        step_objects = []
+        for step_index, step_text in enumerate(use_case.get("main_success_scenario", []), 1):
+            step_objects.append(
+                {
+                    "id": f"{use_case.get('id', '')}-realization-step-{step_index}",
+                    "use_case_id": use_case.get("id", ""),
+                    "use_case_name": use_case.get("name", ""),
+                    "step_index": step_index,
+                    "text": step_text,
+                    "model_layer": "analysis",
+                    "trace": use_case.get("trace", {}),
+                }
+            )
+
         realization_objects.append(
             {
                 "id": f"interaction-realization-{index}",
@@ -1198,6 +1372,7 @@ def _build_interaction_view(
                 "participant_ids": participant_ids,
                 "participant_names": participant_names,
                 "steps": list(use_case.get("main_success_scenario", [])),
+                "step_objects": step_objects,
                 "model_layer": "analysis",
                 "trace": use_case.get("trace", {}),
             }
@@ -1429,8 +1604,10 @@ def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
         normalized_use_cases,
         scenario_objects,
     )
+    use_case_step_objects = _build_use_case_step_objects(normalized_use_cases)
     _stamp_semantic_identity(normalized_actors, change_source="round_3")
     _stamp_semantic_identity(normalized_use_cases, change_source="round_3")
+    _stamp_semantic_identity(use_case_step_objects, change_source="derived_use_case_steps")
     _stamp_semantic_identity(scenario_objects, change_source="round_13")
     _stamp_semantic_identity(risk_objects, change_source="round_12")
     _stamp_semantic_identity(domain_entity_objects, change_source="round_5")
@@ -1449,11 +1626,13 @@ def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
     analysis_view = {
         "actor_ids": [item["id"] for item in normalized_actors],
         "use_case_ids": [item["id"] for item in normalized_use_cases],
+        "use_case_step_ids": [item["id"] for item in use_case_step_objects],
         "scenario_ids": [item["id"] for item in scenario_objects],
         "risk_ids": [item["id"] for item in risk_objects],
         "requirement_ids": [item["id"] for item in all_requirement_objects],
         "actors": normalized_actors,
         "use_cases": normalized_use_cases,
+        "use_case_step_objects": use_case_step_objects,
         "scenario_objects": scenario_objects,
         "risk_objects": risk_objects,
         "requirement_objects": all_requirement_objects,
@@ -1490,6 +1669,11 @@ def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
         interaction_view["realization_objects"],
         change_source="derived_interaction_view",
     )
+    for realization in interaction_view["realization_objects"]:
+        _stamp_semantic_identity(
+            realization.get("step_objects", []),
+            change_source="derived_interaction_view",
+        )
     _stamp_semantic_identity(
         interaction_view["message_objects"],
         change_source="derived_interaction_view",
@@ -1497,9 +1681,13 @@ def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
     traceability = _build_trace_links(
         all_requirement_objects,
         normalized_use_cases,
+        use_case_step_objects,
         domain_entity_objects,
+        business_rule_objects,
         state_entity_objects,
+        state_transition_objects,
         component_objects,
+        interaction_view["message_objects"],
     )
     _bind_use_case_supporting_links(
         normalized_use_cases,
@@ -1528,7 +1716,23 @@ def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
         change_source="derived_traceability",
     )
     _stamp_semantic_identity(
+        traceability["requirement_to_step"],
+        change_source="derived_traceability",
+    )
+    _stamp_semantic_identity(
         traceability["use_case_to_analysis"],
+        change_source="derived_traceability",
+    )
+    _stamp_semantic_identity(
+        traceability["step_to_interaction"],
+        change_source="derived_traceability",
+    )
+    _stamp_semantic_identity(
+        traceability["step_to_transition"],
+        change_source="derived_traceability",
+    )
+    _stamp_semantic_identity(
+        traceability["business_rule_to_transition"],
         change_source="derived_traceability",
     )
     _stamp_semantic_identity(

--- a/src/rupify_tools/interview.py
+++ b/src/rupify_tools/interview.py
@@ -460,7 +460,7 @@ ROUND_DEFINITIONS: list[InterviewRound] = [
         ),
         template=(
             "Use-case details:\n"
-            "- Use Case | priority: high/medium/low | status: drafted/in progress/confirmed\n"
+            "- Use Case | priority: high/medium/low | status: drafted/in progress/confirmed | flow: step 1; step 2\n"
             "Scenarios:\n"
             "- Use Case | Scenario Name | summary | priority: high/medium/low | status: drafted/in progress/confirmed\n"
             "UI notes:\n"
@@ -477,9 +477,13 @@ ROUND_DEFINITIONS: list[InterviewRound] = [
                 "Which use cases need explicit priority, status, or relationships?",
                 guidance=(
                     "Use one line per use case.",
-                    "You can also include used or subordinate use-case links: used: Validate owner; subordinate: Review risk",
+                    "You can also include flow, used, or subordinate links: flow: capture request; validate owner; submit approval",
+                    "Use semicolons inside a field when you need multiple flow steps or linked use cases.",
                 ),
-                example="- Approve deprecation | priority: high | status: drafted | used: Validate owner | subordinate: Review risk",
+                example=(
+                    "- Approve deprecation | priority: high | status: drafted | flow: Capture request; "
+                    "Validate owner; Submit approval | used: Validate owner | subordinate: Review risk"
+                ),
             ),
             InterviewQuestion(
                 "scenarios",

--- a/src/rupify_tools/readiness.py
+++ b/src/rupify_tools/readiness.py
@@ -216,10 +216,49 @@ def evaluate_traceability(model: dict[str, Any]) -> dict[str, dict[str, Any]]:
             traceability.get("requirement_to_use_case", []),
             "requirement_to_use_case",
         ),
+        "requirement_to_step": _trace_family_result(
+            [
+                item.get("id", "")
+                for item in model.get("analysis_view", {}).get("use_case_step_objects", [])
+            ],
+            traceability.get("requirement_to_step", []),
+            "requirement_to_step",
+            source_key="to_id",
+        ),
         "use_case_to_analysis": _trace_family_result(
             [item.get("id", "") for item in use_cases] if analysis_objects else [],
             traceability.get("use_case_to_analysis", []),
             "use_case_to_analysis",
+        ),
+        "step_to_interaction": _trace_family_result(
+            [
+                item.get("id", "")
+                for item in model.get("analysis_view", {}).get("use_case_step_objects", [])
+            ]
+            if model.get("interaction_view", {}).get("message_objects", [])
+            else [],
+            traceability.get("step_to_interaction", []),
+            "step_to_interaction",
+        ),
+        "step_to_transition": _trace_family_result(
+            [
+                item.get("id", "")
+                for item in model.get("analysis_view", {}).get("use_case_step_objects", [])
+            ]
+            if model.get("process_view", {}).get("state_transition_objects", [])
+            else [],
+            traceability.get("step_to_transition", []),
+            "step_to_transition",
+        ),
+        "business_rule_to_transition": _trace_family_result(
+            [
+                item.get("id", "")
+                for item in model.get("logical_view", {}).get("business_rule_objects", [])
+            ]
+            if model.get("process_view", {}).get("state_transition_objects", [])
+            else [],
+            traceability.get("business_rule_to_transition", []),
+            "business_rule_to_transition",
         ),
         "analysis_to_design": _trace_family_result(
             [item.get("id", "") for item in analysis_objects] if design_objects else [],

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -446,7 +446,7 @@ class DiscoveryTests(unittest.TestCase):
                         {
                             "key": "use_case_details",
                             "answer": [
-                                "Approve deprecation | priority: high | status: drafted | used: Validate owner",
+                                "Approve deprecation | priority: high | status: drafted | flow: Capture approval request; Validate owner; Submit approval | used: Validate owner",
                             ],
                         },
                         {
@@ -477,6 +477,18 @@ class DiscoveryTests(unittest.TestCase):
         self.assertEqual(model["use_cases"][0]["priority"], "high")
         self.assertEqual(model["use_cases"][0]["status"], "drafted")
         self.assertEqual(model["use_cases"][0]["used_use_case_ids"], ["validate-owner"])
+        self.assertEqual(
+            model["use_cases"][0]["main_success_scenario"],
+            ["Capture approval request", "Validate owner", "Submit approval"],
+        )
+        self.assertEqual(
+            model["analysis_view"]["use_case_step_ids"],
+            [
+                "approve-deprecation-step-1",
+                "approve-deprecation-step-2",
+                "approve-deprecation-step-3",
+            ],
+        )
         self.assertEqual(
             model["use_cases"][0]["ui_notes"],
             ["Show risk summary and approver comments"],
@@ -637,7 +649,7 @@ class DiscoveryTests(unittest.TestCase):
                     "responses": [
                         {"key": "actors", "answer": ["Operator"]},
                         {"key": "use_cases", "answer": ["Approve System"]},
-                        {"key": "integrations", "answer": "System API"},
+                        {"key": "integrations", "answer": "Validate submitted system"},
                     ],
                 },
                 {
@@ -651,13 +663,32 @@ class DiscoveryTests(unittest.TestCase):
                     "responses": [
                         {"key": "domain_entities", "answer": ["System"]},
                         {"key": "relationships", "answer": ["System has many approvals"]},
+                        {"key": "business_rules", "answer": ["Validate submitted system"]},
+                    ],
+                },
+                {
+                    "round": 6,
+                    "responses": [
+                        {"key": "state_entities", "answer": ["System lifecycle"]},
+                        {"key": "states_and_transitions", "answer": ["Validate submitted system"]},
                     ],
                 },
                 {
                     "round": 7,
                     "responses": [
                         {"key": "components_and_services", "answer": ["System API"]},
-                        {"key": "interfaces_and_integrations", "answer": ["Portal calls System API"]},
+                        {"key": "interfaces_and_integrations", "answer": ["Validate submitted system"]},
+                    ],
+                },
+                {
+                    "round": 13,
+                    "responses": [
+                        {
+                            "key": "use_case_details",
+                            "answer": [
+                                "Approve System | flow: Validate submitted system; Record approval",
+                            ],
+                        },
                     ],
                 },
             ]
@@ -688,6 +719,38 @@ class DiscoveryTests(unittest.TestCase):
         self.assertEqual(
             model["traceability"]["analysis_to_design"][0]["to_id"],
             "component-system-api",
+        )
+        self.assertEqual(
+            model["analysis_view"]["use_case_step_ids"],
+            ["approve-system-step-1", "approve-system-step-2"],
+        )
+        self.assertEqual(
+            model["analysis_view"]["use_case_step_objects"][0]["text"],
+            "Validate submitted system",
+        )
+        self.assertEqual(
+            model["interaction_view"]["realization_objects"][0]["step_objects"][0]["id"],
+            "approve-system-realization-step-1",
+        )
+        self.assertEqual(
+            model["traceability"]["requirement_to_step"][0]["to_id"],
+            "approve-system-step-1",
+        )
+        self.assertEqual(
+            model["traceability"]["step_to_interaction"][0]["from_id"],
+            "approve-system-step-1",
+        )
+        self.assertEqual(
+            model["traceability"]["step_to_transition"][0]["to_id"],
+            "state-transition-1",
+        )
+        self.assertEqual(
+            model["traceability"]["business_rule_to_transition"][0]["from_id"],
+            "business-rule-1",
+        )
+        self.assertEqual(
+            model["traceability"]["step_to_interaction"][0]["change_metadata"]["change_source"],
+            "derived_traceability",
         )
         self.assertEqual(
             model["traceability"]["requirement_to_use_case"][0]["semantic_id"],

--- a/tests/test_interview.py
+++ b/tests/test_interview.py
@@ -245,6 +245,7 @@ class InterviewHarnessTests(unittest.TestCase):
         self.assertEqual(round_definition.questions[0].key, "use_case_details")
         self.assertEqual(round_definition.questions[1].key, "scenarios")
         self.assertEqual(round_definition.questions[2].key, "ui_notes")
+        self.assertIn("flow:", round_definition.questions[0].example)
         self.assertIn("Only add UI notes", round_definition.guidance[1])
 
     def test_ucp_actor_round_exposes_inversion_guidance(self) -> None:

--- a/tests/test_readiness.py
+++ b/tests/test_readiness.py
@@ -270,14 +270,39 @@ class ReadinessTests(unittest.TestCase):
                 {"id": "approve-system"},
                 {"id": "search-systems"},
             ],
-            "logical_view": {"domain_entity_objects": [{"id": "entity-system"}]},
-            "process_view": {"state_entity_objects": []},
+            "analysis_view": {
+                "use_case_step_objects": [
+                    {"id": "approve-system-step-1"},
+                    {"id": "approve-system-step-2"},
+                ]
+            },
+            "logical_view": {
+                "domain_entity_objects": [{"id": "entity-system"}],
+                "business_rule_objects": [{"id": "business-rule-1"}],
+            },
+            "process_view": {
+                "state_entity_objects": [],
+                "state_transition_objects": [{"id": "state-transition-1"}],
+            },
+            "interaction_view": {"message_objects": [{"id": "interaction-message-1"}]},
             "architecture_view": {"component_objects": [{"id": "component-system-api"}]},
             "traceability": {
                 "requirement_to_use_case": [
                     {"from_id": "functional-requirement-1", "to_id": "approve-system"}
                 ],
+                "requirement_to_step": [
+                    {"from_id": "functional-requirement-1", "to_id": "approve-system-step-1"}
+                ],
                 "use_case_to_analysis": [],
+                "step_to_interaction": [
+                    {"from_id": "approve-system-step-1", "to_id": "interaction-message-1"}
+                ],
+                "step_to_transition": [
+                    {"from_id": "approve-system-step-1", "to_id": "state-transition-1"}
+                ],
+                "business_rule_to_transition": [
+                    {"from_id": "business-rule-1", "to_id": "state-transition-1"}
+                ],
                 "analysis_to_design": [],
             },
         }
@@ -294,6 +319,22 @@ class ReadinessTests(unittest.TestCase):
             validation["use_case_to_analysis"]["missing_from_ids"],
             ["approve-system", "search-systems"],
         )
+        self.assertEqual(validation["requirement_to_step"]["status"], "partial")
+        self.assertEqual(
+            validation["requirement_to_step"]["missing_from_ids"],
+            ["approve-system-step-2"],
+        )
+        self.assertEqual(validation["step_to_interaction"]["status"], "partial")
+        self.assertEqual(
+            validation["step_to_interaction"]["missing_from_ids"],
+            ["approve-system-step-2"],
+        )
+        self.assertEqual(validation["step_to_transition"]["status"], "partial")
+        self.assertEqual(
+            validation["step_to_transition"]["missing_from_ids"],
+            ["approve-system-step-2"],
+        )
+        self.assertEqual(validation["business_rule_to_transition"]["status"], "ready")
         self.assertEqual(validation["analysis_to_design"]["status"], "blocked")
         self.assertEqual(
             validation["analysis_to_design"]["missing_from_ids"],
@@ -308,6 +349,9 @@ class ReadinessTests(unittest.TestCase):
                 "approve-system",
                 "search-systems",
                 "entity-system",
+                "business-rule-1",
+                "state-transition-1",
                 "component-system-api",
+                "interaction-message-1",
             ],
         )


### PR DESCRIPTION
## Summary
- add first-class use-case step objects derived from structured use-case flow details
- derive requirement-to-step, step-to-interaction, step-to-transition, and business-rule-to-transition links with semantic metadata
- extend readiness/model docs and regression coverage for the finer-grained trace families

## Testing
- uv run python -m unittest tests.test_interview tests.test_discovery tests.test_readiness
- uv run python -m unittest

Closes #141