### PR TITLE
Add Speckify feedback contract

### DIFF
--- a/docs/end-to-end-usage.md
+++ b/docs/end-to-end-usage.md
@@ -74,6 +74,14 @@ uv run rupify-export-planning \
   --output /tmp/rupify-planning-export.json
 ```
 
+### Normalize Downstream Feedback
+
+```bash
+uv run rupify-normalize-feedback \
+  --input tests/fixtures/speckify_feedback_example.json \
+  --output /tmp/rupify-feedback.json
+```
+
 ### Mermaid Outputs
 
 ```bash

--- a/docs/speckify-feedback-format.md
+++ b/docs/speckify-feedback-format.md
@@ -1,0 +1,82 @@
+# Speckify Feedback Format
+
+Rupify now defines a structured round-trip feedback artifact for downstream corrections discovered
+during decomposition or implementation.
+
+## Purpose
+
+The feedback artifact is proposal-only. It does not rewrite the Rupify model directly.
+
+It exists so Speckify can:
+
+- point back to upstream `semantic_id` values and known change hashes
+- describe what downstream work discovered
+- propose an upstream correction in a machine-readable form
+- keep reversibility auditable instead of relying on prose comments
+
+## CLI
+
+```bash
+uv run rupify-normalize-feedback \
+  --input tests/fixtures/speckify_feedback_example.json \
+  --output /tmp/rupify-feedback.json
+```
+
+## Feedback Shape
+
+- `feedback_metadata`
+  - `schema_version`
+  - `feedback_kind`
+  - `source_model_semantic_id`
+  - `source_model_change_hash`
+  - `source_planning_export_semantic_id`
+  - `source_planning_export_change_hash`
+  - `emitted_by`
+  - `emitted_at`
+  - `proposal_only`
+- `summary`
+  - `feedback_item_count`
+  - `blocking_item_count`
+  - `categories`
+  - `target_semantic_ids`
+- `feedback_items`
+  - flat proposal items with:
+    - `id`
+    - `category`
+    - `title`
+    - `description`
+    - `target_semantic_ids`
+    - `target_change_hashes`
+    - `target_families`
+    - `proposal_status`
+    - `blocking_for_downstream`
+    - `priority`
+    - `encountered_in`
+    - `downstream_evidence`
+    - `related_element_ids`
+    - `related_trace_link_ids`
+    - `proposed_changes`
+      - `operation`
+      - `field_path`
+      - `value`
+      - `rationale`
+    - `requested_action`
+    - `notes`
+
+## Supported Categories
+
+- `clarify`
+- `split`
+- `merge`
+- `revise_invariant`
+- `revise_transition`
+- `add_missing_requirement`
+- `contradiction_detected`
+
+## Contract Guidance
+
+- Speckify should emit feedback items as proposals, never direct model rewrites.
+- `target_semantic_ids` should reference upstream semantic ids from the planning export or model.
+- `target_change_hashes` should be included when downstream work depends on a specific upstream version.
+- `blocking_for_downstream` should be set only when the issue materially prevents safe decomposition.
+- `proposed_changes` should describe the suggested correction, not an automatic patch to apply.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ rupify-interview-to-formal = "rupify_tools.interview_to_formal_cli:main"
 rupify-ucp = "rupify_tools.ucp_cli:main"
 rupify-render = "rupify_tools.render_cli:main"
 rupify-export-planning = "rupify_tools.planning_export_cli:main"
+rupify-normalize-feedback = "rupify_tools.feedback_format_cli:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/src/rupify_tools/feedback_format.py
+++ b/src/rupify_tools/feedback_format.py
@@ -1,0 +1,157 @@
+"""Structured round-trip feedback contract for downstream corrections."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+VALID_FEEDBACK_CATEGORIES = {
+    "clarify",
+    "split",
+    "merge",
+    "revise_invariant",
+    "revise_transition",
+    "add_missing_requirement",
+    "contradiction_detected",
+}
+
+VALID_PROPOSAL_STATUSES = {"proposed", "accepted", "rejected", "superseded"}
+
+
+def _normalized_string_list(value: Any) -> list[str]:
+    """Return a normalized list of non-empty strings."""
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(item).strip() for item in value if str(item).strip()]
+    text = str(value).strip()
+    return [text] if text else []
+
+
+def _normalize_proposed_changes(items: Any) -> list[dict[str, str]]:
+    """Return normalized proposed change operations."""
+    if items is None:
+        return []
+    normalized_items = items if isinstance(items, list) else [items]
+    results = []
+    for item in normalized_items:
+        if not isinstance(item, dict):
+            raise TypeError("Proposed changes must be mappings.")
+        operation = str(item.get("operation", "")).strip() or "revise"
+        field_path = str(item.get("field_path", "")).strip()
+        value = str(item.get("value", "")).strip()
+        rationale = str(item.get("rationale", "")).strip()
+        if not field_path:
+            raise ValueError("Proposed changes must include a non-empty field_path.")
+        results.append(
+            {
+                "operation": operation,
+                "field_path": field_path,
+                "value": value,
+                "rationale": rationale,
+            }
+        )
+    return results
+
+
+def _normalize_feedback_item(item: dict[str, Any], index: int) -> dict[str, Any]:
+    """Normalize one feedback proposal item."""
+    category = str(item.get("category", "")).strip()
+    if category not in VALID_FEEDBACK_CATEGORIES:
+        raise ValueError(f"Unsupported feedback category: {category or '<empty>'}")
+
+    title = str(item.get("title", "")).strip()
+    description = str(item.get("description", "")).strip()
+    if not title:
+        raise ValueError("Feedback items must include a non-empty title.")
+    if not description:
+        raise ValueError("Feedback items must include a non-empty description.")
+
+    target_semantic_ids = _normalized_string_list(item.get("target_semantic_ids"))
+    if not target_semantic_ids:
+        raise ValueError("Feedback items must include at least one target semantic id.")
+
+    proposal_status = str(item.get("proposal_status", "")).strip() or "proposed"
+    if proposal_status not in VALID_PROPOSAL_STATUSES:
+        raise ValueError(f"Unsupported proposal status: {proposal_status}")
+
+    return {
+        "id": str(item.get("id", "")).strip() or f"feedback-{category}-{index}",
+        "category": category,
+        "title": title,
+        "description": description,
+        "target_semantic_ids": target_semantic_ids,
+        "target_change_hashes": _normalized_string_list(item.get("target_change_hashes")),
+        "target_families": _normalized_string_list(item.get("target_families")),
+        "proposal_status": proposal_status,
+        "blocking_for_downstream": bool(item.get("blocking_for_downstream", False)),
+        "priority": str(item.get("priority", "")).strip(),
+        "encountered_in": str(item.get("encountered_in", "")).strip(),
+        "downstream_evidence": _normalized_string_list(item.get("downstream_evidence")),
+        "related_element_ids": _normalized_string_list(item.get("related_element_ids")),
+        "related_trace_link_ids": _normalized_string_list(item.get("related_trace_link_ids")),
+        "proposed_changes": _normalize_proposed_changes(item.get("proposed_changes")),
+        "requested_action": str(item.get("requested_action", "")).strip(),
+        "notes": str(item.get("notes", "")).strip(),
+    }
+
+
+def normalize_feedback_artifact(payload: dict[str, Any]) -> dict[str, Any]:
+    """Normalize a downstream feedback payload into the strict feedback contract."""
+    if not isinstance(payload, dict):
+        raise TypeError("Feedback payload must be a mapping.")
+
+    metadata = payload.get("feedback_metadata", {})
+    if metadata and not isinstance(metadata, dict):
+        raise TypeError("feedback_metadata must be a mapping when provided.")
+
+    source_planning_export = payload.get("source_planning_export", {})
+    if source_planning_export and not isinstance(source_planning_export, dict):
+        raise TypeError("source_planning_export must be a mapping when provided.")
+
+    raw_items = payload.get("feedback_items", [])
+    if not isinstance(raw_items, list):
+        raise TypeError("feedback_items must be a list.")
+
+    feedback_items = [
+        _normalize_feedback_item(item, index)
+        for index, item in enumerate(raw_items, 1)
+    ]
+    feedback_items.sort(key=lambda item: (item["category"], item["id"]))
+
+    category_counts: dict[str, int] = {}
+    for item in feedback_items:
+        category_counts[item["category"]] = category_counts.get(item["category"], 0) + 1
+
+    return {
+        "feedback_metadata": {
+            "schema_version": 1,
+            "feedback_kind": "speckify_feedback",
+            "source_model_semantic_id": str(metadata.get("source_model_semantic_id", "")).strip(),
+            "source_model_change_hash": str(metadata.get("source_model_change_hash", "")).strip(),
+            "source_planning_export_semantic_id": str(
+                source_planning_export.get("source_planning_export_semantic_id", "")
+                or metadata.get("source_planning_export_semantic_id", "")
+            ).strip(),
+            "source_planning_export_change_hash": str(
+                source_planning_export.get("source_planning_export_change_hash", "")
+                or metadata.get("source_planning_export_change_hash", "")
+            ).strip(),
+            "emitted_by": str(metadata.get("emitted_by", "")).strip(),
+            "emitted_at": str(metadata.get("emitted_at", "")).strip(),
+            "proposal_only": True,
+        },
+        "summary": {
+            "feedback_item_count": len(feedback_items),
+            "blocking_item_count": sum(1 for item in feedback_items if item["blocking_for_downstream"]),
+            "categories": category_counts,
+            "target_semantic_ids": sorted(
+                {
+                    semantic_id
+                    for item in feedback_items
+                    for semantic_id in item["target_semantic_ids"]
+                }
+            ),
+        },
+        "feedback_items": feedback_items,
+    }

--- a/src/rupify_tools/feedback_format_cli.py
+++ b/src/rupify_tools/feedback_format_cli.py
@@ -1,0 +1,31 @@
+"""CLI for normalizing the structured downstream feedback artifact."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from .feedback_format import normalize_feedback_artifact
+from .structured_io import load_model, write_text
+
+
+def main() -> int:
+    """Normalize a Speckify feedback payload into the strict feedback contract."""
+    parser = argparse.ArgumentParser(
+        description="Normalize the structured round-trip feedback format for downstream corrections."
+    )
+    parser.add_argument("--input", required=True, help="Path to the raw feedback JSON/YAML file.")
+    parser.add_argument("--output", required=True, help="Path where the normalized feedback JSON should be written.")
+    args = parser.parse_args()
+
+    payload = load_model(args.input)
+    normalized = normalize_feedback_artifact(payload)
+    output_path = Path(args.output)
+    write_text(output_path, json.dumps(normalized, indent=2, sort_keys=True))
+    print(output_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/speckify_feedback_example.json
+++ b/tests/fixtures/speckify_feedback_example.json
@@ -1,0 +1,63 @@
+{
+  "feedback_metadata": {
+    "source_model_semantic_id": "rupify-model",
+    "source_model_change_hash": "modelhash123",
+    "source_planning_export_semantic_id": "rupify-model",
+    "source_planning_export_change_hash": "exporthash123",
+    "emitted_by": "speckify",
+    "emitted_at": "2026-04-20T10:15:00Z"
+  },
+  "feedback_items": [
+    {
+      "category": "clarify",
+      "title": "Clarify owner validation rule",
+      "description": "Downstream decomposition could not tell whether temporary owners satisfy the approval rule.",
+      "target_semantic_ids": ["domain-invariant-1"],
+      "target_change_hashes": ["invarhash123"],
+      "target_families": ["domain_invariants"],
+      "proposal_status": "proposed",
+      "blocking_for_downstream": true,
+      "priority": "high",
+      "encountered_in": "task-decomposition",
+      "downstream_evidence": [
+        "Ownership check split into two incompatible task trees.",
+        "Implementation planning could not choose one validation rule."
+      ],
+      "related_element_ids": ["uc-approve-system"],
+      "related_trace_link_ids": ["trace-domain-invariant-entity-1"],
+      "proposed_changes": [
+        {
+          "operation": "revise",
+          "field_path": "logical_view.domain_invariant_objects[0].description",
+          "value": "A system must have a permanent owner before approval.",
+          "rationale": "This removes the temporary-owner ambiguity discovered downstream."
+        }
+      ],
+      "requested_action": "Clarify whether temporary ownership satisfies approval.",
+      "notes": "Proposal only; do not patch the canonical model automatically."
+    },
+    {
+      "category": "add_missing_requirement",
+      "title": "Missing export audit requirement",
+      "description": "Downstream implementation planning found no explicit requirement for export audit logging.",
+      "target_semantic_ids": ["component-export-service"],
+      "target_change_hashes": ["componenthash123"],
+      "target_families": ["components"],
+      "blocking_for_downstream": false,
+      "encountered_in": "implementation-planning",
+      "downstream_evidence": [
+        "No requirement linked to the export audit tasks."
+      ],
+      "proposed_changes": [
+        {
+          "operation": "add",
+          "field_path": "requirements.functional_objects",
+          "value": "Export actions must create an immutable audit log entry.",
+          "rationale": "Implementation scope already assumes this behavior."
+        }
+      ],
+      "requested_action": "Add the missing requirement upstream.",
+      "notes": ""
+    }
+  ]
+}

--- a/tests/test_feedback_format.py
+++ b/tests/test_feedback_format.py
@@ -1,0 +1,113 @@
+"""Tests for the structured round-trip feedback contract."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+from rupify_tools.feedback_format import normalize_feedback_artifact
+
+
+class FeedbackFormatTests(unittest.TestCase):
+    """Coverage for the downstream feedback artifact contract."""
+
+    def test_normalize_feedback_artifact_preserves_upstream_links_and_proposals(self) -> None:
+        """Normalization should preserve upstream semantic ids, hashes, and proposal structure."""
+        payload = {
+            "feedback_metadata": {
+                "source_model_semantic_id": "rupify-model",
+                "source_model_change_hash": "modelhash123",
+                "source_planning_export_semantic_id": "rupify-model",
+                "source_planning_export_change_hash": "exporthash123",
+                "emitted_by": "speckify",
+                "emitted_at": "2026-04-20T10:15:00Z",
+            },
+            "feedback_items": [
+                {
+                    "category": "clarify",
+                    "title": "Clarify owner validation rule",
+                    "description": "Temporary owner handling is ambiguous downstream.",
+                    "target_semantic_ids": ["domain-invariant-1"],
+                    "target_change_hashes": ["invarhash123"],
+                    "target_families": ["domain_invariants"],
+                    "blocking_for_downstream": True,
+                    "downstream_evidence": ["Task graph diverged on owner validation."],
+                    "proposed_changes": [
+                        {
+                            "field_path": "logical_view.domain_invariant_objects[0].description",
+                            "value": "A system must have a permanent owner before approval.",
+                            "rationale": "Downstream planning needs one rule.",
+                        }
+                    ],
+                    "requested_action": "Clarify the invariant upstream.",
+                }
+            ],
+        }
+
+        normalized = normalize_feedback_artifact(payload)
+
+        self.assertEqual(normalized["feedback_metadata"]["feedback_kind"], "speckify_feedback")
+        self.assertEqual(normalized["feedback_metadata"]["proposal_only"], True)
+        self.assertEqual(normalized["summary"]["blocking_item_count"], 1)
+        self.assertEqual(normalized["summary"]["categories"], {"clarify": 1})
+        self.assertEqual(normalized["summary"]["target_semantic_ids"], ["domain-invariant-1"])
+        self.assertEqual(normalized["feedback_items"][0]["target_change_hashes"], ["invarhash123"])
+        self.assertEqual(normalized["feedback_items"][0]["proposal_status"], "proposed")
+        self.assertEqual(
+            normalized["feedback_items"][0]["proposed_changes"][0]["operation"],
+            "revise",
+        )
+
+    def test_normalize_feedback_artifact_rejects_unknown_category(self) -> None:
+        """Unsupported categories should fail clearly instead of degrading silently."""
+        with self.assertRaisesRegex(ValueError, "Unsupported feedback category"):
+            normalize_feedback_artifact(
+                {
+                    "feedback_items": [
+                        {
+                            "category": "invent_new_category",
+                            "title": "Bad category",
+                            "description": "Unsupported.",
+                            "target_semantic_ids": ["uc-redeem"],
+                        }
+                    ]
+                }
+            )
+
+    def test_cli_writes_normalized_feedback_json(self) -> None:
+        """The feedback CLI should normalize a fixture and write JSON output."""
+        repo_root = Path(__file__).resolve().parents[1]
+        fixture_path = repo_root / "tests" / "fixtures" / "speckify_feedback_example.json"
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = Path(temp_dir) / "normalized-feedback.json"
+            completed = subprocess.run(
+                [
+                    "uv",
+                    "run",
+                    "python",
+                    "-m",
+                    "rupify_tools.feedback_format_cli",
+                    "--input",
+                    str(fixture_path),
+                    "--output",
+                    str(output_path),
+                ],
+                text=True,
+                capture_output=True,
+                check=True,
+                cwd=repo_root,
+            )
+
+            payload = json.loads(output_path.read_text(encoding="utf-8"))
+            self.assertEqual(payload["feedback_metadata"]["feedback_kind"], "speckify_feedback")
+            self.assertEqual(payload["summary"]["feedback_item_count"], 2)
+            self.assertEqual(payload["summary"]["blocking_item_count"], 1)
+            self.assertIn("domain-invariant-1", payload["summary"]["target_semantic_ids"])
+            self.assertIn(str(output_path), completed.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a strict proposal-only round-trip feedback artifact for downstream corrections, linked back to upstream semantic ids and change hashes
- ship the contract as code and CLI via feedback_format.py and rupify-normalize-feedback
- document the feedback format and add fixture-backed regression coverage for the normalizer and CLI

## Testing
- uv run python -m unittest tests.test_feedback_format tests.test_planning_export tests.test_interview tests.test_readiness
- uv run python -m unittest

Closes #136