### PR TITLE
Add element readiness semantics

### DIFF
--- a/skills/rupify/references/rupify-model.md
+++ b/skills/rupify/references/rupify-model.md
@@ -63,6 +63,12 @@ The canonical project model is `rupify-model.yaml`.
   - `other_artifact_refs`
   - `other_requirement_ids`
   - `scenario_ids`
+  - `content_semantics`: `normative` or `informative`
+  - `readiness`
+    - `status`: `ready`, `partial`, or `blocked`
+    - `missing_fields`
+    - `blocking_ambiguity_ids`
+    - `normative_ready`
 - `analysis_view` (authoritative source for analysis-layer objects)
   - `use_case_step_objects`
     - `id`
@@ -89,6 +95,8 @@ The canonical project model is `rupify-model.yaml`.
   - `participating_analysis_object_ids`
   - `other_requirement_ids`
   - `trace`
+  - `content_semantics`: `normative` or `informative`
+  - `readiness`
 - `requirements`
   - `functional`
   - `functional_objects`
@@ -101,6 +109,8 @@ The canonical project model is `rupify-model.yaml`.
     - `linked_step_ids`
     - `fit_criterion`
     - `trace`
+    - `content_semantics`: `normative` or `informative`
+    - `readiness`
   - `non_functional`
   - `non_functional_objects`
     - `id`
@@ -112,6 +122,8 @@ The canonical project model is `rupify-model.yaml`.
     - `linked_step_ids`
     - `fit_criterion`
     - `trace`
+    - `content_semantics`: `normative` or `informative`
+    - `readiness`
   - `acceptance_constraints`
   - `acceptance_constraint_objects`
     - `id`
@@ -122,6 +134,8 @@ The canonical project model is `rupify-model.yaml`.
     - `linked_use_case_ids`
     - `model_layer`: `analysis`
     - `trace`
+    - `content_semantics`: `normative` or `informative`
+    - `readiness`
 - `ambiguities` (compatibility mirror derived from `analysis_view.ambiguity_objects`)
   - `id`
   - `ambiguity_type`
@@ -134,6 +148,18 @@ The canonical project model is `rupify-model.yaml`.
   - `last_updated`
   - `model_layer`: `analysis`
   - `trace`
+  - `content_semantics`: `normative` or `informative`
+  - `readiness`
+- `element_readiness`
+  - `by_family`
+    - per-family readiness entries keyed by canonical family name
+    - each entry includes `id`, `family`, `content_semantics`, `status`, `missing_fields`,
+      `blocking_ambiguity_ids`, and `normative_ready`
+  - `summary`
+    - `ready_normative_ids`
+    - `partial_normative_ids`
+    - `blocked_normative_ids`
+    - `informative_ids`
 - `analysis_view` (authoritative source for analysis-layer objects)
   - `actors`
   - `use_cases`

--- a/src/rupify_tools/discovery.py
+++ b/src/rupify_tools/discovery.py
@@ -1547,6 +1547,7 @@ def _stable_semantic_payload(value: Any) -> Any:
             "trace",
             "change_metadata",
             "semantic_id",
+            "readiness",
             "complexity_trace",
             "last_changed_at",
         }
@@ -1604,6 +1605,17 @@ def _stamp_semantic_identity(
             item,
             change_source=change_source,
         )
+    return items
+
+
+def _apply_content_semantics(
+    items: list[dict[str, Any]],
+    *,
+    semantics: str,
+) -> list[dict[str, Any]]:
+    """Attach normative-versus-informative semantics to canonical records."""
+    for item in items:
+        item["content_semantics"] = semantics
     return items
 
 
@@ -2002,6 +2014,28 @@ def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
         + state_entity_objects
         + component_objects,
     )
+    _apply_content_semantics(normalized_actors, semantics="informative")
+    _apply_content_semantics(normalized_use_cases, semantics="normative")
+    _apply_content_semantics(use_case_step_objects, semantics="normative")
+    _apply_content_semantics(scenario_objects, semantics="normative")
+    _apply_content_semantics(risk_objects, semantics="informative")
+    _apply_content_semantics(functional_requirement_objects, semantics="normative")
+    _apply_content_semantics(non_functional_requirement_objects, semantics="normative")
+    _apply_content_semantics(acceptance_constraint_objects, semantics="normative")
+    _apply_content_semantics(ambiguity_objects, semantics="informative")
+    _apply_content_semantics(domain_entity_objects, semantics="normative")
+    _apply_content_semantics(relationship_objects, semantics="normative")
+    _apply_content_semantics(business_rule_objects, semantics="normative")
+    _apply_content_semantics(domain_invariant_objects, semantics="normative")
+    _apply_content_semantics(state_entity_objects, semantics="normative")
+    _apply_content_semantics(state_transition_objects, semantics="normative")
+    _apply_content_semantics(trigger_objects, semantics="normative")
+    _apply_content_semantics(state_invariant_objects, semantics="normative")
+    _apply_content_semantics(guard_condition_objects, semantics="normative")
+    _apply_content_semantics(forbidden_transition_objects, semantics="normative")
+    _apply_content_semantics(component_objects, semantics="informative")
+    _apply_content_semantics(interface_objects, semantics="informative")
+    _apply_content_semantics(runtime_boundary_objects, semantics="informative")
     _stamp_semantic_identity(normalized_actors, change_source="round_3")
     _stamp_semantic_identity(normalized_use_cases, change_source="round_3")
     _stamp_semantic_identity(use_case_step_objects, change_source="derived_use_case_steps")
@@ -2247,5 +2281,32 @@ def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
             "formal_specification": [],
         },
     }
+    from .readiness import evaluate_element_readiness
+
+    element_readiness = evaluate_element_readiness(model)
+    model["element_readiness"] = element_readiness
+    readiness_by_id = {
+        item["id"]: item
+        for family_items in element_readiness.get("by_family", {}).values()
+        for item in family_items
+        if item.get("id")
+    }
+    for items in (
+        functional_requirement_objects,
+        non_functional_requirement_objects,
+        acceptance_constraint_objects,
+        normalized_use_cases,
+        use_case_step_objects,
+        scenario_objects,
+        domain_invariant_objects,
+        state_transition_objects,
+        state_invariant_objects,
+        guard_condition_objects,
+        forbidden_transition_objects,
+        ambiguity_objects,
+    ):
+        for item in items:
+            if item.get("id") in readiness_by_id:
+                item["readiness"] = readiness_by_id[item["id"]]
     model["model_metadata"] = _build_model_metadata(model)
     return model

--- a/src/rupify_tools/interview.py
+++ b/src/rupify_tools/interview.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from .discovery import normalize_replay_to_model
 from .readiness import (
+    evaluate_element_readiness,
     evaluate_readiness,
     evaluate_readiness_details,
     evaluate_traceability,
@@ -784,6 +785,7 @@ def replay_session(round_inputs: list[dict[str, Any]]) -> dict[str, Any]:
     }
     model = normalize_replay_to_model(replay)
     replay["traceability_validation"] = evaluate_traceability(model)
+    replay["element_readiness_validation"] = evaluate_element_readiness(model)
     return replay
 
 

--- a/src/rupify_tools/readiness.py
+++ b/src/rupify_tools/readiness.py
@@ -335,3 +335,164 @@ def evaluate_traceability(model: dict[str, Any]) -> dict[str, dict[str, Any]]:
             "artifact_lineage",
         ),
     }
+
+
+def _unresolved_ambiguity_ids_by_element(model: dict[str, Any]) -> dict[str, list[str]]:
+    """Return unresolved ambiguity ids grouped by the element ids they block."""
+    ambiguity_lookup = {
+        item.get("id", ""): item
+        for item in model.get("analysis_view", {}).get("ambiguity_objects", [])
+        if item.get("id")
+    }
+    unresolved_by_element: dict[str, list[str]] = {}
+    for link in model.get("traceability", {}).get("ambiguity_to_element", []):
+        ambiguity_id = str(link.get("from_id", "")).strip()
+        element_id = str(link.get("to_id", "")).strip()
+        ambiguity = ambiguity_lookup.get(ambiguity_id, {})
+        resolution_status = str(ambiguity.get("resolution_status", "")).strip().lower()
+        if not ambiguity_id or not element_id or resolution_status in {"resolved", "closed"}:
+            continue
+        unresolved_by_element.setdefault(element_id, []).append(ambiguity_id)
+    return unresolved_by_element
+
+
+def _base_element_result(
+    item: dict[str, Any],
+    family: str,
+    required_fields: list[tuple[str, Any]],
+    unresolved_ambiguities: dict[str, list[str]],
+) -> dict[str, Any]:
+    """Build one element-level readiness result."""
+    item_id = str(item.get("id", "")).strip()
+    missing_fields = []
+    for field_name, value in required_fields:
+        if isinstance(value, list):
+            if not value:
+                missing_fields.append(field_name)
+            continue
+        if not str(value).strip():
+            missing_fields.append(field_name)
+
+    blocking_ambiguity_ids = unresolved_ambiguities.get(item_id, [])
+    if missing_fields:
+        status = "blocked"
+    elif blocking_ambiguity_ids:
+        status = "partial"
+    else:
+        status = "ready"
+
+    return {
+        "id": item_id,
+        "family": family,
+        "content_semantics": item.get("content_semantics", ""),
+        "status": status,
+        "missing_fields": missing_fields,
+        "blocking_ambiguity_ids": blocking_ambiguity_ids,
+        "normative_ready": item.get("content_semantics") == "normative" and status == "ready",
+    }
+
+
+def evaluate_element_readiness(model: dict[str, Any]) -> dict[str, Any]:
+    """Evaluate readiness on individual canonical elements that downstream tools consume."""
+    analysis_view = model.get("analysis_view", {})
+    process_view = model.get("process_view", {})
+    unresolved_ambiguities = _unresolved_ambiguity_ids_by_element(model)
+
+    family_specs = {
+        "requirements": (
+            model.get("requirements", {}).get("functional_objects", [])
+            + model.get("requirements", {}).get("non_functional_objects", []),
+            lambda item: [("statement", item.get("statement", ""))],
+        ),
+        "acceptance_constraints": (
+            model.get("requirements", {}).get("acceptance_constraint_objects", []),
+            lambda item: [("description", item.get("description", ""))],
+        ),
+        "use_cases": (
+            analysis_view.get("use_cases", model.get("use_cases", [])),
+            lambda item: [
+                ("name", item.get("name", "")),
+                ("goal", item.get("goal", "")),
+                ("main_success_scenario", item.get("main_success_scenario", [])),
+            ],
+        ),
+        "scenarios": (
+            analysis_view.get("scenario_objects", model.get("scenarios", [])),
+            lambda item: [
+                ("name", item.get("name", "")),
+                ("summary", item.get("summary", "")),
+                ("flow_of_events", item.get("flow_of_events", [])),
+            ],
+        ),
+        "use_case_steps": (
+            analysis_view.get("use_case_step_objects", []),
+            lambda item: [("text", item.get("text", ""))],
+        ),
+        "state_transitions": (
+            process_view.get("state_transition_objects", []),
+            lambda item: [("description", item.get("description", ""))],
+        ),
+        "domain_invariants": (
+            model.get("logical_view", {}).get("domain_invariant_objects", []),
+            lambda item: [
+                ("description", item.get("description", "")),
+                ("scope_entity_ids", item.get("scope_entity_ids", [])),
+            ],
+        ),
+        "state_invariants": (
+            process_view.get("state_invariant_objects", []),
+            lambda item: [
+                ("description", item.get("description", "")),
+                ("state_entity_ids", item.get("state_entity_ids", [])),
+            ],
+        ),
+        "guard_conditions": (
+            process_view.get("guard_condition_objects", []),
+            lambda item: [
+                ("description", item.get("description", "")),
+                ("related_transition_ids", item.get("related_transition_ids", [])),
+            ],
+        ),
+        "forbidden_transitions": (
+            process_view.get("forbidden_transition_objects", []),
+            lambda item: [("description", item.get("description", ""))],
+        ),
+        "ambiguities": (
+            analysis_view.get("ambiguity_objects", model.get("ambiguities", [])),
+            lambda item: [("description", item.get("description", ""))],
+        ),
+    }
+
+    by_family: dict[str, list[dict[str, Any]]] = {}
+    all_items = []
+    for family, (items, requirement_builder) in family_specs.items():
+        family_results = [
+            _base_element_result(item, family, requirement_builder(item), unresolved_ambiguities)
+            for item in items
+        ]
+        by_family[family] = family_results
+        all_items.extend(family_results)
+
+    return {
+        "by_family": by_family,
+        "summary": {
+            "ready_normative_ids": [
+                item["id"]
+                for item in all_items
+                if item["content_semantics"] == "normative" and item["status"] == "ready"
+            ],
+            "partial_normative_ids": [
+                item["id"]
+                for item in all_items
+                if item["content_semantics"] == "normative" and item["status"] == "partial"
+            ],
+            "blocked_normative_ids": [
+                item["id"]
+                for item in all_items
+                if item["content_semantics"] == "normative" and item["status"] == "blocked"
+            ],
+            "informative_ids": [
+                item["id"] for item in all_items if item["content_semantics"] == "informative"
+            ],
+        },
+    }

--- a/src/rupify_tools/render.py
+++ b/src/rupify_tools/render.py
@@ -136,6 +136,7 @@ def _structured_semantic_section(title: str, items: list[dict[str, Any]]) -> str
         line = f"- `{item.get('id', 'item')}` {text}"
         details = []
         for key, label in (
+            ("content_semantics", "semantics"),
             ("constraint_kind", "kind"),
             ("ambiguity_type", "type"),
             ("resolution_status", "status"),
@@ -160,6 +161,12 @@ def _structured_semantic_section(title: str, items: list[dict[str, Any]]) -> str
             details.append(
                 f"blocking: {'yes' if item.get('blocking_for_downstream') else 'no'}"
             )
+        if readiness := item.get("readiness", {}):
+            details.append(f"readiness: {readiness.get('status', 'unspecified')}")
+            if readiness.get("blocking_ambiguity_ids"):
+                details.append(
+                    f"blocking ambiguities: {', '.join(readiness['blocking_ambiguity_ids'])}"
+                )
         if trace := item.get("trace"):
             details.append(
                 f"source: round {trace.get('source_round', 'n/a')} {trace.get('source_key', '')}".strip()
@@ -911,6 +918,8 @@ def render_use_case_documents(model: dict[str, Any]) -> str:
 - Supporting Actors: {", ".join(supporting_actors) or "None"}
 - Priority: {use_case.get("priority", "") or "Unspecified"}
 - Status: {use_case.get("status", "") or "Unspecified"}
+- Content Semantics: {use_case.get("content_semantics", "") or "Unspecified"}
+- Readiness: {use_case.get("readiness", {}).get("status", "unspecified")}
 - Complexity: {use_case.get("complexity", "unclassified")}
 - Goal: {use_case.get("goal", "Unspecified")}
 - Trigger: {use_case.get("trigger", "") or "Unspecified"}
@@ -1101,6 +1110,8 @@ def render_scenario_documents(model: dict[str, Any]) -> str:
 - Parent Use Case: {parent_use_case_name}
 - Priority: {scenario.get("priority", "") or "Unspecified"}
 - Status: {scenario.get("status", "") or "Unspecified"}
+- Content Semantics: {scenario.get("content_semantics", "") or "Unspecified"}
+- Readiness: {scenario.get("readiness", {}).get("status", "unspecified")}
 - Source: round {scenario.get("trace", {}).get("source_round", "n/a")} {scenario.get("trace", {}).get("source_key", "")}
 
 ### Brief Description

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -886,6 +886,23 @@ class DiscoveryTests(unittest.TestCase):
             model["traceability"]["ambiguity_to_element"][0]["to_id"],
             "entity-system",
         )
+        self.assertEqual(
+            model["logical_view"]["domain_invariant_objects"][0]["content_semantics"],
+            "normative",
+        )
+        self.assertEqual(
+            model["requirements"]["acceptance_constraint_objects"][0]["content_semantics"],
+            "normative",
+        )
+        self.assertEqual(model["ambiguities"][0]["content_semantics"], "informative")
+        self.assertEqual(
+            model["logical_view"]["domain_invariant_objects"][0]["readiness"]["status"],
+            "ready",
+        )
+        self.assertIn(
+            "domain-invariant-1",
+            model["element_readiness"]["summary"]["ready_normative_ids"],
+        )
 
     def test_normalize_replay_to_model_with_real_fixture(self) -> None:
         """The checked-in interview fixture should normalize into the canonical V1.5 shape."""

--- a/tests/test_interview.py
+++ b/tests/test_interview.py
@@ -73,6 +73,14 @@ class InterviewHarnessTests(unittest.TestCase):
         self.assertEqual(replay["readiness"]["architecture"], "blocked")
         self.assertEqual(replay["readiness_details"]["discovery"]["required_missing"], [])
         self.assertEqual(replay["traceability_validation"]["requirement_to_use_case"]["status"], "blocked")
+        self.assertEqual(
+            replay["element_readiness_validation"]["summary"]["ready_normative_ids"],
+            [
+                "non_functional-requirement-1",
+                "acceptance-constraint-requirement-1",
+                "acceptance-constraint-success-1",
+            ],
+        )
         self.assertEqual(replay["stale_artifacts"], [])
 
     def test_replay_session_accepts_individual_question_responses(self) -> None:

--- a/tests/test_readiness.py
+++ b/tests/test_readiness.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import unittest
 
 from rupify_tools.readiness import (
+    evaluate_element_readiness,
     evaluate_readiness,
     evaluate_readiness_details,
     evaluate_traceability,
@@ -400,3 +401,105 @@ class ReadinessTests(unittest.TestCase):
                 "interaction-message-1",
             ],
         )
+
+    def test_evaluate_element_readiness_marks_only_defensible_normative_elements_ready(self) -> None:
+        """Element readiness should distinguish normative-ready elements from blocked or informative ones."""
+        model = {
+            "requirements": {
+                "functional_objects": [
+                    {
+                        "id": "functional-requirement-1",
+                        "statement": "Approve system changes",
+                        "content_semantics": "normative",
+                    }
+                ],
+                "non_functional_objects": [],
+                "acceptance_constraint_objects": [
+                    {
+                        "id": "acceptance-constraint-1",
+                        "description": "SSO is required",
+                        "content_semantics": "normative",
+                    }
+                ],
+            },
+            "analysis_view": {
+                "use_cases": [
+                    {
+                        "id": "approve-system",
+                        "name": "Approve System",
+                        "goal": "Approve system changes.",
+                        "main_success_scenario": ["Validate request", "Approve request"],
+                        "content_semantics": "normative",
+                    }
+                ],
+                "use_case_step_objects": [
+                    {
+                        "id": "approve-system-step-1",
+                        "text": "Validate request",
+                        "content_semantics": "normative",
+                    }
+                ],
+                "scenario_objects": [
+                    {
+                        "id": "scenario-approval",
+                        "name": "Happy path",
+                        "summary": "Normal approval path",
+                        "flow_of_events": [],
+                        "content_semantics": "normative",
+                    }
+                ],
+                "ambiguity_objects": [
+                    {
+                        "id": "ambiguity-open-question-1",
+                        "description": "Should archived systems need approval?",
+                        "resolution_status": "open",
+                        "content_semantics": "informative",
+                    }
+                ],
+            },
+            "logical_view": {
+                "domain_invariant_objects": [
+                    {
+                        "id": "domain-invariant-1",
+                        "description": "System must have an owner",
+                        "scope_entity_ids": ["entity-system"],
+                        "content_semantics": "normative",
+                    }
+                ]
+            },
+            "process_view": {
+                "state_transition_objects": [
+                    {
+                        "id": "state-transition-1",
+                        "description": "Draft -> Approved",
+                        "content_semantics": "normative",
+                    }
+                ],
+                "state_invariant_objects": [],
+                "guard_condition_objects": [],
+                "forbidden_transition_objects": [],
+            },
+            "traceability": {
+                "ambiguity_to_element": [
+                    {
+                        "from_id": "ambiguity-open-question-1",
+                        "to_id": "approve-system",
+                    }
+                ]
+            },
+            "ambiguities": [],
+        }
+
+        validation = evaluate_element_readiness(model)
+
+        self.assertIn("functional-requirement-1", validation["summary"]["ready_normative_ids"])
+        self.assertIn("acceptance-constraint-1", validation["summary"]["ready_normative_ids"])
+        self.assertIn("approve-system", validation["summary"]["partial_normative_ids"])
+        self.assertIn("scenario-approval", validation["summary"]["blocked_normative_ids"])
+        self.assertIn("ambiguity-open-question-1", validation["summary"]["informative_ids"])
+        self.assertEqual(validation["by_family"]["use_cases"][0]["status"], "partial")
+        self.assertEqual(
+            validation["by_family"]["use_cases"][0]["blocking_ambiguity_ids"],
+            ["ambiguity-open-question-1"],
+        )
+        self.assertEqual(validation["by_family"]["scenarios"][0]["missing_fields"], ["flow_of_events"])

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -263,6 +263,8 @@ class RenderTests(unittest.TestCase):
                     "constraint_kind": "non_functional_requirement",
                     "source_requirement_id": "non_functional-requirement-1",
                     "linked_use_case_ids": ["uc-redeem"],
+                    "content_semantics": "normative",
+                    "readiness": {"status": "ready"},
                     "trace": {"source_round": 2, "source_key": "constraints"},
                 }
             ],
@@ -276,6 +278,8 @@ class RenderTests(unittest.TestCase):
                     "applies_to_element_ids": ["customer"],
                     "blocking_for_downstream": True,
                     "resolution_status": "open",
+                    "content_semantics": "informative",
+                    "readiness": {"status": "ready"},
                     "trace": {},
                 }
             ]
@@ -285,6 +289,7 @@ class RenderTests(unittest.TestCase):
 
         self.assertIn("## Acceptance Constraints", rendered)
         self.assertIn("Security: SSO required", rendered)
+        self.assertIn("semantics: normative", rendered)
         self.assertIn("kind: non_functional_requirement", rendered)
         self.assertIn("use cases: uc-redeem", rendered)
         self.assertIn("## Ambiguities", rendered)
@@ -867,6 +872,7 @@ class RenderTests(unittest.TestCase):
                     "id": "state-invariant-1",
                     "description": "Redemption Request must have an owner before approval.",
                     "state_entity_ids": ["state-entity-redemption-request"],
+                    "readiness": {"status": "ready"},
                 }
             ],
             "guard_condition_objects": [
@@ -875,6 +881,7 @@ class RenderTests(unittest.TestCase):
                     "description": "Approval requires manager approval.",
                     "related_transition_ids": ["state-transition-1"],
                     "source_trigger_id": "trigger-1",
+                    "readiness": {"status": "ready"},
                 }
             ],
             "forbidden_transition_objects": [
@@ -882,6 +889,7 @@ class RenderTests(unittest.TestCase):
                     "id": "forbidden-transition-1",
                     "description": "Redemption Request cannot move from Approved to Requested.",
                     "related_transition_id": "state-transition-1",
+                    "readiness": {"status": "ready"},
                 }
             ],
             "ambiguity_objects": [
@@ -892,6 +900,7 @@ class RenderTests(unittest.TestCase):
                     "applies_to_element_ids": ["state-transition-1"],
                     "blocking_for_downstream": True,
                     "resolution_status": "open",
+                    "readiness": {"status": "ready"},
                 }
             ],
         }
@@ -933,6 +942,7 @@ class RenderTests(unittest.TestCase):
         self.assertIn("## Guard To Transition Traceability", rendered)
         self.assertIn("## Forbidden Transition Traceability", rendered)
         self.assertIn("## Ambiguities", rendered)
+        self.assertIn("readiness:", rendered)
 
     def test_domain_model_render_includes_logical_traceability(self) -> None:
         """Domain-model rendering should surface logical semantics and relevant trace links."""
@@ -1053,6 +1063,75 @@ class RenderTests(unittest.TestCase):
         self.assertIn("## Domain Invariant To Entity Traceability", rendered)
         self.assertIn("## Ambiguities", rendered)
         self.assertIn("blocking: yes", rendered)
+
+    def test_use_case_and_scenario_documents_render_element_semantics(self) -> None:
+        """Compiled document families should surface element semantics and readiness."""
+        model = build_model()
+        model["analysis_view"] = {
+            "actors": [],
+            "use_cases": [
+                {
+                    "id": "uc-redeem",
+                    "name": "Redeem Reward",
+                    "primary_actor": "Customer",
+                    "priority": "high",
+                    "status": "confirmed",
+                    "content_semantics": "normative",
+                    "readiness": {"status": "ready"},
+                    "complexity": "complex",
+                    "goal": "Redeem a reward.",
+                    "trigger": "Customer selects reward",
+                    "trace": {"source_round": 3, "source_key": "use_cases"},
+                    "preconditions": [],
+                    "postconditions": [],
+                    "extension_points": [],
+                    "used_use_case_ids": [],
+                    "subordinate_use_case_ids": [],
+                    "main_success_scenario": ["Customer selects reward."],
+                    "extensions": [],
+                    "scenario_ids": ["scenario-happy-path"],
+                    "ui_notes": [],
+                    "participating_analysis_object_ids": [],
+                    "other_requirement_ids": [],
+                    "other_artifact_refs": [],
+                    "supporting_actor_ids": [],
+                }
+            ],
+            "scenario_objects": [
+                {
+                    "id": "scenario-happy-path",
+                    "name": "Happy Path",
+                    "use_case_id": "uc-redeem",
+                    "use_case_name": "Redeem Reward",
+                    "summary": "Customer redeems a reward",
+                    "priority": "high",
+                    "status": "confirmed",
+                    "content_semantics": "normative",
+                    "readiness": {"status": "ready"},
+                    "trace": {"source_round": 13, "source_key": "scenarios"},
+                    "flow_of_events": ["Customer selects reward."],
+                    "activity_notes": [],
+                    "sequence_notes": [],
+                    "participating_analysis_object_ids": [],
+                    "other_requirement_ids": [],
+                    "other_artifact_refs": [],
+                }
+            ],
+            "requirement_objects": [],
+            "domain_entity_objects": [],
+            "relationship_objects": [],
+            "state_entity_objects": [],
+        }
+        model["interaction_view"] = {"realization_objects": []}
+        model["traceability"] = {"artifact_lineage": []}
+
+        use_case_rendered = render_use_case_documents(model)
+        scenario_rendered = render_scenario_documents(model)
+
+        self.assertIn("- Content Semantics: normative", use_case_rendered)
+        self.assertIn("- Readiness: ready", use_case_rendered)
+        self.assertIn("- Content Semantics: normative", scenario_rendered)
+        self.assertIn("- Readiness: ready", scenario_rendered)
 
     def test_render_domain_mermaid_outputs_class_diagram(self) -> None:
         """Domain Mermaid rendering should emit a deterministic class diagram."""


### PR DESCRIPTION
## Summary
- add element-level  and derived  metadata to canonical planning objects
- expose a dedicated  evaluation so downstream tooling can select only ready normative elements
- surface semantics and readiness in replay output, renderers, model docs, and regression coverage

## Testing
- uv run python -m unittest tests.test_interview tests.test_discovery tests.test_render tests.test_readiness
- uv run python -m unittest

Closes #139