### PR TITLE
Add structured semantic planning objects

### DIFF
--- a/skills/rupify/references/rupify-model.md
+++ b/skills/rupify/references/rupify-model.md
@@ -112,6 +112,28 @@ The canonical project model is `rupify-model.yaml`.
     - `linked_step_ids`
     - `fit_criterion`
     - `trace`
+  - `acceptance_constraints`
+  - `acceptance_constraint_objects`
+    - `id`
+    - `name`
+    - `description`
+    - `constraint_kind`
+    - `source_requirement_id`
+    - `linked_use_case_ids`
+    - `model_layer`: `analysis`
+    - `trace`
+- `ambiguities` (compatibility mirror derived from `analysis_view.ambiguity_objects`)
+  - `id`
+  - `ambiguity_type`
+  - `description`
+  - `applies_to_element_ids`
+  - `blocking_for_downstream`
+  - `resolution_status`
+  - `source`
+  - `notes`
+  - `last_updated`
+  - `model_layer`: `analysis`
+  - `trace`
 - `analysis_view` (authoritative source for analysis-layer objects)
   - `actors`
   - `use_cases`
@@ -119,24 +141,36 @@ The canonical project model is `rupify-model.yaml`.
   - `scenario_objects`
   - `risk_objects`
   - `requirement_objects`
+  - `acceptance_constraint_objects`
+  - `ambiguity_objects`
   - `domain_entity_objects`
   - `relationship_objects`
   - `business_rule_objects`
+  - `domain_invariant_objects`
   - `state_entity_objects`
   - `state_transition_objects`
   - `trigger_objects`
+  - `state_invariant_objects`
+  - `guard_condition_objects`
+  - `forbidden_transition_objects`
   - `actor_ids`
   - `use_case_ids`
   - `use_case_step_ids`
   - `scenario_ids`
   - `risk_ids`
   - `requirement_ids`
+  - `acceptance_constraint_ids`
+  - `ambiguity_ids`
   - `domain_entity_ids`
   - `relationship_ids`
   - `business_rule_ids`
+  - `domain_invariant_ids`
   - `state_entity_ids`
   - `state_transition_ids`
   - `trigger_ids`
+  - `state_invariant_ids`
+  - `guard_condition_ids`
+  - `forbidden_transition_ids`
   - `scenario_objects`
     - `id`
     - `name`
@@ -160,6 +194,64 @@ The canonical project model is `rupify-model.yaml`.
     - `priority`
     - `status`
     - `mitigation`
+    - `model_layer`: `analysis`
+    - `trace`
+  - `acceptance_constraint_objects`
+    - `id`
+    - `name`
+    - `description`
+    - `constraint_kind`
+    - `source_requirement_id`
+    - `linked_use_case_ids`
+    - `model_layer`: `analysis`
+    - `trace`
+  - `ambiguity_objects`
+    - `id`
+    - `ambiguity_type`
+    - `description`
+    - `applies_to_element_ids`
+    - `blocking_for_downstream`
+    - `resolution_status`
+    - `source`
+    - `notes`
+    - `last_updated`
+    - `model_layer`: `analysis`
+    - `trace`
+  - `domain_invariant_objects`
+    - `id`
+    - `name`
+    - `description`
+    - `scope_entity_ids`
+    - `source_business_rule_id`
+    - `model_layer`: `analysis`
+    - `trace`
+  - `state_invariant_objects`
+    - `id`
+    - `name`
+    - `description`
+    - `state_entity_ids`
+    - `source_business_rule_id`
+    - `model_layer`: `analysis`
+    - `trace`
+  - `guard_condition_objects`
+    - `id`
+    - `name`
+    - `description`
+    - `condition_text`
+    - `state_entity_ids`
+    - `related_transition_ids`
+    - `source_trigger_id`
+    - `model_layer`: `analysis`
+    - `trace`
+  - `forbidden_transition_objects`
+    - `id`
+    - `name`
+    - `description`
+    - `related_transition_id`
+    - `from_state`
+    - `to_state`
+    - `state_entity_id`
+    - `source_business_rule_id`
     - `model_layer`: `analysis`
     - `trace`
 - `traceability`
@@ -194,6 +286,42 @@ The canonical project model is `rupify-model.yaml`.
     - `link_type`
     - `basis`
   - `business_rule_to_transition`
+    - `id`
+    - `from_id`
+    - `to_id`
+    - `link_type`
+    - `basis`
+  - `domain_invariant_to_entity`
+    - `id`
+    - `from_id`
+    - `to_id`
+    - `link_type`
+    - `basis`
+  - `state_invariant_to_state`
+    - `id`
+    - `from_id`
+    - `to_id`
+    - `link_type`
+    - `basis`
+  - `guard_to_transition`
+    - `id`
+    - `from_id`
+    - `to_id`
+    - `link_type`
+    - `basis`
+  - `forbidden_transition_to_transition`
+    - `id`
+    - `from_id`
+    - `to_id`
+    - `link_type`
+    - `basis`
+  - `acceptance_constraint_to_requirement`
+    - `id`
+    - `from_id`
+    - `to_id`
+    - `link_type`
+    - `basis`
+  - `ambiguity_to_element`
     - `id`
     - `from_id`
     - `to_id`
@@ -276,6 +404,15 @@ The canonical project model is `rupify-model.yaml`.
     - `model_layer`: `analysis`
     - `scope`
     - `trace`
+  - `domain_invariants`
+  - `domain_invariant_objects`
+    - `id`
+    - `name`
+    - `description`
+    - `scope_entity_ids`
+    - `source_business_rule_id`
+    - `model_layer`: `analysis`
+    - `trace`
 - `process_view` (derived compatibility view from `analysis_view` for V1/V1.5 renderers)
   - `state_entities`
   - `state_entity_objects`
@@ -310,6 +447,38 @@ The canonical project model is `rupify-model.yaml`.
     - `approval_required`
     - `constraint_type`
     - `exceptional_behavior`
+    - `trace`
+  - `state_invariants`
+  - `state_invariant_objects`
+    - `id`
+    - `name`
+    - `description`
+    - `state_entity_ids`
+    - `source_business_rule_id`
+    - `model_layer`: `analysis`
+    - `trace`
+  - `guard_conditions`
+  - `guard_condition_objects`
+    - `id`
+    - `name`
+    - `description`
+    - `condition_text`
+    - `state_entity_ids`
+    - `related_transition_ids`
+    - `source_trigger_id`
+    - `model_layer`: `analysis`
+    - `trace`
+  - `forbidden_transitions`
+  - `forbidden_transition_objects`
+    - `id`
+    - `name`
+    - `description`
+    - `related_transition_id`
+    - `from_state`
+    - `to_state`
+    - `state_entity_id`
+    - `source_business_rule_id`
+    - `model_layer`: `analysis`
     - `trace`
 - `design_view` (authoritative source for design-layer objects)
   - `component_objects`

--- a/src/rupify_tools/discovery.py
+++ b/src/rupify_tools/discovery.py
@@ -7,6 +7,8 @@ import json
 import re
 from typing import Any
 
+from .model_metadata import normalize_uncertainty_list
+
 TECHNICAL_FACTOR_ALIASES = {
     "distributed system": "distributed_system",
     "response time": "response_time",
@@ -909,6 +911,229 @@ def _build_use_case_step_objects(use_cases: list[dict[str, Any]]) -> list[dict[s
     return step_objects
 
 
+def _matched_object_ids(text: str, candidates: list[dict[str, Any]]) -> list[str]:
+    """Return canonical ids whose names are explicitly referenced by text."""
+    matched_ids = []
+    for candidate in candidates:
+        candidate_id = candidate.get("id", "")
+        candidate_name = candidate.get("name", "")
+        if candidate_id and candidate_name and _texts_overlap(text, candidate_name):
+            matched_ids.append(candidate_id)
+    return matched_ids
+
+
+def _build_domain_invariant_objects(
+    business_rules: list[dict[str, Any]],
+    domain_entities: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Promote explicit domain rules into first-class invariant objects."""
+    invariant_objects = []
+    for index, rule in enumerate(business_rules, 1):
+        rule_text = rule.get("rule_text", "")
+        if not rule_text:
+            continue
+        invariant_objects.append(
+            {
+                "id": f"domain-invariant-{index}",
+                "name": rule.get("name", f"Domain Invariant {index}"),
+                "description": rule_text,
+                "scope_entity_ids": _matched_object_ids(
+                    " ".join(part for part in (rule.get("scope", ""), rule_text) if part),
+                    domain_entities,
+                ),
+                "source_business_rule_id": rule.get("id", ""),
+                "model_layer": "analysis",
+                "trace": rule.get("trace", {}),
+            }
+        )
+    return invariant_objects
+
+
+def _build_state_invariant_objects(
+    business_rules: list[dict[str, Any]],
+    state_entities: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Promote explicit lifecycle-oriented rules into state invariant objects."""
+    invariant_objects = []
+    for index, rule in enumerate(business_rules, 1):
+        rule_text = rule.get("rule_text", "")
+        matched_state_ids = _matched_object_ids(
+            " ".join(part for part in (rule.get("scope", ""), rule_text) if part),
+            state_entities,
+        )
+        if not rule_text or not matched_state_ids:
+            continue
+        invariant_objects.append(
+            {
+                "id": f"state-invariant-{index}",
+                "name": rule.get("name", f"State Invariant {index}"),
+                "description": rule_text,
+                "state_entity_ids": matched_state_ids,
+                "source_business_rule_id": rule.get("id", ""),
+                "model_layer": "analysis",
+                "trace": rule.get("trace", {}),
+            }
+        )
+    return invariant_objects
+
+
+def _build_guard_condition_objects(
+    trigger_objects: list[dict[str, Any]],
+    state_entities: list[dict[str, Any]],
+    state_transitions: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Promote explicit trigger and approval text into first-class guard conditions."""
+    guard_objects = []
+    for index, trigger in enumerate(trigger_objects, 1):
+        description = trigger.get("description", "")
+        if not description:
+            continue
+        related_transition_ids = [
+            transition.get("id", "")
+            for transition in state_transitions
+            if transition.get("id")
+            and (
+                _texts_overlap(description, transition.get("description", ""))
+                or _texts_overlap(trigger.get("event_name", ""), transition.get("trigger", ""))
+            )
+        ]
+        if not related_transition_ids and trigger.get("approval_required") and len(state_transitions) == 1:
+            related_transition_ids = [state_transitions[0].get("id", "")]
+        guard_objects.append(
+            {
+                "id": f"guard-condition-{index}",
+                "name": trigger.get("event_name", "") or f"Guard Condition {index}",
+                "description": description,
+                "condition_text": description,
+                "state_entity_ids": _matched_object_ids(description, state_entities),
+                "related_transition_ids": related_transition_ids,
+                "source_trigger_id": trigger.get("id", ""),
+                "model_layer": "analysis",
+                "trace": trigger.get("trace", {}),
+            }
+        )
+    return guard_objects
+
+
+def _build_forbidden_transition_objects(
+    business_rules: list[dict[str, Any]],
+    state_transitions: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Promote explicit negative transition rules into first-class forbidden transitions."""
+    forbidden_objects = []
+    negative_markers = ("cannot", "must not", "may not", "forbid", "forbidden", "never")
+    for index, rule in enumerate(business_rules, 1):
+        rule_text = rule.get("rule_text", "")
+        if not rule_text or not any(marker in rule_text.lower() for marker in negative_markers):
+            continue
+        matched_transition = None
+        for transition in state_transitions:
+            transition_text = " ".join(
+                [
+                    transition.get("description", ""),
+                    transition.get("from_state", ""),
+                    transition.get("to_state", ""),
+                ]
+            ).strip()
+            if transition_text and _texts_overlap(rule_text, transition_text):
+                matched_transition = transition
+                break
+        if matched_transition is None and len(state_transitions) == 1:
+            matched_transition = state_transitions[0]
+        forbidden_objects.append(
+            {
+                "id": f"forbidden-transition-{index}",
+                "name": f"Forbidden Transition {index}",
+                "description": rule_text,
+                "related_transition_id": matched_transition.get("id", "") if matched_transition else "",
+                "from_state": matched_transition.get("from_state", "") if matched_transition else "",
+                "to_state": matched_transition.get("to_state", "") if matched_transition else "",
+                "state_entity_id": matched_transition.get("state_entity_id", "") if matched_transition else "",
+                "source_business_rule_id": rule.get("id", ""),
+                "model_layer": "analysis",
+                "trace": rule.get("trace", {}),
+            }
+        )
+    return forbidden_objects
+
+
+def _build_acceptance_constraint_objects(
+    non_functional_requirements: list[dict[str, Any]],
+    success_criteria: list[str],
+) -> list[dict[str, Any]]:
+    """Promote explicit acceptance constraints from NFRs and success criteria."""
+    constraint_objects = []
+    for index, requirement in enumerate(non_functional_requirements, 1):
+        statement = requirement.get("statement", "")
+        if not statement:
+            continue
+        constraint_objects.append(
+            {
+                "id": f"acceptance-constraint-requirement-{index}",
+                "name": requirement.get("quality_attribute", "") or f"Acceptance Constraint {index}",
+                "description": statement,
+                "constraint_kind": "non_functional_requirement",
+                "source_requirement_id": requirement.get("id", ""),
+                "linked_use_case_ids": list(requirement.get("linked_use_case_ids", [])),
+                "model_layer": "analysis",
+                "trace": requirement.get("trace", {}),
+            }
+        )
+    for index, criterion in enumerate(success_criteria, 1):
+        if not criterion:
+            continue
+        constraint_objects.append(
+            {
+                "id": f"acceptance-constraint-success-{index}",
+                "name": f"Success Criterion {index}",
+                "description": criterion,
+                "constraint_kind": "success_criterion",
+                "source_requirement_id": "",
+                "linked_use_case_ids": [],
+                "model_layer": "analysis",
+                "trace": {"source_round": 2, "source_key": "success_criteria"},
+            }
+        )
+    return constraint_objects
+
+
+def _build_ambiguity_objects(
+    assumptions: list[Any],
+    open_questions: list[Any],
+    element_candidates: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Promote uncertainty surfaces into first-class ambiguity objects."""
+    ambiguity_objects = []
+    normalized_items = [
+        ("assumption", item) for item in normalize_uncertainty_list(assumptions)
+    ] + [
+        ("open_question", item) for item in normalize_uncertainty_list(open_questions)
+    ]
+    for index, (ambiguity_type, item) in enumerate(normalized_items, 1):
+        description = item.get("text", "")
+        if not description:
+            continue
+        ambiguity_objects.append(
+            {
+                "id": f"ambiguity-{ambiguity_type}-{index}",
+                "ambiguity_type": ambiguity_type,
+                "description": description,
+                "applies_to_element_ids": _matched_object_ids(description, element_candidates),
+                "blocking_for_downstream": ambiguity_type == "open_question"
+                and item.get("status", "").strip().lower() not in {"resolved", "closed"},
+                "resolution_status": item.get("status", "").strip() or (
+                    "assumed" if ambiguity_type == "assumption" else "open"
+                ),
+                "source": item.get("source", "").strip(),
+                "notes": item.get("notes", "").strip(),
+                "last_updated": item.get("last_updated", "").strip(),
+                "model_layer": "analysis",
+                "trace": {},
+            }
+        )
+    return ambiguity_objects
+
+
 def _build_trace_links(
     requirement_objects: list[dict[str, Any]],
     use_cases: list[dict[str, Any]],
@@ -1083,6 +1308,122 @@ def _build_trace_links(
     }
 
 
+def _build_semantic_support_trace_links(
+    domain_invariants: list[dict[str, Any]],
+    state_invariants: list[dict[str, Any]],
+    guard_conditions: list[dict[str, Any]],
+    forbidden_transitions: list[dict[str, Any]],
+    acceptance_constraints: list[dict[str, Any]],
+    ambiguity_objects: list[dict[str, Any]],
+) -> dict[str, list[dict[str, Any]]]:
+    """Build explicit trace links for structured invariants, constraints, and ambiguities."""
+    domain_invariant_to_entity = []
+    state_invariant_to_state = []
+    guard_to_transition = []
+    forbidden_transition_to_transition = []
+    acceptance_constraint_to_requirement = []
+    ambiguity_to_element = []
+
+    for invariant in domain_invariants:
+        for entity_id in invariant.get("scope_entity_ids", []):
+            if not entity_id:
+                continue
+            domain_invariant_to_entity.append(
+                {
+                    "id": f"trace-domain-invariant-entity-{len(domain_invariant_to_entity) + 1}",
+                    "from_id": invariant["id"],
+                    "to_id": entity_id,
+                    "link_type": "domain_invariant_to_entity",
+                    "basis": "domain invariant scope references domain entity",
+                }
+            )
+
+    for invariant in state_invariants:
+        for state_entity_id in invariant.get("state_entity_ids", []):
+            if not state_entity_id:
+                continue
+            state_invariant_to_state.append(
+                {
+                    "id": f"trace-state-invariant-state-{len(state_invariant_to_state) + 1}",
+                    "from_id": invariant["id"],
+                    "to_id": state_entity_id,
+                    "link_type": "state_invariant_to_state",
+                    "basis": "state invariant scope references state entity",
+                }
+            )
+
+    for guard in guard_conditions:
+        for transition_id in guard.get("related_transition_ids", []):
+            if not transition_id:
+                continue
+            guard_to_transition.append(
+                {
+                    "id": f"trace-guard-transition-{len(guard_to_transition) + 1}",
+                    "from_id": guard["id"],
+                    "to_id": transition_id,
+                    "link_type": "guard_to_transition",
+                    "basis": "guard condition text references state transition",
+                }
+            )
+
+    for forbidden_transition in forbidden_transitions:
+        transition_id = forbidden_transition.get("related_transition_id", "")
+        if not transition_id:
+            continue
+        forbidden_transition_to_transition.append(
+            {
+                "id": (
+                    "trace-forbidden-transition-"
+                    f"{len(forbidden_transition_to_transition) + 1}"
+                ),
+                "from_id": forbidden_transition["id"],
+                "to_id": transition_id,
+                "link_type": "forbidden_transition_to_transition",
+                "basis": "forbidden transition references canonical state transition",
+            }
+        )
+
+    for constraint in acceptance_constraints:
+        requirement_id = constraint.get("source_requirement_id", "")
+        if not requirement_id:
+            continue
+        acceptance_constraint_to_requirement.append(
+            {
+                "id": (
+                    "trace-acceptance-constraint-requirement-"
+                    f"{len(acceptance_constraint_to_requirement) + 1}"
+                ),
+                "from_id": constraint["id"],
+                "to_id": requirement_id,
+                "link_type": "acceptance_constraint_to_requirement",
+                "basis": "acceptance constraint is derived from canonical requirement",
+            }
+        )
+
+    for ambiguity in ambiguity_objects:
+        for element_id in ambiguity.get("applies_to_element_ids", []):
+            if not element_id:
+                continue
+            ambiguity_to_element.append(
+                {
+                    "id": f"trace-ambiguity-element-{len(ambiguity_to_element) + 1}",
+                    "from_id": ambiguity["id"],
+                    "to_id": element_id,
+                    "link_type": "ambiguity_to_element",
+                    "basis": "ambiguity text explicitly references canonical element",
+                }
+            )
+
+    return {
+        "domain_invariant_to_entity": domain_invariant_to_entity,
+        "state_invariant_to_state": state_invariant_to_state,
+        "guard_to_transition": guard_to_transition,
+        "forbidden_transition_to_transition": forbidden_transition_to_transition,
+        "acceptance_constraint_to_requirement": acceptance_constraint_to_requirement,
+        "ambiguity_to_element": ambiguity_to_element,
+    }
+
+
 def _bind_use_case_supporting_links(
     use_cases: list[dict[str, Any]],
     requirement_objects: list[dict[str, Any]],
@@ -1117,14 +1458,20 @@ def _bind_use_case_supporting_links(
 def _build_artifact_lineage(
     risk_objects: list[dict[str, Any]],
     requirement_objects: list[dict[str, Any]],
+    acceptance_constraint_objects: list[dict[str, Any]],
+    ambiguity_objects: list[dict[str, Any]],
     use_cases: list[dict[str, Any]],
     scenario_objects: list[dict[str, Any]],
     domain_entity_objects: list[dict[str, Any]],
     relationship_objects: list[dict[str, Any]],
     business_rule_objects: list[dict[str, Any]],
+    domain_invariant_objects: list[dict[str, Any]],
     state_entity_objects: list[dict[str, Any]],
     state_transition_objects: list[dict[str, Any]],
     trigger_objects: list[dict[str, Any]],
+    state_invariant_objects: list[dict[str, Any]],
+    guard_condition_objects: list[dict[str, Any]],
+    forbidden_transition_objects: list[dict[str, Any]],
     component_objects: list[dict[str, Any]],
     interface_objects: list[dict[str, Any]],
     runtime_boundary_objects: list[dict[str, Any]],
@@ -1139,6 +1486,8 @@ def _build_artifact_lineage(
         ("system-document.md", "interfaces and integrations", interface_objects),
         ("system-document.md", "runtime boundaries", runtime_boundary_objects),
         ("requirements-spec.md", "functional requirements", requirement_objects),
+        ("requirements-spec.md", "acceptance constraints", acceptance_constraint_objects),
+        ("requirements-spec.md", "ambiguities", ambiguity_objects),
         ("use-case-model.md", "use cases", use_cases),
         ("use-case-documents.md", "use-case documents", use_cases),
         ("use-case-documents.md", "scenario summaries", scenario_objects),
@@ -1146,6 +1495,8 @@ def _build_artifact_lineage(
         ("domain-model.md", "domain entities", domain_entity_objects),
         ("domain-model.md", "relationships", relationship_objects),
         ("domain-model.md", "business rules", business_rule_objects),
+        ("domain-model.md", "domain invariants", domain_invariant_objects),
+        ("domain-model.md", "ambiguities", ambiguity_objects),
         ("interaction-model.md", "use-case realizations", realization_objects),
         ("interaction-model.md", "message flows", message_objects),
         ("deployment-model.md", "components", component_objects),
@@ -1154,6 +1505,10 @@ def _build_artifact_lineage(
         ("state-model.md", "state entities", state_entity_objects),
         ("state-model.md", "state transitions", state_transition_objects),
         ("state-model.md", "triggers and approvals", trigger_objects),
+        ("state-model.md", "state invariants", state_invariant_objects),
+        ("state-model.md", "guard conditions", guard_condition_objects),
+        ("state-model.md", "forbidden transitions", forbidden_transition_objects),
+        ("state-model.md", "ambiguities", ambiguity_objects),
     ]
 
     artifact_lineage = []
@@ -1283,6 +1638,7 @@ def _derive_logical_view(analysis_view: dict[str, Any]) -> dict[str, Any]:
     domain_entity_objects = analysis_view["domain_entity_objects"]
     relationship_objects = analysis_view["relationship_objects"]
     business_rule_objects = analysis_view["business_rule_objects"]
+    domain_invariant_objects = analysis_view["domain_invariant_objects"]
     return {
         "domain_entities": [item["name"] for item in domain_entity_objects],
         "domain_entity_objects": domain_entity_objects,
@@ -1290,6 +1646,8 @@ def _derive_logical_view(analysis_view: dict[str, Any]) -> dict[str, Any]:
         "relationship_objects": relationship_objects,
         "business_rules": [item["rule_text"] for item in business_rule_objects],
         "business_rule_objects": business_rule_objects,
+        "domain_invariants": [item["description"] for item in domain_invariant_objects],
+        "domain_invariant_objects": domain_invariant_objects,
     }
 
 
@@ -1298,6 +1656,9 @@ def _derive_process_view(analysis_view: dict[str, Any]) -> dict[str, Any]:
     state_entity_objects = analysis_view["state_entity_objects"]
     state_transition_objects = analysis_view["state_transition_objects"]
     trigger_objects = analysis_view["trigger_objects"]
+    state_invariant_objects = analysis_view["state_invariant_objects"]
+    guard_condition_objects = analysis_view["guard_condition_objects"]
+    forbidden_transition_objects = analysis_view["forbidden_transition_objects"]
     return {
         "state_entities": [item["name"] for item in state_entity_objects],
         "state_entity_objects": state_entity_objects,
@@ -1305,6 +1666,12 @@ def _derive_process_view(analysis_view: dict[str, Any]) -> dict[str, Any]:
         "state_transition_objects": state_transition_objects,
         "triggers_and_approvals": [item["description"] for item in trigger_objects],
         "trigger_objects": trigger_objects,
+        "state_invariants": [item["description"] for item in state_invariant_objects],
+        "state_invariant_objects": state_invariant_objects,
+        "guard_conditions": [item["description"] for item in guard_condition_objects],
+        "guard_condition_objects": guard_condition_objects,
+        "forbidden_transitions": [item["description"] for item in forbidden_transition_objects],
+        "forbidden_transition_objects": forbidden_transition_objects,
     }
 
 
@@ -1605,6 +1972,36 @@ def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
         scenario_objects,
     )
     use_case_step_objects = _build_use_case_step_objects(normalized_use_cases)
+    domain_invariant_objects = _build_domain_invariant_objects(
+        business_rule_objects,
+        domain_entity_objects,
+    )
+    state_invariant_objects = _build_state_invariant_objects(
+        business_rule_objects,
+        state_entity_objects,
+    )
+    guard_condition_objects = _build_guard_condition_objects(
+        trigger_objects,
+        state_entity_objects,
+        state_transition_objects,
+    )
+    forbidden_transition_objects = _build_forbidden_transition_objects(
+        business_rule_objects,
+        state_transition_objects,
+    )
+    acceptance_constraint_objects = _build_acceptance_constraint_objects(
+        non_functional_requirement_objects,
+        _ensure_list(round_2.get("success_criteria")),
+    )
+    ambiguity_objects = _build_ambiguity_objects(
+        replay.get("assumptions", []),
+        replay.get("open_questions", []),
+        normalized_actors
+        + normalized_use_cases
+        + domain_entity_objects
+        + state_entity_objects
+        + component_objects,
+    )
     _stamp_semantic_identity(normalized_actors, change_source="round_3")
     _stamp_semantic_identity(normalized_use_cases, change_source="round_3")
     _stamp_semantic_identity(use_case_step_objects, change_source="derived_use_case_steps")
@@ -1613,9 +2010,16 @@ def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
     _stamp_semantic_identity(domain_entity_objects, change_source="round_5")
     _stamp_semantic_identity(relationship_objects, change_source="round_5")
     _stamp_semantic_identity(business_rule_objects, change_source="round_5")
+    _stamp_semantic_identity(domain_invariant_objects, change_source="derived_domain_invariants")
+    _stamp_semantic_identity(state_invariant_objects, change_source="derived_state_invariants")
     _stamp_semantic_identity(state_entity_objects, change_source="round_6")
     _stamp_semantic_identity(state_transition_objects, change_source="round_6")
     _stamp_semantic_identity(trigger_objects, change_source="round_6")
+    _stamp_semantic_identity(guard_condition_objects, change_source="derived_guard_conditions")
+    _stamp_semantic_identity(
+        forbidden_transition_objects,
+        change_source="derived_forbidden_transitions",
+    )
     _stamp_semantic_identity(component_objects, change_source="round_7")
     _stamp_semantic_identity(interface_objects, change_source="round_7")
     _stamp_semantic_identity(runtime_boundary_objects, change_source="round_7")
@@ -1623,6 +2027,11 @@ def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
     _stamp_semantic_identity(functional_requirement_objects, change_source="round_4")
     _stamp_semantic_identity(non_functional_requirement_objects, change_source="round_2_or_4")
     _stamp_semantic_identity(all_requirement_objects, change_source="requirements")
+    _stamp_semantic_identity(
+        acceptance_constraint_objects,
+        change_source="derived_acceptance_constraints",
+    )
+    _stamp_semantic_identity(ambiguity_objects, change_source="derived_ambiguities")
     analysis_view = {
         "actor_ids": [item["id"] for item in normalized_actors],
         "use_case_ids": [item["id"] for item in normalized_use_cases],
@@ -1630,24 +2039,36 @@ def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
         "scenario_ids": [item["id"] for item in scenario_objects],
         "risk_ids": [item["id"] for item in risk_objects],
         "requirement_ids": [item["id"] for item in all_requirement_objects],
+        "acceptance_constraint_ids": [item["id"] for item in acceptance_constraint_objects],
+        "ambiguity_ids": [item["id"] for item in ambiguity_objects],
         "actors": normalized_actors,
         "use_cases": normalized_use_cases,
         "use_case_step_objects": use_case_step_objects,
         "scenario_objects": scenario_objects,
         "risk_objects": risk_objects,
         "requirement_objects": all_requirement_objects,
+        "acceptance_constraint_objects": acceptance_constraint_objects,
+        "ambiguity_objects": ambiguity_objects,
         "domain_entity_objects": domain_entity_objects,
         "relationship_objects": relationship_objects,
         "business_rule_objects": business_rule_objects,
+        "domain_invariant_objects": domain_invariant_objects,
         "state_entity_objects": state_entity_objects,
         "state_transition_objects": state_transition_objects,
         "trigger_objects": trigger_objects,
+        "state_invariant_objects": state_invariant_objects,
+        "guard_condition_objects": guard_condition_objects,
+        "forbidden_transition_objects": forbidden_transition_objects,
         "domain_entity_ids": [item["id"] for item in domain_entity_objects],
         "relationship_ids": [item["id"] for item in relationship_objects],
         "business_rule_ids": [item["id"] for item in business_rule_objects],
+        "domain_invariant_ids": [item["id"] for item in domain_invariant_objects],
         "state_entity_ids": [item["id"] for item in state_entity_objects],
         "state_transition_ids": [item["id"] for item in state_transition_objects],
         "trigger_ids": [item["id"] for item in trigger_objects],
+        "state_invariant_ids": [item["id"] for item in state_invariant_objects],
+        "guard_condition_ids": [item["id"] for item in guard_condition_objects],
+        "forbidden_transition_ids": [item["id"] for item in forbidden_transition_objects],
     }
     design_view = {
         "component_objects": component_objects,
@@ -1689,6 +2110,16 @@ def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
         component_objects,
         interaction_view["message_objects"],
     )
+    traceability.update(
+        _build_semantic_support_trace_links(
+            domain_invariant_objects,
+            state_invariant_objects,
+            guard_condition_objects,
+            forbidden_transition_objects,
+            acceptance_constraint_objects,
+            ambiguity_objects,
+        )
+    )
     _bind_use_case_supporting_links(
         normalized_use_cases,
         all_requirement_objects,
@@ -1697,14 +2128,20 @@ def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
     traceability["artifact_lineage"] = _build_artifact_lineage(
         risk_objects,
         all_requirement_objects,
+        acceptance_constraint_objects,
+        ambiguity_objects,
         normalized_use_cases,
         scenario_objects,
         domain_entity_objects,
         relationship_objects,
         business_rule_objects,
+        domain_invariant_objects,
         state_entity_objects,
         state_transition_objects,
         trigger_objects,
+        state_invariant_objects,
+        guard_condition_objects,
+        forbidden_transition_objects,
         component_objects,
         interface_objects,
         runtime_boundary_objects,
@@ -1736,6 +2173,30 @@ def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
         change_source="derived_traceability",
     )
     _stamp_semantic_identity(
+        traceability["domain_invariant_to_entity"],
+        change_source="derived_traceability",
+    )
+    _stamp_semantic_identity(
+        traceability["state_invariant_to_state"],
+        change_source="derived_traceability",
+    )
+    _stamp_semantic_identity(
+        traceability["guard_to_transition"],
+        change_source="derived_traceability",
+    )
+    _stamp_semantic_identity(
+        traceability["forbidden_transition_to_transition"],
+        change_source="derived_traceability",
+    )
+    _stamp_semantic_identity(
+        traceability["acceptance_constraint_to_requirement"],
+        change_source="derived_traceability",
+    )
+    _stamp_semantic_identity(
+        traceability["ambiguity_to_element"],
+        change_source="derived_traceability",
+    )
+    _stamp_semantic_identity(
         traceability["analysis_to_design"],
         change_source="derived_traceability",
     )
@@ -1754,6 +2215,7 @@ def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
         "business_goals": _ensure_list(round_2.get("outcomes")),
         "success_criteria": _ensure_list(round_2.get("success_criteria")),
         "risks": risk_objects,
+        "ambiguities": ambiguity_objects,
         "actors": normalized_actors,
         "use_cases": normalized_use_cases,
         "scenarios": scenario_objects,
@@ -1762,6 +2224,8 @@ def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
             "functional_objects": functional_requirement_objects,
             "non_functional": _requirement_statements_by_kind(all_requirement_objects, "non_functional"),
             "non_functional_objects": non_functional_requirement_objects,
+            "acceptance_constraints": [item["description"] for item in acceptance_constraint_objects],
+            "acceptance_constraint_objects": acceptance_constraint_objects,
         },
         "analysis_view": analysis_view,
         "traceability": traceability,
@@ -1771,8 +2235,8 @@ def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
         "design_view": design_view,
         "interaction_view": interaction_view,
         "metadata_fields": _ensure_list(round_4.get("metadata_fields")),
-        "assumptions": [],
-        "open_questions": [],
+        "assumptions": replay.get("assumptions", []),
+        "open_questions": replay.get("open_questions", []),
         "ucp": {
             "technical_factors": technical_factors,
             "environmental_factors": environmental_factors,

--- a/src/rupify_tools/readiness.py
+++ b/src/rupify_tools/readiness.py
@@ -196,13 +196,19 @@ def evaluate_traceability(model: dict[str, Any]) -> dict[str, dict[str, Any]]:
     design_objects = model.get("architecture_view", {}).get("component_objects", [])
     artifact_source_objects = (
         requirement_objects
+        + model.get("requirements", {}).get("acceptance_constraint_objects", [])
+        + model.get("analysis_view", {}).get("ambiguity_objects", [])
         + use_cases
         + model.get("logical_view", {}).get("domain_entity_objects", [])
         + model.get("logical_view", {}).get("relationship_objects", [])
         + model.get("logical_view", {}).get("business_rule_objects", [])
+        + model.get("logical_view", {}).get("domain_invariant_objects", [])
         + model.get("process_view", {}).get("state_entity_objects", [])
         + model.get("process_view", {}).get("state_transition_objects", [])
         + model.get("process_view", {}).get("trigger_objects", [])
+        + model.get("process_view", {}).get("state_invariant_objects", [])
+        + model.get("process_view", {}).get("guard_condition_objects", [])
+        + model.get("process_view", {}).get("forbidden_transition_objects", [])
         + model.get("architecture_view", {}).get("component_objects", [])
         + model.get("architecture_view", {}).get("interface_objects", [])
         + model.get("architecture_view", {}).get("runtime_boundary_objects", [])
@@ -259,6 +265,64 @@ def evaluate_traceability(model: dict[str, Any]) -> dict[str, dict[str, Any]]:
             else [],
             traceability.get("business_rule_to_transition", []),
             "business_rule_to_transition",
+        ),
+        "domain_invariant_to_entity": _trace_family_result(
+            [
+                item.get("id", "")
+                for item in model.get("logical_view", {}).get("domain_invariant_objects", [])
+            ]
+            if model.get("logical_view", {}).get("domain_entity_objects", [])
+            else [],
+            traceability.get("domain_invariant_to_entity", []),
+            "domain_invariant_to_entity",
+        ),
+        "state_invariant_to_state": _trace_family_result(
+            [
+                item.get("id", "")
+                for item in model.get("process_view", {}).get("state_invariant_objects", [])
+            ]
+            if model.get("process_view", {}).get("state_entity_objects", [])
+            else [],
+            traceability.get("state_invariant_to_state", []),
+            "state_invariant_to_state",
+        ),
+        "guard_to_transition": _trace_family_result(
+            [
+                item.get("id", "")
+                for item in model.get("process_view", {}).get("guard_condition_objects", [])
+            ]
+            if model.get("process_view", {}).get("state_transition_objects", [])
+            else [],
+            traceability.get("guard_to_transition", []),
+            "guard_to_transition",
+        ),
+        "forbidden_transition_to_transition": _trace_family_result(
+            [
+                item.get("id", "")
+                for item in model.get("process_view", {}).get("forbidden_transition_objects", [])
+            ]
+            if model.get("process_view", {}).get("state_transition_objects", [])
+            else [],
+            traceability.get("forbidden_transition_to_transition", []),
+            "forbidden_transition_to_transition",
+        ),
+        "acceptance_constraint_to_requirement": _trace_family_result(
+            [
+                item.get("id", "")
+                for item in model.get("requirements", {}).get("acceptance_constraint_objects", [])
+                if item.get("source_requirement_id", "")
+            ],
+            traceability.get("acceptance_constraint_to_requirement", []),
+            "acceptance_constraint_to_requirement",
+        ),
+        "ambiguity_to_element": _trace_family_result(
+            [
+                item.get("id", "")
+                for item in model.get("analysis_view", {}).get("ambiguity_objects", [])
+                if item.get("applies_to_element_ids", [])
+            ],
+            traceability.get("ambiguity_to_element", []),
+            "ambiguity_to_element",
         ),
         "analysis_to_design": _trace_family_result(
             [item.get("id", "") for item in analysis_objects] if design_objects else [],

--- a/src/rupify_tools/render.py
+++ b/src/rupify_tools/render.py
@@ -119,6 +119,61 @@ def _object_text_section(
     return _named_section(title, fallback)
 
 
+def _structured_semantic_section(title: str, items: list[dict[str, Any]]) -> str:
+    """Render structured semantic objects with a compact metadata summary."""
+    if not items:
+        return ""
+
+    rendered = []
+    for item in items:
+        text = (
+            item.get("description")
+            or item.get("condition_text")
+            or item.get("rule_text")
+            or item.get("text")
+            or "Unspecified"
+        )
+        line = f"- `{item.get('id', 'item')}` {text}"
+        details = []
+        for key, label in (
+            ("constraint_kind", "kind"),
+            ("ambiguity_type", "type"),
+            ("resolution_status", "status"),
+            ("source_requirement_id", "requirement"),
+            ("source_business_rule_id", "business rule"),
+            ("source_trigger_id", "trigger"),
+            ("related_transition_id", "transition"),
+        ):
+            if item.get(key):
+                details.append(f"{label}: {item[key]}")
+        for key, label in (
+            ("scope_entity_ids", "scope"),
+            ("state_entity_ids", "states"),
+            ("related_transition_ids", "transitions"),
+            ("linked_use_case_ids", "use cases"),
+            ("applies_to_element_ids", "applies to"),
+        ):
+            values = item.get(key, [])
+            if values:
+                details.append(f"{label}: {', '.join(values)}")
+        if "blocking_for_downstream" in item:
+            details.append(
+                f"blocking: {'yes' if item.get('blocking_for_downstream') else 'no'}"
+            )
+        if trace := item.get("trace"):
+            details.append(
+                f"source: round {trace.get('source_round', 'n/a')} {trace.get('source_key', '')}".strip()
+            )
+        if details:
+            line = f"{line} ({'; '.join(details)})"
+        rendered.append(line)
+    return f"""
+## {title}
+
+{"\n".join(rendered)}
+"""
+
+
 def _traceability_section(
     title: str,
     links: list[dict[str, Any]],
@@ -528,6 +583,7 @@ def render_requirements_spec(model: dict[str, Any]) -> str:
         process_view.get("state_transition_objects", []),
     )
     trigger_objects = analysis_view.get("trigger_objects", process_view.get("trigger_objects", []))
+    ambiguity_objects = analysis_view.get("ambiguity_objects", model.get("ambiguities", []))
     component_objects = design_view.get("component_objects", architecture_view.get("component_objects", []))
     interface_objects = design_view.get("interface_objects", architecture_view.get("interface_objects", []))
     runtime_boundary_objects = design_view.get(
@@ -561,6 +617,10 @@ def render_requirements_spec(model: dict[str, Any]) -> str:
 ## Non-Functional Requirements
 
 {_bullet_list(requirements.get("non_functional", []))}
+{_structured_semantic_section(
+    "Acceptance Constraints",
+    requirements.get("acceptance_constraint_objects", []),
+)}
 {_object_name_section(
     "Logical View",
     domain_entity_objects,
@@ -617,6 +677,10 @@ def render_requirements_spec(model: dict[str, Any]) -> str:
 {_traceability_section(
     "Analysis To Design Traceability",
     traceability.get("analysis_to_design", []),
+)}
+{_structured_semantic_section(
+    "Ambiguities",
+    ambiguity_objects,
 )}
 
 ## Assumptions
@@ -1111,6 +1175,11 @@ def render_domain_model(model: dict[str, Any]) -> str:
         "business_rule_objects",
         logical_view.get("business_rule_objects", []),
     )
+    domain_invariant_objects = analysis_view.get(
+        "domain_invariant_objects",
+        logical_view.get("domain_invariant_objects", []),
+    )
+    ambiguity_objects = analysis_view.get("ambiguity_objects", model.get("ambiguities", []))
     domain_entity_ids = {item.get("id", "") for item in domain_entity_objects if item.get("id")}
 
     return f"""# Domain Model
@@ -1138,9 +1207,21 @@ def render_domain_model(model: dict[str, Any]) -> str:
     business_rule_objects,
     logical_view.get("business_rules", []),
 )}
+{_structured_semantic_section(
+    "Domain Invariants",
+    domain_invariant_objects,
+)}
 {_traceability_section(
     "Use-Case To Domain Traceability",
     _filter_trace_links(traceability.get("use_case_to_analysis", []), domain_entity_ids),
+)}
+{_traceability_section(
+    "Domain Invariant To Entity Traceability",
+    _filter_trace_links(traceability.get("domain_invariant_to_entity", []), domain_entity_ids),
+)}
+{_structured_semantic_section(
+    "Ambiguities",
+    ambiguity_objects,
 )}
 {_artifact_lineage_section(
     "Artifact Lineage",
@@ -1509,6 +1590,19 @@ def render_state_model(model: dict[str, Any]) -> str:
         "trigger_objects",
         process_view.get("trigger_objects", []),
     )
+    state_invariant_objects = analysis_view.get(
+        "state_invariant_objects",
+        process_view.get("state_invariant_objects", []),
+    )
+    guard_condition_objects = analysis_view.get(
+        "guard_condition_objects",
+        process_view.get("guard_condition_objects", []),
+    )
+    forbidden_transition_objects = analysis_view.get(
+        "forbidden_transition_objects",
+        process_view.get("forbidden_transition_objects", []),
+    )
+    ambiguity_objects = analysis_view.get("ambiguity_objects", model.get("ambiguities", []))
     component_objects = design_view.get("component_objects", [])
     state_entity_ids = {item.get("id", "") for item in state_entity_objects if item.get("id")}
     component_ids = {item.get("id", "") for item in component_objects if item.get("id")}
@@ -1538,9 +1632,33 @@ def render_state_model(model: dict[str, Any]) -> str:
     trigger_objects,
     process_view.get("triggers_and_approvals", []),
 )}
+{_structured_semantic_section(
+    "State Invariants",
+    state_invariant_objects,
+)}
+{_structured_semantic_section(
+    "Guard Conditions",
+    guard_condition_objects,
+)}
+{_structured_semantic_section(
+    "Forbidden Transitions",
+    forbidden_transition_objects,
+)}
 {_traceability_section(
     "Use-Case To State Traceability",
     _filter_trace_links(traceability.get("use_case_to_analysis", []), state_entity_ids),
+)}
+{_traceability_section(
+    "State Invariant To State Traceability",
+    _filter_trace_links(traceability.get("state_invariant_to_state", []), state_entity_ids),
+)}
+{_traceability_section(
+    "Guard To Transition Traceability",
+    traceability.get("guard_to_transition", []),
+)}
+{_traceability_section(
+    "Forbidden Transition Traceability",
+    traceability.get("forbidden_transition_to_transition", []),
 )}
 {_traceability_section(
     "State To Design Traceability",
@@ -1548,6 +1666,10 @@ def render_state_model(model: dict[str, Any]) -> str:
         traceability.get("analysis_to_design", []),
         state_entity_ids | component_ids,
     ),
+)}
+{_structured_semantic_section(
+    "Ambiguities",
+    ambiguity_objects,
 )}
 {_artifact_lineage_section(
     "Artifact Lineage",

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -785,6 +785,108 @@ class DiscoveryTests(unittest.TestCase):
             },
         )
 
+    def test_normalize_replay_to_model_promotes_structured_invariants_constraints_and_ambiguities(
+        self,
+    ) -> None:
+        """Normalization should expose structured semantic objects for downstream planning."""
+        replay = replay_session(
+            [
+                {
+                    "round": 2,
+                    "responses": [
+                        {"key": "constraints", "answer": ["Security: SSO required"]},
+                        {"key": "success_criteria", "answer": ["Approval completes within one day"]},
+                    ],
+                },
+                {
+                    "round": 5,
+                    "responses": [
+                        {"key": "domain_entities", "answer": ["System"]},
+                        {
+                            "key": "business_rules",
+                            "answer": [
+                                "System must retain an owner",
+                                "System lifecycle cannot move from Approved to Draft",
+                            ],
+                        },
+                    ],
+                },
+                {
+                    "round": 6,
+                    "responses": [
+                        {"key": "state_entities", "answer": ["System lifecycle"]},
+                        {
+                            "key": "states_and_transitions",
+                            "answer": ["System lifecycle: Draft -> Approved"],
+                        },
+                        {
+                            "key": "triggers_and_approvals",
+                            "answer": ["Approval requires manager approval"],
+                        },
+                    ],
+                },
+            ]
+        )
+        replay["assumptions"] = [
+            {
+                "text": "System ownership rules may change after pilot.",
+                "status": "assumed",
+                "source": "workshop",
+            }
+        ]
+        replay["open_questions"] = [
+            {
+                "text": "Should System lifecycle include Archived state?",
+                "status": "open",
+                "source": "review",
+            }
+        ]
+
+        model = normalize_replay_to_model(replay)
+
+        self.assertEqual(
+            model["requirements"]["acceptance_constraint_objects"][0]["source_requirement_id"],
+            "non_functional-requirement-1",
+        )
+        self.assertEqual(
+            model["requirements"]["acceptance_constraint_objects"][1]["constraint_kind"],
+            "success_criterion",
+        )
+        self.assertEqual(
+            model["logical_view"]["domain_invariant_objects"][0]["scope_entity_ids"],
+            ["entity-system"],
+        )
+        self.assertEqual(
+            model["process_view"]["state_invariant_objects"][0]["state_entity_ids"],
+            ["state-entity-system-lifecycle"],
+        )
+        self.assertEqual(
+            model["process_view"]["guard_condition_objects"][0]["related_transition_ids"],
+            ["state-transition-1"],
+        )
+        self.assertEqual(
+            model["process_view"]["forbidden_transition_objects"][0]["related_transition_id"],
+            "state-transition-1",
+        )
+        self.assertEqual(model["ambiguities"][0]["ambiguity_type"], "assumption")
+        self.assertEqual(model["ambiguities"][1]["resolution_status"], "open")
+        self.assertEqual(
+            model["traceability"]["domain_invariant_to_entity"][0]["to_id"],
+            "entity-system",
+        )
+        self.assertEqual(
+            model["traceability"]["guard_to_transition"][0]["to_id"],
+            "state-transition-1",
+        )
+        self.assertEqual(
+            model["traceability"]["acceptance_constraint_to_requirement"][0]["to_id"],
+            "non_functional-requirement-1",
+        )
+        self.assertEqual(
+            model["traceability"]["ambiguity_to_element"][0]["to_id"],
+            "entity-system",
+        )
+
     def test_normalize_replay_to_model_with_real_fixture(self) -> None:
         """The checked-in interview fixture should normalize into the canonical V1.5 shape."""
         repo_root = Path(__file__).resolve().parents[1]

--- a/tests/test_readiness.py
+++ b/tests/test_readiness.py
@@ -264,13 +264,20 @@ class ReadinessTests(unittest.TestCase):
                 "functional_objects": [
                     {"id": "functional-requirement-1"},
                     {"id": "functional-requirement-2"},
-                ]
+                ],
+                "acceptance_constraint_objects": [
+                    {
+                        "id": "acceptance-constraint-requirement-1",
+                        "source_requirement_id": "functional-requirement-1",
+                    }
+                ],
             },
             "use_cases": [
                 {"id": "approve-system"},
                 {"id": "search-systems"},
             ],
             "analysis_view": {
+                "ambiguity_objects": [{"id": "ambiguity-open-question-1", "applies_to_element_ids": ["entity-system"]}],
                 "use_case_step_objects": [
                     {"id": "approve-system-step-1"},
                     {"id": "approve-system-step-2"},
@@ -279,10 +286,14 @@ class ReadinessTests(unittest.TestCase):
             "logical_view": {
                 "domain_entity_objects": [{"id": "entity-system"}],
                 "business_rule_objects": [{"id": "business-rule-1"}],
+                "domain_invariant_objects": [{"id": "domain-invariant-1"}],
             },
             "process_view": {
-                "state_entity_objects": [],
+                "state_entity_objects": [{"id": "state-entity-system"}],
                 "state_transition_objects": [{"id": "state-transition-1"}],
+                "state_invariant_objects": [{"id": "state-invariant-1"}],
+                "guard_condition_objects": [{"id": "guard-condition-1"}],
+                "forbidden_transition_objects": [{"id": "forbidden-transition-1"}],
             },
             "interaction_view": {"message_objects": [{"id": "interaction-message-1"}]},
             "architecture_view": {"component_objects": [{"id": "component-system-api"}]},
@@ -302,6 +313,27 @@ class ReadinessTests(unittest.TestCase):
                 ],
                 "business_rule_to_transition": [
                     {"from_id": "business-rule-1", "to_id": "state-transition-1"}
+                ],
+                "domain_invariant_to_entity": [
+                    {"from_id": "domain-invariant-1", "to_id": "entity-system"}
+                ],
+                "state_invariant_to_state": [
+                    {"from_id": "state-invariant-1", "to_id": "state-entity-system"}
+                ],
+                "guard_to_transition": [
+                    {"from_id": "guard-condition-1", "to_id": "state-transition-1"}
+                ],
+                "forbidden_transition_to_transition": [
+                    {"from_id": "forbidden-transition-1", "to_id": "state-transition-1"}
+                ],
+                "acceptance_constraint_to_requirement": [
+                    {
+                        "from_id": "acceptance-constraint-requirement-1",
+                        "to_id": "functional-requirement-1",
+                    }
+                ],
+                "ambiguity_to_element": [
+                    {"from_id": "ambiguity-open-question-1", "to_id": "entity-system"}
                 ],
                 "analysis_to_design": [],
             },
@@ -335,10 +367,16 @@ class ReadinessTests(unittest.TestCase):
             ["approve-system-step-2"],
         )
         self.assertEqual(validation["business_rule_to_transition"]["status"], "ready")
+        self.assertEqual(validation["domain_invariant_to_entity"]["status"], "ready")
+        self.assertEqual(validation["state_invariant_to_state"]["status"], "ready")
+        self.assertEqual(validation["guard_to_transition"]["status"], "ready")
+        self.assertEqual(validation["forbidden_transition_to_transition"]["status"], "ready")
+        self.assertEqual(validation["acceptance_constraint_to_requirement"]["status"], "ready")
+        self.assertEqual(validation["ambiguity_to_element"]["status"], "ready")
         self.assertEqual(validation["analysis_to_design"]["status"], "blocked")
         self.assertEqual(
             validation["analysis_to_design"]["missing_from_ids"],
-            ["entity-system"],
+            ["entity-system", "state-entity-system"],
         )
         self.assertEqual(validation["artifact_lineage"]["status"], "blocked")
         self.assertEqual(
@@ -346,11 +384,18 @@ class ReadinessTests(unittest.TestCase):
             [
                 "functional-requirement-1",
                 "functional-requirement-2",
+                "acceptance-constraint-requirement-1",
+                "ambiguity-open-question-1",
                 "approve-system",
                 "search-systems",
                 "entity-system",
                 "business-rule-1",
+                "domain-invariant-1",
+                "state-entity-system",
                 "state-transition-1",
+                "state-invariant-1",
+                "guard-condition-1",
+                "forbidden-transition-1",
                 "component-system-api",
                 "interaction-message-1",
             ],

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -250,6 +250,47 @@ class RenderTests(unittest.TestCase):
             rendered,
         )
 
+    def test_requirements_render_includes_acceptance_constraints_and_ambiguities(self) -> None:
+        """Requirements rendering should surface structured acceptance and ambiguity objects."""
+        model = build_model()
+        model["requirements"] = {
+            "functional": [],
+            "non_functional": [],
+            "acceptance_constraint_objects": [
+                {
+                    "id": "acceptance-constraint-1",
+                    "description": "Security: SSO required",
+                    "constraint_kind": "non_functional_requirement",
+                    "source_requirement_id": "non_functional-requirement-1",
+                    "linked_use_case_ids": ["uc-redeem"],
+                    "trace": {"source_round": 2, "source_key": "constraints"},
+                }
+            ],
+        }
+        model["analysis_view"] = {
+            "ambiguity_objects": [
+                {
+                    "id": "ambiguity-open-question-1",
+                    "ambiguity_type": "open_question",
+                    "description": "Should partner merchants count as actors in V1?",
+                    "applies_to_element_ids": ["customer"],
+                    "blocking_for_downstream": True,
+                    "resolution_status": "open",
+                    "trace": {},
+                }
+            ]
+        }
+
+        rendered = render_requirements_spec(model)
+
+        self.assertIn("## Acceptance Constraints", rendered)
+        self.assertIn("Security: SSO required", rendered)
+        self.assertIn("kind: non_functional_requirement", rendered)
+        self.assertIn("use cases: uc-redeem", rendered)
+        self.assertIn("## Ambiguities", rendered)
+        self.assertIn("type: open_question", rendered)
+        self.assertIn("blocking: yes", rendered)
+
     def test_render_prefers_layer_collections_when_present(self) -> None:
         """Rendering should remain coherent when analysis/design objects live under layer sections."""
         from rupify_tools.render import render_use_case_model
@@ -801,6 +842,98 @@ class RenderTests(unittest.TestCase):
             rendered,
         )
 
+    def test_state_model_render_includes_structured_semantic_sections(self) -> None:
+        """State-model rendering should surface structured state invariants, guards, and forbidden transitions."""
+        model = build_model()
+        model["analysis_view"] = {
+            "state_entity_objects": [
+                {
+                    "id": "state-entity-redemption-request",
+                    "name": "Redemption Request",
+                    "states": ["Requested", "Approved"],
+                }
+            ],
+            "state_transition_objects": [
+                {
+                    "id": "state-transition-1",
+                    "description": "Requested -> Approved",
+                    "from_state": "Requested",
+                    "to_state": "Approved",
+                }
+            ],
+            "trigger_objects": [],
+            "state_invariant_objects": [
+                {
+                    "id": "state-invariant-1",
+                    "description": "Redemption Request must have an owner before approval.",
+                    "state_entity_ids": ["state-entity-redemption-request"],
+                }
+            ],
+            "guard_condition_objects": [
+                {
+                    "id": "guard-condition-1",
+                    "description": "Approval requires manager approval.",
+                    "related_transition_ids": ["state-transition-1"],
+                    "source_trigger_id": "trigger-1",
+                }
+            ],
+            "forbidden_transition_objects": [
+                {
+                    "id": "forbidden-transition-1",
+                    "description": "Redemption Request cannot move from Approved to Requested.",
+                    "related_transition_id": "state-transition-1",
+                }
+            ],
+            "ambiguity_objects": [
+                {
+                    "id": "ambiguity-open-question-1",
+                    "ambiguity_type": "open_question",
+                    "description": "Should Approved be terminal?",
+                    "applies_to_element_ids": ["state-transition-1"],
+                    "blocking_for_downstream": True,
+                    "resolution_status": "open",
+                }
+            ],
+        }
+        model["traceability"] = {
+            "state_invariant_to_state": [
+                {
+                    "id": "trace-state-invariant-state-1",
+                    "from_id": "state-invariant-1",
+                    "to_id": "state-entity-redemption-request",
+                }
+            ],
+            "guard_to_transition": [
+                {
+                    "id": "trace-guard-transition-1",
+                    "from_id": "guard-condition-1",
+                    "to_id": "state-transition-1",
+                }
+            ],
+            "forbidden_transition_to_transition": [
+                {
+                    "id": "trace-forbidden-transition-1",
+                    "from_id": "forbidden-transition-1",
+                    "to_id": "state-transition-1",
+                }
+            ],
+        }
+
+        rendered = render_state_model(model)
+
+        self.assertIn("## State Invariants", rendered)
+        self.assertIn("Redemption Request must have an owner before approval.", rendered)
+        self.assertIn("states: state-entity-redemption-request", rendered)
+        self.assertIn("## Guard Conditions", rendered)
+        self.assertIn("trigger: trigger-1", rendered)
+        self.assertIn("transitions: state-transition-1", rendered)
+        self.assertIn("## Forbidden Transitions", rendered)
+        self.assertIn("transition: state-transition-1", rendered)
+        self.assertIn("## State Invariant To State Traceability", rendered)
+        self.assertIn("## Guard To Transition Traceability", rendered)
+        self.assertIn("## Forbidden Transition Traceability", rendered)
+        self.assertIn("## Ambiguities", rendered)
+
     def test_domain_model_render_includes_logical_traceability(self) -> None:
         """Domain-model rendering should surface logical semantics and relevant trace links."""
         model = build_model()
@@ -870,6 +1003,56 @@ class RenderTests(unittest.TestCase):
 
         self.assertIn("## Artifact Lineage", rendered)
         self.assertIn("entity-member -> domain-model.md#domain entities", rendered)
+
+    def test_domain_model_render_includes_domain_invariants_and_ambiguities(self) -> None:
+        """Domain-model rendering should surface structured domain invariants and ambiguity links."""
+        model = build_model()
+        model["analysis_view"] = {
+            "domain_entity_objects": [
+                {
+                    "id": "entity-member",
+                    "name": "Member",
+                }
+            ],
+            "relationship_objects": [],
+            "business_rule_objects": [],
+            "domain_invariant_objects": [
+                {
+                    "id": "domain-invariant-1",
+                    "description": "Member must have enough points.",
+                    "scope_entity_ids": ["entity-member"],
+                    "source_business_rule_id": "business-rule-1",
+                }
+            ],
+            "ambiguity_objects": [
+                {
+                    "id": "ambiguity-open-question-1",
+                    "ambiguity_type": "open_question",
+                    "description": "Should guest shoppers count as Members?",
+                    "applies_to_element_ids": ["entity-member"],
+                    "blocking_for_downstream": True,
+                    "resolution_status": "open",
+                }
+            ],
+        }
+        model["traceability"] = {
+            "domain_invariant_to_entity": [
+                {
+                    "id": "trace-domain-invariant-entity-1",
+                    "from_id": "domain-invariant-1",
+                    "to_id": "entity-member",
+                }
+            ]
+        }
+
+        rendered = render_domain_model(model)
+
+        self.assertIn("## Domain Invariants", rendered)
+        self.assertIn("scope: entity-member", rendered)
+        self.assertIn("business rule: business-rule-1", rendered)
+        self.assertIn("## Domain Invariant To Entity Traceability", rendered)
+        self.assertIn("## Ambiguities", rendered)
+        self.assertIn("blocking: yes", rendered)
 
     def test_render_domain_mermaid_outputs_class_diagram(self) -> None:
         """Domain Mermaid rendering should emit a deterministic class diagram."""


### PR DESCRIPTION
## Summary
- promote invariants, guard conditions, forbidden transitions, acceptance constraints, and ambiguities into first-class canonical objects
- derive supporting traceability and artifact lineage for the new semantic families and surface them in requirements, domain, and state renderers
- extend readiness validation and regression coverage for the new downstream-planning contract surfaces

## Testing
- uv run python -m unittest tests.test_discovery tests.test_render tests.test_readiness
- uv run python -m unittest

Closes #137