### PR TITLE
Add specification publication bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Current first-class outputs include:
 - `state-model.md`
 - `ucp-estimate.md`
 - Mermaid diagram bundles for domain, interaction, deployment, and state views
+- stable publication bundles for packaging model, artifacts, and downstream exports together
 
 The repository is documentation-first and dogfood-oriented. The current open-source goal is to make
 Rupify usable as a model-driven specification system with a clear end-to-end skill and CLI
@@ -32,6 +33,7 @@ Rupify currently provides:
   documents
 - Mermaid outputs for domain, interaction, deployment, and state publication
 - readiness, staleness, provenance, and cross-view traceability in the model workflow
+- a stable publication bundle layout for intentional specification handoff and packaging
 
 The remaining roadmap is now productization and workflow expansion:
 
@@ -114,6 +116,7 @@ uv run rupify-interview-replay --help
 uv run rupify-interview-to-formal --help
 uv run rupify-ucp --help
 uv run rupify-render --help
+uv run rupify-publish-bundle --help
 ```
 
 Common commands:
@@ -127,6 +130,7 @@ uv run python -m rupify_tools.render_cli --model examples/it-systems-inventory/r
 uv run python -m rupify_tools.render_cli --model examples/it-systems-inventory/rupify-model.json --output-dir /tmp/rupify-mermaid-state --artifact-family state-mermaid
 uv run python -m rupify_tools.render_cli --model examples/it-systems-inventory/rupify-model.json --output-dir /tmp/rupify-mermaid-interaction --artifact-family interaction-mermaid
 uv run python -m rupify_tools.render_cli --model examples/it-systems-inventory/rupify-model.json --output-dir /tmp/rupify-mermaid-deployment --artifact-family deployment-mermaid
+uv run rupify-publish-bundle --model examples/it-systems-inventory/rupify-model.json --output-dir /tmp/rupify-publication-bundle --archive /tmp/rupify-publication-bundle.zip
 uv run rupify-interview-to-formal --input tests/fixtures/it_systems_inventory_session.json --output-dir /tmp/rupify-from-interview --write-model /tmp/rupify-from-interview/rupify-model.json
 ```
 

--- a/docs/end-to-end-usage.md
+++ b/docs/end-to-end-usage.md
@@ -5,6 +5,7 @@ This document explains the supported end-to-end ways to use Rupify today.
 ## Choose The Right Command
 
 - `rupify-render`: start from a canonical model and generate Markdown or Mermaid artifacts
+- `rupify-publish-bundle`: start from a canonical model and package a stable publication bundle
 - `rupify-ucp`: start from a canonical model and calculate only the UCP estimate
 - `rupify-interview-to-formal`: start from an interview fixture and generate the normalized model plus the formal Markdown bundle
 - `rupify-interview-replay`: start from an interview fixture and inspect replay, readiness, staleness, and trace validation
@@ -23,6 +24,7 @@ Everything else hangs off that:
 - formal Markdown artifacts render from the canonical model
 - Mermaid diagrams render from the canonical model
 - UCP estimation renders from the canonical model
+- publication bundles package model-backed outputs from the canonical model
 
 Do not treat raw interview text, copied Markdown, or Mermaid files as the primary editing surface.
 
@@ -73,6 +75,24 @@ uv run rupify-export-planning \
   --model examples/it-systems-inventory/rupify-model.json \
   --output /tmp/rupify-planning-export.json
 ```
+
+### Publication Bundle
+
+```bash
+uv run rupify-publish-bundle \
+  --model examples/it-systems-inventory/rupify-model.json \
+  --output-dir /tmp/rupify-publication-bundle \
+  --archive /tmp/rupify-publication-bundle.zip
+```
+
+This writes one stable handoff layout containing:
+
+- the canonical model snapshot
+- the formal Markdown bundle
+- the UCP estimate
+- Mermaid publication artifacts
+- the Speckify planning export
+- a root bundle manifest with source-model metadata and stable relative paths
 
 ### Normalize Downstream Feedback
 
@@ -206,3 +226,5 @@ In practice this means:
 - UCP rendering can fail if required estimate inputs are missing
 - YAML input support fails clearly unless the optional dependency is installed
 - incomplete views should remain partial or blocked instead of being silently fabricated
+
+See also: [Specification Publication Bundles](specification-publication-bundles.md)

--- a/docs/github-issue-map.md
+++ b/docs/github-issue-map.md
@@ -109,6 +109,8 @@ See also: [Document Ingestion Future Direction](document-ingestion-future.md)
 - the template-driven document-suite epic extends the canonical model toward concrete appendix-style
   deliverables for system, use-case, and scenario documents
 - the remaining V2 work is now expansion and productization rather than foundational translation
+- the current productization track includes stable publication bundles for packaging model-backed
+  outputs as an intentional handoff surface
 
 ## Labels To Use
 

--- a/docs/specification-publication-bundles.md
+++ b/docs/specification-publication-bundles.md
@@ -1,0 +1,82 @@
+# Specification Publication Bundles
+
+This document defines the stable publication layout for sharing a complete Rupify specification.
+
+## Purpose
+
+Use a publication bundle when you want one intentional handoff surface instead of a loose
+collection of model files, rendered Markdown, and ad hoc downstream exports.
+
+The canonical model remains the source of truth. The publication bundle is a generated package
+that snapshots that model together with the derived outputs that are safe to publish or hand off.
+
+## Bundle Layout
+
+The current stable layout is:
+
+```text
+bundle-manifest.json
+model/
+  rupify-model.json
+artifacts/
+  formal/
+    system-document.md
+    requirements-spec.md
+    use-case-model.md
+    use-case-documents.md
+    scenario-documents.md
+    domain-model.md
+    interaction-model.md
+    deployment-model.md
+    state-model.md
+  ucp/
+    ucp-estimate.md
+  mermaid/
+    domain-model.mmd
+    interaction-model.mmd
+    deployment-model.mmd
+    state-model.mmd
+exports/
+  speckify-planning-export.json
+```
+
+## Manifest Contract
+
+`bundle-manifest.json` is the root index for the package.
+
+It records:
+
+- the publication bundle schema version
+- the source model semantic id and change metadata
+- the artifact families included in the bundle
+- the stable relative paths for the model, formal artifacts, Mermaid artifacts, and planning export
+- a compact file-count summary
+
+This keeps publication traceable back to the canonical model instead of treating the published
+Markdown bundle as the source of truth.
+
+## Generation
+
+Generate a bundle from any normalized model:
+
+```bash
+uv run rupify-publish-bundle \
+  --model examples/it-systems-inventory/rupify-model.json \
+  --output-dir /tmp/rupify-publication-bundle
+```
+
+If you also want a zip archive for handoff:
+
+```bash
+uv run rupify-publish-bundle \
+  --model examples/it-systems-inventory/rupify-model.json \
+  --output-dir /tmp/rupify-publication-bundle \
+  --archive /tmp/rupify-publication-bundle.zip
+```
+
+## Operational Rules
+
+- do not hand-edit published bundle files as the primary source
+- regenerate the bundle from the canonical model when requirements or design semantics change
+- use the root manifest to locate bundle contents instead of hard-coding ad hoc file paths
+- treat the planning export as the downstream machine contract, not as a replacement for the model

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ rupify-interview-replay = "rupify_tools.interview_replay:main"
 rupify-interview-to-formal = "rupify_tools.interview_to_formal_cli:main"
 rupify-ucp = "rupify_tools.ucp_cli:main"
 rupify-render = "rupify_tools.render_cli:main"
+rupify-publish-bundle = "rupify_tools.publication_bundle_cli:main"
 rupify-export-planning = "rupify_tools.planning_export_cli:main"
 rupify-normalize-feedback = "rupify_tools.feedback_format_cli:main"
 

--- a/src/rupify_tools/publication_bundle.py
+++ b/src/rupify_tools/publication_bundle.py
@@ -1,0 +1,136 @@
+"""Specification publication bundle generation for Rupify."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from zipfile import ZIP_DEFLATED, ZipFile
+
+from .planning_export import build_planning_export
+from .render import render_artifact_family
+from .structured_io import write_text
+
+
+BUNDLE_MANIFEST_FILENAME = "bundle-manifest.json"
+MODEL_OUTPUT_PATH = Path("model") / "rupify-model.json"
+PLANNING_EXPORT_OUTPUT_PATH = Path("exports") / "speckify-planning-export.json"
+FORMAL_OUTPUT_DIR = Path("artifacts") / "formal"
+UCP_OUTPUT_DIR = Path("artifacts") / "ucp"
+MERMAID_OUTPUT_DIR = Path("artifacts") / "mermaid"
+MERMAID_FAMILIES: tuple[str, ...] = (
+    "domain-mermaid",
+    "interaction-mermaid",
+    "deployment-mermaid",
+    "state-mermaid",
+)
+
+
+def _json_text(payload: dict[str, Any]) -> str:
+    """Return stable JSON text for one bundle payload."""
+    return json.dumps(payload, indent=2, sort_keys=True)
+
+
+def _relative_paths(paths: list[Path]) -> list[str]:
+    """Return sorted bundle-relative path strings."""
+    return sorted(str(path).replace("\\", "/") for path in paths)
+
+
+def _artifact_paths_for_family(
+    artifact_family: str,
+    output_dir: Path,
+    model: dict[str, Any],
+) -> dict[Path, str]:
+    """Render one artifact family into bundle-relative paths."""
+    rendered = render_artifact_family(model, artifact_family)
+    return {output_dir / filename: content for filename, content in rendered.items()}
+
+
+def _build_manifest(
+    model: dict[str, Any],
+    bundle_files: dict[Path, str],
+) -> dict[str, Any]:
+    """Build the stable publication bundle manifest."""
+    model_metadata = model.get("model_metadata", {})
+    artifact_paths = [
+        path for path in bundle_files if path.parts and path.parts[0] == "artifacts"
+    ]
+    formal_paths = [
+        path for path in artifact_paths if path.parts[:2] == ("artifacts", "formal")
+    ]
+    mermaid_paths = [
+        path for path in artifact_paths if path.parts[:2] == ("artifacts", "mermaid")
+    ]
+    ucp_paths = [path for path in artifact_paths if path.parts[:2] == ("artifacts", "ucp")]
+
+    return {
+        "bundle_metadata": {
+            "schema_version": 1,
+            "bundle_kind": "rupify_specification_publication_bundle",
+            "source_model_semantic_id": model_metadata.get("semantic_id", ""),
+            "source_model_change_metadata": model_metadata.get("change_metadata", {}),
+            "generated_artifact_families": [
+                "formal",
+                "ucp",
+                *MERMAID_FAMILIES,
+                "speckify-planning-export",
+            ],
+        },
+        "layout": {
+            "model": str(MODEL_OUTPUT_PATH),
+            "formal_artifacts": _relative_paths(formal_paths),
+            "ucp_artifacts": _relative_paths(ucp_paths),
+            "mermaid_artifacts": _relative_paths(mermaid_paths),
+            "planning_export": str(PLANNING_EXPORT_OUTPUT_PATH),
+        },
+        "summary": {
+            "file_count": len(bundle_files) + 1,
+            "formal_artifact_count": len(formal_paths),
+            "ucp_artifact_count": len(ucp_paths),
+            "mermaid_artifact_count": len(mermaid_paths),
+        },
+    }
+
+
+def build_publication_bundle(model: dict[str, Any]) -> dict[Path, str]:
+    """Build the stable publication bundle for one canonical model."""
+    bundle_files: dict[Path, str] = {
+        MODEL_OUTPUT_PATH: _json_text(model),
+        PLANNING_EXPORT_OUTPUT_PATH: _json_text(build_planning_export(model)),
+    }
+    bundle_files.update(_artifact_paths_for_family("formal", FORMAL_OUTPUT_DIR, model))
+    bundle_files.update(_artifact_paths_for_family("ucp", UCP_OUTPUT_DIR, model))
+    for family in MERMAID_FAMILIES:
+        bundle_files.update(_artifact_paths_for_family(family, MERMAID_OUTPUT_DIR, model))
+
+    bundle_files[Path(BUNDLE_MANIFEST_FILENAME)] = _json_text(
+        _build_manifest(model, bundle_files)
+    )
+    return dict(sorted(bundle_files.items(), key=lambda item: str(item[0])))
+
+
+def write_publication_bundle(
+    model: dict[str, Any],
+    output_dir: str | Path,
+) -> list[Path]:
+    """Write the publication bundle to one output directory."""
+    root = Path(output_dir)
+    written_paths = []
+    for relative_path, content in build_publication_bundle(model).items():
+        output_path = root / relative_path
+        write_text(output_path, content)
+        written_paths.append(output_path)
+    return written_paths
+
+
+def create_bundle_archive(output_dir: str | Path, archive_path: str | Path) -> Path:
+    """Create a zip archive from a previously written publication bundle."""
+    root = Path(output_dir)
+    destination = Path(archive_path)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+
+    with ZipFile(destination, "w", compression=ZIP_DEFLATED) as handle:
+        for path in sorted(root.rglob("*")):
+            if path.is_file():
+                handle.write(path, arcname=path.relative_to(root))
+    return destination

--- a/src/rupify_tools/publication_bundle_cli.py
+++ b/src/rupify_tools/publication_bundle_cli.py
@@ -1,0 +1,43 @@
+"""CLI for writing a stable Rupify publication bundle."""
+
+from __future__ import annotations
+
+import argparse
+
+from .publication_bundle import create_bundle_archive, write_publication_bundle
+from .structured_io import load_model
+
+
+def main() -> int:
+    """Build the stable publication bundle from a canonical model."""
+    parser = argparse.ArgumentParser(
+        description="Build a stable publication bundle from a normalized Rupify model."
+    )
+    parser.add_argument(
+        "--model",
+        required=True,
+        help="Path to the normalized Rupify model JSON/YAML.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        required=True,
+        help="Directory where the bundle should be written.",
+    )
+    parser.add_argument(
+        "--archive",
+        help="Optional path where a zip archive of the written bundle should be created.",
+    )
+    args = parser.parse_args()
+
+    model = load_model(args.model)
+    for path in write_publication_bundle(model, args.output_dir):
+        print(path)
+
+    if args.archive:
+        print(create_bundle_archive(args.output_dir, args.archive))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_publication_bundle.py
+++ b/tests/test_publication_bundle.py
@@ -1,0 +1,134 @@
+"""Tests for stable specification publication bundles."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from zipfile import ZipFile
+
+from rupify_tools.publication_bundle import (
+    build_publication_bundle,
+    create_bundle_archive,
+    write_publication_bundle,
+)
+from tests.test_ucp import build_model
+
+
+class PublicationBundleTests(unittest.TestCase):
+    """Coverage for bundle publication and packaging."""
+
+    def test_build_publication_bundle_uses_stable_layout_and_manifest(self) -> None:
+        """The publication bundle should keep a stable layout and root manifest."""
+        model = build_model()
+        model["model_metadata"] = {
+            "semantic_id": "rupify-model",
+            "change_metadata": {"semantic_hash": "abc123", "change_source": "test_fixture"},
+        }
+
+        bundle = build_publication_bundle(model)
+
+        self.assertIn(Path("bundle-manifest.json"), bundle)
+        self.assertIn(Path("model") / "rupify-model.json", bundle)
+        self.assertIn(Path("exports") / "speckify-planning-export.json", bundle)
+        self.assertIn(Path("artifacts") / "formal" / "requirements-spec.md", bundle)
+        self.assertIn(Path("artifacts") / "ucp" / "ucp-estimate.md", bundle)
+        self.assertIn(Path("artifacts") / "mermaid" / "domain-model.mmd", bundle)
+        self.assertIn(Path("artifacts") / "mermaid" / "state-model.mmd", bundle)
+
+        manifest = json.loads(bundle[Path("bundle-manifest.json")])
+        self.assertEqual(
+            manifest["bundle_metadata"]["bundle_kind"],
+            "rupify_specification_publication_bundle",
+        )
+        self.assertEqual(
+            manifest["bundle_metadata"]["source_model_semantic_id"],
+            "rupify-model",
+        )
+        self.assertEqual(
+            manifest["layout"]["planning_export"],
+            "exports/speckify-planning-export.json",
+        )
+        self.assertIn(
+            "artifacts/formal/use-case-documents.md",
+            manifest["layout"]["formal_artifacts"],
+        )
+        self.assertIn(
+            "artifacts/mermaid/interaction-model.mmd",
+            manifest["layout"]["mermaid_artifacts"],
+        )
+        self.assertEqual(manifest["summary"]["ucp_artifact_count"], 1)
+
+    def test_write_publication_bundle_and_archive_create_expected_files(self) -> None:
+        """The writer and archive helper should package the full bundle layout."""
+        model = build_model()
+        model["model_metadata"] = {
+            "semantic_id": "rupify-model",
+            "change_metadata": {"semantic_hash": "abc123"},
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_dir = Path(temp_dir) / "published-spec"
+            archive_path = Path(temp_dir) / "published-spec.zip"
+
+            written_paths = write_publication_bundle(model, output_dir)
+            create_bundle_archive(output_dir, archive_path)
+
+            self.assertTrue((output_dir / "bundle-manifest.json").exists())
+            self.assertTrue((output_dir / "model" / "rupify-model.json").exists())
+            self.assertTrue(
+                (output_dir / "artifacts" / "formal" / "system-document.md").exists()
+            )
+            self.assertTrue(
+                (output_dir / "exports" / "speckify-planning-export.json").exists()
+            )
+            self.assertTrue(archive_path.exists())
+            self.assertEqual(len(written_paths), 17)
+
+            with ZipFile(archive_path) as handle:
+                archive_names = set(handle.namelist())
+
+            self.assertIn("bundle-manifest.json", archive_names)
+            self.assertIn("model/rupify-model.json", archive_names)
+            self.assertIn("artifacts/mermaid/deployment-model.mmd", archive_names)
+
+    def test_cli_writes_bundle_and_optional_archive(self) -> None:
+        """The CLI should write the full publication bundle and optional archive."""
+        repo_root = Path(__file__).resolve().parents[1]
+        with tempfile.TemporaryDirectory() as temp_dir:
+            model_path = Path(temp_dir) / "model.json"
+            output_dir = Path(temp_dir) / "bundle"
+            archive_path = Path(temp_dir) / "bundle.zip"
+            model = build_model()
+            model["model_metadata"] = {
+                "semantic_id": "rupify-model",
+                "change_metadata": {"semantic_hash": "abc123"},
+            }
+            model_path.write_text(json.dumps(model), encoding="utf-8")
+
+            result = subprocess.run(
+                [
+                    "uv",
+                    "run",
+                    "python",
+                    "-m",
+                    "rupify_tools.publication_bundle_cli",
+                    "--model",
+                    str(model_path),
+                    "--output-dir",
+                    str(output_dir),
+                    "--archive",
+                    str(archive_path),
+                ],
+                cwd=repo_root,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertIn(str(output_dir / "bundle-manifest.json"), result.stdout)
+            self.assertIn(str(archive_path), result.stdout)
+            self.assertTrue((output_dir / "artifacts" / "formal" / "domain-model.md").exists())
+            self.assertTrue(archive_path.exists())


### PR DESCRIPTION
## Summary
- add a model-first publication bundle builder and rupify-publish-bundle CLI
- package the canonical model, formal artifacts, UCP output, Mermaid outputs, and Speckify planning export under a stable documented layout
- add bundle tests, publication docs, and README/end-to-end usage updates

Closes #88

## Verification
- uv run python -m unittest tests.test_publication_bundle
- uv run python -m unittest
