### PR TITLE
Add Speckify planning export

### DIFF
--- a/docs/end-to-end-usage.md
+++ b/docs/end-to-end-usage.md
@@ -66,6 +66,14 @@ uv run rupify-render \
   --artifact-family ucp
 ```
 
+### Downstream Planning Export
+
+```bash
+uv run rupify-export-planning \
+  --model examples/it-systems-inventory/rupify-model.json \
+  --output /tmp/rupify-planning-export.json
+```
+
 ### Mermaid Outputs
 
 ```bash

--- a/docs/speckify-planning-export.md
+++ b/docs/speckify-planning-export.md
@@ -1,0 +1,67 @@
+# Speckify Planning Export
+
+Rupify now exposes a dedicated machine-oriented planning export for downstream Speckify consumption.
+
+## Purpose
+
+The canonical model remains the source of truth inside Rupify. The planning export is a stricter
+downstream contract that:
+
+- flattens planning-relevant canonical elements into one machine-friendly `elements` collection
+- preserves stable ids through `id`, `semantic_id`, and `change_metadata`
+- carries element-level `content_semantics` and `readiness_status`
+- exposes `ready_normative_elements` so downstream tools can consume only defensible planning inputs
+- preserves flattened `trace_links` and `blocking_ambiguities`
+
+## CLI
+
+```bash
+uv run rupify-export-planning \
+  --model examples/it-systems-inventory/rupify-model.json \
+  --output /tmp/rupify-planning-export.json
+```
+
+## Export Shape
+
+- `export_metadata`
+  - `schema_version`
+  - `export_kind`
+  - `source_model_semantic_id`
+  - `source_model_change_metadata`
+- `summary`
+  - `element_count`
+  - `trace_link_count`
+  - `ready_normative_count`
+  - `blocking_ambiguity_count`
+  - `ready_normative_ids`
+  - `partial_or_blocked_normative_ids`
+  - `blocking_ambiguity_ids`
+- `elements`
+  - flat machine-oriented element records with:
+    - `id`
+    - `semantic_id`
+    - `family`
+    - `name`
+    - `text`
+    - `content_semantics`
+    - `readiness_status`
+    - `normative_ready`
+    - `missing_fields`
+    - `blocking_ambiguity_ids`
+    - `source_round`
+    - `source_key`
+    - `change_metadata`
+    - `attributes`
+- `ready_normative_elements`
+  - the ready subset of `elements` where `content_semantics == normative`
+- `blocking_ambiguities`
+  - the ambiguity subset that explicitly blocks downstream planning
+- `trace_links`
+  - flattened traceability and artifact lineage records
+
+## Contract Guidance
+
+- Speckify should prefer `ready_normative_elements` when selecting decomposition inputs.
+- `elements` should still be retained for context, partial markers, and auditability.
+- `trace_links` should be treated as the canonical link surface for downstream graph traversal.
+- `blocking_ambiguities` should be treated as explicit stop conditions, not hidden warnings.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ rupify-interview-replay = "rupify_tools.interview_replay:main"
 rupify-interview-to-formal = "rupify_tools.interview_to_formal_cli:main"
 rupify-ucp = "rupify_tools.ucp_cli:main"
 rupify-render = "rupify_tools.render_cli:main"
+rupify-export-planning = "rupify_tools.planning_export_cli:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/src/rupify_tools/planning_export.py
+++ b/src/rupify_tools/planning_export.py
@@ -1,0 +1,210 @@
+"""Machine-oriented downstream planning export for Speckify."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+ELEMENT_FAMILY_SPECS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("functional_requirements", ("requirements", "functional_objects")),
+    ("non_functional_requirements", ("requirements", "non_functional_objects")),
+    ("acceptance_constraints", ("requirements", "acceptance_constraint_objects")),
+    ("actors", ("analysis_view", "actors")),
+    ("use_cases", ("analysis_view", "use_cases")),
+    ("use_case_steps", ("analysis_view", "use_case_step_objects")),
+    ("scenarios", ("analysis_view", "scenario_objects")),
+    ("ambiguities", ("analysis_view", "ambiguity_objects")),
+    ("risks", ("analysis_view", "risk_objects")),
+    ("domain_entities", ("logical_view", "domain_entity_objects")),
+    ("relationships", ("logical_view", "relationship_objects")),
+    ("business_rules", ("logical_view", "business_rule_objects")),
+    ("domain_invariants", ("logical_view", "domain_invariant_objects")),
+    ("state_entities", ("process_view", "state_entity_objects")),
+    ("state_transitions", ("process_view", "state_transition_objects")),
+    ("triggers", ("process_view", "trigger_objects")),
+    ("state_invariants", ("process_view", "state_invariant_objects")),
+    ("guard_conditions", ("process_view", "guard_condition_objects")),
+    ("forbidden_transitions", ("process_view", "forbidden_transition_objects")),
+    ("components", ("architecture_view", "component_objects")),
+    ("interfaces", ("architecture_view", "interface_objects")),
+    ("runtime_boundaries", ("architecture_view", "runtime_boundary_objects")),
+)
+
+
+def _get_nested(model: dict[str, Any], path: tuple[str, ...]) -> list[dict[str, Any]]:
+    """Return a nested list from the canonical model."""
+    current: Any = model
+    for key in path:
+        if not isinstance(current, dict):
+            return []
+        current = current.get(key, {})
+    return current if isinstance(current, list) else []
+
+
+def _pick_first_text(item: dict[str, Any]) -> str:
+    """Return the most useful text field for one canonical item."""
+    for key in (
+        "statement",
+        "description",
+        "summary",
+        "goal",
+        "text",
+        "rule_text",
+        "condition_text",
+        "name",
+    ):
+        value = str(item.get(key, "")).strip()
+        if value:
+            return value
+    return ""
+
+
+def _pick_first_name(item: dict[str, Any]) -> str:
+    """Return the most useful name-like field for one canonical item."""
+    for key in ("name", "use_case_name", "event_name"):
+        value = str(item.get(key, "")).strip()
+        if value:
+            return value
+    return ""
+
+
+def _export_attributes(item: dict[str, Any]) -> dict[str, Any]:
+    """Return machine-friendly family-specific attributes for one element."""
+    attribute_keys = (
+        "requirement_kind",
+        "quality_attribute",
+        "linked_use_case_ids",
+        "linked_step_ids",
+        "primary_actor_id",
+        "supporting_actor_ids",
+        "scenario_ids",
+        "used_use_case_ids",
+        "subordinate_use_case_ids",
+        "preconditions",
+        "postconditions",
+        "main_success_scenario",
+        "extensions",
+        "flow_of_events",
+        "scope_entity_ids",
+        "state_entity_ids",
+        "related_transition_ids",
+        "related_transition_id",
+        "source_requirement_id",
+        "source_business_rule_id",
+        "source_trigger_id",
+        "applies_to_element_ids",
+        "blocking_for_downstream",
+        "resolution_status",
+        "priority",
+        "status",
+        "complexity",
+        "constraint_kind",
+        "ambiguity_type",
+        "from_state",
+        "to_state",
+        "trigger",
+        "state_entity_id",
+        "source_entity_id",
+        "target_entity_id",
+        "source_component_id",
+        "target_component_id",
+        "component_kind",
+        "interaction_verb",
+        "runtime_environment",
+        "boundary_type",
+    )
+    return {
+        key: item[key]
+        for key in attribute_keys
+        if key in item and item.get(key) not in ("", [], {}, None)
+    }
+
+
+def _export_element(item: dict[str, Any], family: str) -> dict[str, Any]:
+    """Convert one canonical element into the planning export shape."""
+    readiness = item.get("readiness", {})
+    trace = item.get("trace", {})
+    return {
+        "id": item.get("id", ""),
+        "semantic_id": item.get("semantic_id", item.get("id", "")),
+        "family": family,
+        "name": _pick_first_name(item),
+        "text": _pick_first_text(item),
+        "content_semantics": item.get("content_semantics", ""),
+        "readiness_status": readiness.get("status", ""),
+        "normative_ready": readiness.get("normative_ready", False),
+        "missing_fields": list(readiness.get("missing_fields", [])),
+        "blocking_ambiguity_ids": list(readiness.get("blocking_ambiguity_ids", [])),
+        "source_round": trace.get("source_round", ""),
+        "source_key": trace.get("source_key", ""),
+        "change_metadata": item.get("change_metadata", {}),
+        "attributes": _export_attributes(item),
+    }
+
+
+def _export_trace_link(link: dict[str, Any], family: str) -> dict[str, Any]:
+    """Convert one canonical trace link into the planning export shape."""
+    return {
+        "id": link.get("id", ""),
+        "semantic_id": link.get("semantic_id", link.get("id", "")),
+        "family": family,
+        "from_id": link.get("from_id", ""),
+        "to_id": link.get("to_id", ""),
+        "to_artifact": link.get("to_artifact", ""),
+        "artifact_section": link.get("artifact_section", ""),
+        "link_type": link.get("link_type", ""),
+        "basis": link.get("basis", ""),
+        "change_metadata": link.get("change_metadata", {}),
+    }
+
+
+def build_planning_export(model: dict[str, Any]) -> dict[str, Any]:
+    """Build the strict downstream planning export consumed by Speckify."""
+    elements = []
+    for family, path in ELEMENT_FAMILY_SPECS:
+        elements.extend(_export_element(item, family) for item in _get_nested(model, path))
+    elements.sort(key=lambda item: (item["family"], item["semantic_id"], item["id"]))
+
+    trace_links = []
+    for family, links in sorted(model.get("traceability", {}).items()):
+        if not isinstance(links, list):
+            continue
+        trace_links.extend(_export_trace_link(link, family) for link in links)
+    trace_links.sort(key=lambda item: (item["family"], item["semantic_id"], item["id"]))
+
+    ready_normative_elements = [
+        item
+        for item in elements
+        if item["content_semantics"] == "normative" and item["readiness_status"] == "ready"
+    ]
+    blocking_ambiguities = [
+        item
+        for item in elements
+        if item["family"] == "ambiguities" and item["attributes"].get("blocking_for_downstream")
+    ]
+
+    return {
+        "export_metadata": {
+            "schema_version": 1,
+            "export_kind": "speckify_planning_export",
+            "source_model_semantic_id": model.get("model_metadata", {}).get("semantic_id", ""),
+            "source_model_change_metadata": model.get("model_metadata", {}).get("change_metadata", {}),
+        },
+        "summary": {
+            "element_count": len(elements),
+            "trace_link_count": len(trace_links),
+            "ready_normative_count": len(ready_normative_elements),
+            "blocking_ambiguity_count": len(blocking_ambiguities),
+            "ready_normative_ids": [item["id"] for item in ready_normative_elements],
+            "partial_or_blocked_normative_ids": [
+                item["id"]
+                for item in elements
+                if item["content_semantics"] == "normative" and item["readiness_status"] != "ready"
+            ],
+            "blocking_ambiguity_ids": [item["id"] for item in blocking_ambiguities],
+        },
+        "elements": elements,
+        "ready_normative_elements": ready_normative_elements,
+        "blocking_ambiguities": blocking_ambiguities,
+        "trace_links": trace_links,
+    }

--- a/src/rupify_tools/planning_export_cli.py
+++ b/src/rupify_tools/planning_export_cli.py
@@ -1,0 +1,31 @@
+"""CLI for writing the machine-oriented downstream planning export."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from .planning_export import build_planning_export
+from .structured_io import load_model, write_text
+
+
+def main() -> int:
+    """Generate the downstream planning export from a normalized Rupify model."""
+    parser = argparse.ArgumentParser(
+        description="Build the machine-oriented downstream planning export for Speckify."
+    )
+    parser.add_argument("--model", required=True, help="Path to the normalized Rupify model JSON/YAML.")
+    parser.add_argument("--output", required=True, help="Path where the export JSON should be written.")
+    args = parser.parse_args()
+
+    model = load_model(args.model)
+    export = build_planning_export(model)
+    output_path = Path(args.output)
+    write_text(output_path, json.dumps(export, indent=2, sort_keys=True))
+    print(output_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_planning_export.py
+++ b/tests/test_planning_export.py
@@ -1,0 +1,261 @@
+"""Tests for the machine-oriented downstream planning export."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+from rupify_tools.planning_export import build_planning_export
+from tests.test_ucp import build_model
+
+
+class PlanningExportTests(unittest.TestCase):
+    """Coverage for the Speckify planning export contract."""
+
+    def test_build_planning_export_flattens_ready_normative_elements_and_trace_links(self) -> None:
+        """The export should flatten canonical elements and trace links into a strict contract."""
+        model = build_model()
+        model["model_metadata"] = {
+            "semantic_id": "rupify-model",
+            "change_metadata": {"semantic_hash": "abc123"},
+        }
+        model["requirements"] = {
+            "functional_objects": [
+                {
+                    "id": "functional-requirement-1",
+                    "semantic_id": "functional-requirement-1",
+                    "statement": "Approve system changes",
+                    "content_semantics": "normative",
+                    "readiness": {
+                        "status": "ready",
+                        "normative_ready": True,
+                        "missing_fields": [],
+                        "blocking_ambiguity_ids": [],
+                    },
+                    "change_metadata": {"semantic_hash": "reqhash"},
+                    "trace": {"source_round": 4, "source_key": "workflow_scope"},
+                }
+            ],
+            "non_functional_objects": [],
+            "acceptance_constraint_objects": [
+                {
+                    "id": "acceptance-constraint-1",
+                    "semantic_id": "acceptance-constraint-1",
+                    "description": "SSO is required",
+                    "content_semantics": "normative",
+                    "readiness": {
+                        "status": "partial",
+                        "normative_ready": False,
+                        "missing_fields": [],
+                        "blocking_ambiguity_ids": ["ambiguity-open-question-1"],
+                    },
+                    "change_metadata": {"semantic_hash": "constrainthash"},
+                    "trace": {"source_round": 2, "source_key": "constraints"},
+                    "constraint_kind": "non_functional_requirement",
+                    "source_requirement_id": "functional-requirement-1",
+                    "linked_use_case_ids": ["uc-redeem"],
+                }
+            ],
+        }
+        model["analysis_view"] = {
+            "use_cases": [
+                {
+                    "id": "uc-redeem",
+                    "semantic_id": "uc-redeem",
+                    "name": "Redeem Reward",
+                    "goal": "Redeem a reward.",
+                    "content_semantics": "normative",
+                    "readiness": {
+                        "status": "ready",
+                        "normative_ready": True,
+                        "missing_fields": [],
+                        "blocking_ambiguity_ids": [],
+                    },
+                    "change_metadata": {"semantic_hash": "uchash"},
+                    "trace": {"source_round": 3, "source_key": "use_cases"},
+                    "main_success_scenario": ["Customer selects reward."],
+                }
+            ],
+            "use_case_step_objects": [
+                {
+                    "id": "uc-redeem-step-1",
+                    "semantic_id": "uc-redeem-step-1",
+                    "text": "Customer selects reward.",
+                    "content_semantics": "normative",
+                    "readiness": {
+                        "status": "ready",
+                        "normative_ready": True,
+                        "missing_fields": [],
+                        "blocking_ambiguity_ids": [],
+                    },
+                    "change_metadata": {"semantic_hash": "stephash"},
+                    "trace": {"source_round": 13, "source_key": "use_case_details"},
+                }
+            ],
+            "scenario_objects": [],
+            "ambiguity_objects": [
+                {
+                    "id": "ambiguity-open-question-1",
+                    "semantic_id": "ambiguity-open-question-1",
+                    "description": "Should archived systems need approval?",
+                    "content_semantics": "informative",
+                    "readiness": {
+                        "status": "ready",
+                        "normative_ready": False,
+                        "missing_fields": [],
+                        "blocking_ambiguity_ids": [],
+                    },
+                    "change_metadata": {"semantic_hash": "ambhash"},
+                    "trace": {},
+                    "ambiguity_type": "open_question",
+                    "resolution_status": "open",
+                    "blocking_for_downstream": True,
+                    "applies_to_element_ids": ["uc-redeem"],
+                }
+            ],
+            "risk_objects": [],
+            "actors": [],
+        }
+        model["logical_view"] = {
+            "domain_entity_objects": [],
+            "relationship_objects": [],
+            "business_rule_objects": [],
+            "domain_invariant_objects": [],
+        }
+        model["process_view"] = {
+            "state_entity_objects": [],
+            "state_transition_objects": [],
+            "trigger_objects": [],
+            "state_invariant_objects": [],
+            "guard_condition_objects": [],
+            "forbidden_transition_objects": [],
+        }
+        model["architecture_view"] = {
+            "component_objects": [],
+            "interface_objects": [],
+            "runtime_boundary_objects": [],
+        }
+        model["traceability"] = {
+            "requirement_to_use_case": [
+                {
+                    "id": "trace-req-uc-1",
+                    "semantic_id": "trace-req-uc-1",
+                    "from_id": "functional-requirement-1",
+                    "to_id": "uc-redeem",
+                    "link_type": "requirement_to_use_case",
+                    "basis": "requirement statement references use-case name",
+                    "change_metadata": {"semantic_hash": "tracehash"},
+                }
+            ],
+            "ambiguity_to_element": [
+                {
+                    "id": "trace-ambiguity-element-1",
+                    "semantic_id": "trace-ambiguity-element-1",
+                    "from_id": "ambiguity-open-question-1",
+                    "to_id": "uc-redeem",
+                    "link_type": "ambiguity_to_element",
+                    "basis": "ambiguity text explicitly references canonical element",
+                    "change_metadata": {"semantic_hash": "ambtracehash"},
+                }
+            ],
+        }
+
+        export = build_planning_export(model)
+
+        self.assertEqual(export["export_metadata"]["export_kind"], "speckify_planning_export")
+        self.assertEqual(
+            export["summary"]["ready_normative_ids"],
+            ["functional-requirement-1", "uc-redeem-step-1", "uc-redeem"],
+        )
+        self.assertEqual(export["summary"]["blocking_ambiguity_ids"], ["ambiguity-open-question-1"])
+        self.assertEqual(
+            next(item for item in export["elements"] if item["id"] == "ambiguity-open-question-1")[
+                "change_metadata"
+            ],
+            {"semantic_hash": "ambhash"},
+        )
+        self.assertIn("acceptance-constraint-1", export["summary"]["partial_or_blocked_normative_ids"])
+        self.assertTrue(any(item["family"] == "use_cases" for item in export["ready_normative_elements"]))
+        self.assertTrue(any(link["family"] == "ambiguity_to_element" for link in export["trace_links"]))
+        self.assertEqual(
+            next(item for item in export["elements"] if item["id"] == "acceptance-constraint-1")["attributes"]["linked_use_case_ids"],
+            ["uc-redeem"],
+        )
+
+    def test_cli_writes_planning_export_json(self) -> None:
+        """The planning export CLI should load a model file and write JSON output."""
+        repo_root = Path(__file__).resolve().parents[1]
+        with tempfile.TemporaryDirectory() as temp_dir:
+            model_path = Path(temp_dir) / "model.json"
+            output_path = Path(temp_dir) / "planning-export.json"
+            model_path.write_text(
+                json.dumps(
+                    {
+                        "model_metadata": {"semantic_id": "rupify-model", "change_metadata": {}},
+                        "requirements": {
+                            "functional_objects": [],
+                            "non_functional_objects": [],
+                            "acceptance_constraint_objects": [],
+                        },
+                        "analysis_view": {
+                            "actors": [],
+                            "use_cases": [],
+                            "use_case_step_objects": [],
+                            "scenario_objects": [],
+                            "ambiguity_objects": [],
+                            "risk_objects": [],
+                        },
+                        "logical_view": {
+                            "domain_entity_objects": [],
+                            "relationship_objects": [],
+                            "business_rule_objects": [],
+                            "domain_invariant_objects": [],
+                        },
+                        "process_view": {
+                            "state_entity_objects": [],
+                            "state_transition_objects": [],
+                            "trigger_objects": [],
+                            "state_invariant_objects": [],
+                            "guard_condition_objects": [],
+                            "forbidden_transition_objects": [],
+                        },
+                        "architecture_view": {
+                            "component_objects": [],
+                            "interface_objects": [],
+                            "runtime_boundary_objects": [],
+                        },
+                        "traceability": {},
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            completed = subprocess.run(
+                [
+                    "uv",
+                    "run",
+                    "python",
+                    "-m",
+                    "rupify_tools.planning_export_cli",
+                    "--model",
+                    str(model_path),
+                    "--output",
+                    str(output_path),
+                ],
+                text=True,
+                capture_output=True,
+                check=True,
+                cwd=repo_root,
+            )
+
+            payload = json.loads(output_path.read_text(encoding="utf-8"))
+            self.assertEqual(payload["export_metadata"]["export_kind"], "speckify_planning_export")
+            self.assertEqual(payload["summary"]["element_count"], 0)
+            self.assertIn(str(output_path), completed.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a dedicated machine-oriented planning export that flattens canonical elements, trace links, ready normative elements, and blocking ambiguities
- ship the export as code and CLI via planning_export.py and rupify-export-planning
- document the Speckify contract and add export/CLI regression coverage

## Testing
- uv run python -m unittest tests.test_planning_export tests.test_interview tests.test_discovery tests.test_render tests.test_readiness
- uv run python -m unittest

Closes #140