### PR TITLE
Add CMDB Speckify export proof bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ improving Rupify:
 
 - [Example Model](examples/it-systems-inventory/rupify-model.yaml)
 - [Example Feedback](examples/it-systems-inventory/rupify-feedback.md)
+- [V2 Publication Bundle](examples/it-systems-inventory-v2/README.md)
 
 ## Current Limitations
 

--- a/docs/dogfooding.md
+++ b/docs/dogfooding.md
@@ -48,9 +48,15 @@ Current dogfooding example:
 
 - `examples/it-systems-inventory/`
 - `examples/it-systems-inventory/rupify-feedback.md`
+- `examples/it-systems-inventory-v2/`
 
 The checked-in IT systems inventory bundle should now demonstrate both layers of the formal output:
 
 - overview artifacts such as `requirements-spec.md`, `use-case-model.md`, and `deployment-model.md`
 - compiled template-driven documents such as `system-document.md`, `use-case-documents.md`, and
   `scenario-documents.md`
+
+The V2 sibling bundle should additionally demonstrate the productization boundary:
+
+- the stable publication-bundle layout
+- the checked-in Speckify planning export generated from the same CMDB interview fixture

--- a/examples/it-systems-inventory-v2/README.md
+++ b/examples/it-systems-inventory-v2/README.md
@@ -1,0 +1,60 @@
+# IT Systems Inventory V2 Bundle
+
+This directory is the V2 checked-in publication bundle for the existing CMDB-style interview
+fixture at [tests/fixtures/it_systems_inventory_session.json](/Volumes/Data/GitHub/Peterbb148/rupify/tests/fixtures/it_systems_inventory_session.json).
+
+It was generated from the current Rupify pipeline rather than assembled by hand:
+
+```bash
+uv run rupify-interview-to-formal \
+  --input tests/fixtures/it_systems_inventory_session.json \
+  --output-dir /tmp/rupify-cmdb-v2-formal \
+  --write-model /tmp/rupify-cmdb-v2-formal/rupify-model.json
+
+uv run rupify-publish-bundle \
+  --model /tmp/rupify-cmdb-v2-formal/rupify-model.json \
+  --output-dir /tmp/rupify-cmdb-v2-bundle
+```
+
+## Purpose
+
+This bundle is the concrete proof for the downstream Speckify integration path under issue `#84`.
+
+It demonstrates that the existing CMDB interview can now be carried all the way through:
+
+- canonical model normalization
+- formal Markdown artifact rendering
+- Mermaid publication artifacts
+- UCP output
+- stable publication bundle packaging
+- Speckify-facing planning export generation
+
+## Speckify Handoff Surface
+
+The primary downstream contract for Speckify is:
+
+- [exports/speckify-planning-export.json](/Volumes/Data/GitHub/Peterbb148/rupify/examples/it-systems-inventory-v2/exports/speckify-planning-export.json)
+
+The root publication index for the full handoff bundle is:
+
+- [bundle-manifest.json](/Volumes/Data/GitHub/Peterbb148/rupify/examples/it-systems-inventory-v2/bundle-manifest.json)
+
+The canonical model snapshot used to generate the bundle is:
+
+- [model/rupify-model.json](/Volumes/Data/GitHub/Peterbb148/rupify/examples/it-systems-inventory-v2/model/rupify-model.json)
+
+## Current Result
+
+This V2 export currently shows:
+
+- a complete publication bundle with 17 files
+- 72 flattened planning elements
+- 127 trace links
+- 29 ready normative elements
+- 0 blocking ambiguities
+
+## Known Limits In This Example
+
+- [artifacts/formal/scenario-documents.md](/Volumes/Data/GitHub/Peterbb148/rupify/examples/it-systems-inventory-v2/artifacts/formal/scenario-documents.md)
+  is still empty because this fixture does not yet carry explicit named scenario objects
+- this proves the Rupify export boundary, not a full Speckify repository-side import workflow

--- a/examples/it-systems-inventory-v2/artifacts/formal/deployment-model.md
+++ b/examples/it-systems-inventory-v2/artifacts/formal/deployment-model.md
@@ -1,0 +1,38 @@
+# Deployment Model
+
+## Project
+
+- Name: A system to manage inventory of IT Systems themselves.
+- Domain: Unspecified
+
+## Scope
+
+All IT systems
+
+## Components
+
+- `component-system-inventory-web-app` System Inventory Web App [source: round 7 components_and_services]
+- `component-system-inventory-api` System Inventory API [source: round 7 components_and_services]
+- `component-reporting-consumers` Reporting Consumers [source: round 7 components_and_services]
+
+
+## Interfaces and Integrations
+
+- `interface-1` System Inventory Web App calls System Inventory API [source: round 7 interfaces_and_integrations]
+- `interface-2` System Inventory API sends Reporting Consumers [source: round 7 interfaces_and_integrations]
+
+
+## Runtime Boundaries
+
+- `runtime-boundary-1` System Inventory API runs separately from the UI [source: round 7 runtime_boundaries]
+
+
+## Artifact Lineage
+
+- `trace-artifact-deployment-model-components-component-system-inventory-web-app` component-system-inventory-web-app -> deployment-model.md#components (canonical components object renders into deployment-model.md)
+- `trace-artifact-deployment-model-components-component-system-inventory-api` component-system-inventory-api -> deployment-model.md#components (canonical components object renders into deployment-model.md)
+- `trace-artifact-deployment-model-components-component-reporting-consumers` component-reporting-consumers -> deployment-model.md#components (canonical components object renders into deployment-model.md)
+- `trace-artifact-deployment-model-interfaces-and-integrations-interface-1` interface-1 -> deployment-model.md#interfaces and integrations (canonical interfaces and integrations object renders into deployment-model.md)
+- `trace-artifact-deployment-model-interfaces-and-integrations-interface-2` interface-2 -> deployment-model.md#interfaces and integrations (canonical interfaces and integrations object renders into deployment-model.md)
+- `trace-artifact-deployment-model-runtime-boundaries-runtime-boundary-1` runtime-boundary-1 -> deployment-model.md#runtime boundaries (canonical runtime boundaries object renders into deployment-model.md)
+

--- a/examples/it-systems-inventory-v2/artifacts/formal/domain-model.md
+++ b/examples/it-systems-inventory-v2/artifacts/formal/domain-model.md
@@ -1,0 +1,83 @@
+# Domain Model
+
+## Project
+
+- Name: A system to manage inventory of IT Systems themselves.
+- Domain: Unspecified
+
+## Scope
+
+All IT systems
+
+## Domain Entities
+
+- `entity-system` System [source: round 5 domain_entities]
+- `entity-risk-assessment` Risk Assessment [source: round 5 domain_entities]
+- `entity-cost-record` Cost Record [source: round 5 domain_entities]
+- `entity-capability` Capability [source: round 5 domain_entities]
+- `entity-contract` Contract [source: round 5 domain_entities]
+- `entity-integration` Integration [source: round 5 domain_entities]
+
+
+## Relationships
+
+- `relationship-1` A System has one Business Owner [source: round 5 relationships]
+- `relationship-2` A System has one Technical Owner [source: round 5 relationships]
+- `relationship-3` A System has many Integrations (multiplicity: 1 -> *; roles: integrations / a_system) [source: round 5 relationships]
+- `relationship-4` A System has many Capabilities (multiplicity: 1 -> *; roles: capabilities / a_system) [source: round 5 relationships]
+- `relationship-5` A System has one Contract [source: round 5 relationships]
+- `relationship-6` A System has many Risk Assessments (multiplicity: 1 -> *; roles: risk_assessments / a_system) [source: round 5 relationships]
+- `relationship-7` A System has many Cost Records (multiplicity: 1 -> *; roles: cost_records / a_system) [source: round 5 relationships]
+
+
+## Business Rules
+
+- `business-rule-1` A System must have a business owner before it becomes Active. [source: round 5 business_rules]
+- `business-rule-2` A System lifecycle state change requires approval for deprecation. [source: round 5 business_rules]
+- `business-rule-3` A System must record vendor and contract dates. [source: round 5 business_rules]
+
+
+## Domain Invariants
+
+- `domain-invariant-1` A System must have a business owner before it becomes Active. (semantics: normative; business rule: business-rule-1; scope: entity-system; readiness: ready; source: round 5 business_rules)
+- `domain-invariant-2` A System lifecycle state change requires approval for deprecation. (semantics: normative; business rule: business-rule-2; scope: entity-system; readiness: ready; source: round 5 business_rules)
+- `domain-invariant-3` A System must record vendor and contract dates. (semantics: normative; business rule: business-rule-3; scope: entity-system, entity-contract; readiness: ready; source: round 5 business_rules)
+
+
+## Use-Case To Domain Traceability
+
+- `trace-uc-analysis-1` register-a-system -> entity-system (use-case text references analysis object name)
+- `trace-uc-analysis-3` compare-overlapping-systems -> entity-system (use-case text references analysis object name)
+
+
+## Domain Invariant To Entity Traceability
+
+- `trace-domain-invariant-entity-1` domain-invariant-1 -> entity-system (domain invariant scope references domain entity)
+- `trace-domain-invariant-entity-2` domain-invariant-2 -> entity-system (domain invariant scope references domain entity)
+- `trace-domain-invariant-entity-3` domain-invariant-3 -> entity-system (domain invariant scope references domain entity)
+- `trace-domain-invariant-entity-4` domain-invariant-3 -> entity-contract (domain invariant scope references domain entity)
+
+
+
+## Artifact Lineage
+
+- `trace-artifact-domain-model-domain-entities-entity-system` entity-system -> domain-model.md#domain entities (canonical domain entities object renders into domain-model.md)
+- `trace-artifact-domain-model-domain-entities-entity-risk-assessment` entity-risk-assessment -> domain-model.md#domain entities (canonical domain entities object renders into domain-model.md)
+- `trace-artifact-domain-model-domain-entities-entity-cost-record` entity-cost-record -> domain-model.md#domain entities (canonical domain entities object renders into domain-model.md)
+- `trace-artifact-domain-model-domain-entities-entity-capability` entity-capability -> domain-model.md#domain entities (canonical domain entities object renders into domain-model.md)
+- `trace-artifact-domain-model-domain-entities-entity-contract` entity-contract -> domain-model.md#domain entities (canonical domain entities object renders into domain-model.md)
+- `trace-artifact-domain-model-domain-entities-entity-integration` entity-integration -> domain-model.md#domain entities (canonical domain entities object renders into domain-model.md)
+- `trace-artifact-domain-model-relationships-relationship-1` relationship-1 -> domain-model.md#relationships (canonical relationships object renders into domain-model.md)
+- `trace-artifact-domain-model-relationships-relationship-2` relationship-2 -> domain-model.md#relationships (canonical relationships object renders into domain-model.md)
+- `trace-artifact-domain-model-relationships-relationship-3` relationship-3 -> domain-model.md#relationships (canonical relationships object renders into domain-model.md)
+- `trace-artifact-domain-model-relationships-relationship-4` relationship-4 -> domain-model.md#relationships (canonical relationships object renders into domain-model.md)
+- `trace-artifact-domain-model-relationships-relationship-5` relationship-5 -> domain-model.md#relationships (canonical relationships object renders into domain-model.md)
+- `trace-artifact-domain-model-relationships-relationship-6` relationship-6 -> domain-model.md#relationships (canonical relationships object renders into domain-model.md)
+- `trace-artifact-domain-model-relationships-relationship-7` relationship-7 -> domain-model.md#relationships (canonical relationships object renders into domain-model.md)
+- `trace-artifact-domain-model-business-rules-business-rule-1` business-rule-1 -> domain-model.md#business rules (canonical business rules object renders into domain-model.md)
+- `trace-artifact-domain-model-business-rules-business-rule-2` business-rule-2 -> domain-model.md#business rules (canonical business rules object renders into domain-model.md)
+- `trace-artifact-domain-model-business-rules-business-rule-3` business-rule-3 -> domain-model.md#business rules (canonical business rules object renders into domain-model.md)
+- `trace-artifact-domain-model-domain-invariants-domain-invariant-1` domain-invariant-1 -> domain-model.md#domain invariants (canonical domain invariants object renders into domain-model.md)
+- `trace-artifact-domain-model-domain-invariants-domain-invariant-2` domain-invariant-2 -> domain-model.md#domain invariants (canonical domain invariants object renders into domain-model.md)
+- `trace-artifact-domain-model-domain-invariants-domain-invariant-3` domain-invariant-3 -> domain-model.md#domain invariants (canonical domain invariants object renders into domain-model.md)
+

--- a/examples/it-systems-inventory-v2/artifacts/formal/interaction-model.md
+++ b/examples/it-systems-inventory-v2/artifacts/formal/interaction-model.md
@@ -1,0 +1,127 @@
+# Interaction Model
+
+## Project
+
+- Name: A system to manage inventory of IT Systems themselves.
+- Domain: Unspecified
+
+## Scope
+
+All IT systems
+
+## Use-Case Realizations
+
+### Register a system
+
+- Realization ID: `interaction-realization-1`
+- Use case ID: `register-a-system`
+- Participants: Unspecified
+
+#### Steps
+
+1. No interaction steps documented.
+
+- Source: round 3 use_cases
+
+### edit metadata
+
+- Realization ID: `interaction-realization-2`
+- Use case ID: `edit-metadata`
+- Participants: Unspecified
+
+#### Steps
+
+1. No interaction steps documented.
+
+- Source: round 3 use_cases
+
+### compare overlapping systems
+
+- Realization ID: `interaction-realization-3`
+- Use case ID: `compare-overlapping-systems`
+- Participants: Unspecified
+
+#### Steps
+
+1. No interaction steps documented.
+
+- Source: round 3 use_cases
+
+### track lifecycle state
+
+- Realization ID: `interaction-realization-4`
+- Use case ID: `track-lifecycle-state`
+- Participants: Unspecified
+
+#### Steps
+
+1. No interaction steps documented.
+
+- Source: round 3 use_cases
+
+### review risks
+
+- Realization ID: `interaction-realization-5`
+- Use case ID: `review-risks`
+- Participants: Unspecified
+
+#### Steps
+
+1. No interaction steps documented.
+
+- Source: round 3 use_cases
+
+### see costs
+
+- Realization ID: `interaction-realization-6`
+- Use case ID: `see-costs`
+- Participants: Unspecified
+
+#### Steps
+
+1. No interaction steps documented.
+
+- Source: round 3 use_cases
+
+### approve deprecation
+
+- Realization ID: `interaction-realization-7`
+- Use case ID: `approve-deprecation`
+- Participants: Unspecified
+
+#### Steps
+
+1. No interaction steps documented.
+
+- Source: round 3 use_cases
+
+### report portfolio gaps
+
+- Realization ID: `interaction-realization-8`
+- Use case ID: `report-portfolio-gaps`
+- Participants: Unspecified
+
+#### Steps
+
+1. No interaction steps documented.
+
+- Source: round 3 use_cases
+
+## Message Flows
+
+- `interaction-message-1` System Inventory Web App -> System Inventory API (calls): System Inventory Web App calls System Inventory API [source: round 7 interfaces_and_integrations]
+- `interaction-message-2` System Inventory API -> Reporting Consumers (sends): System Inventory API sends Reporting Consumers [source: round 7 interfaces_and_integrations]
+
+## Artifact Lineage
+
+- `trace-artifact-interaction-model-use-case-realizations-interaction-realization-1` interaction-realization-1 -> interaction-model.md#use-case realizations (canonical use-case realizations object renders into interaction-model.md)
+- `trace-artifact-interaction-model-use-case-realizations-interaction-realization-2` interaction-realization-2 -> interaction-model.md#use-case realizations (canonical use-case realizations object renders into interaction-model.md)
+- `trace-artifact-interaction-model-use-case-realizations-interaction-realization-3` interaction-realization-3 -> interaction-model.md#use-case realizations (canonical use-case realizations object renders into interaction-model.md)
+- `trace-artifact-interaction-model-use-case-realizations-interaction-realization-4` interaction-realization-4 -> interaction-model.md#use-case realizations (canonical use-case realizations object renders into interaction-model.md)
+- `trace-artifact-interaction-model-use-case-realizations-interaction-realization-5` interaction-realization-5 -> interaction-model.md#use-case realizations (canonical use-case realizations object renders into interaction-model.md)
+- `trace-artifact-interaction-model-use-case-realizations-interaction-realization-6` interaction-realization-6 -> interaction-model.md#use-case realizations (canonical use-case realizations object renders into interaction-model.md)
+- `trace-artifact-interaction-model-use-case-realizations-interaction-realization-7` interaction-realization-7 -> interaction-model.md#use-case realizations (canonical use-case realizations object renders into interaction-model.md)
+- `trace-artifact-interaction-model-use-case-realizations-interaction-realization-8` interaction-realization-8 -> interaction-model.md#use-case realizations (canonical use-case realizations object renders into interaction-model.md)
+- `trace-artifact-interaction-model-message-flows-interaction-message-1` interaction-message-1 -> interaction-model.md#message flows (canonical message flows object renders into interaction-model.md)
+- `trace-artifact-interaction-model-message-flows-interaction-message-2` interaction-message-2 -> interaction-model.md#message flows (canonical message flows object renders into interaction-model.md)
+

--- a/examples/it-systems-inventory-v2/artifacts/formal/requirements-spec.md
+++ b/examples/it-systems-inventory-v2/artifacts/formal/requirements-spec.md
@@ -1,0 +1,139 @@
+# Requirements Specification
+
+## Project
+
+- Name: A system to manage inventory of IT Systems themselves.
+- Domain: Unspecified
+- Scope: All IT systems
+
+## Problem Statement
+
+We have many IT Systems and some overlap, some are free, some are expensive, all are slightly different.
+
+## Business Goals
+
+- Better planning of IT systems purchasing and life cycle
+
+## Success Criteria
+
+- Better planning of IT systems purchasing and life cycle
+
+## Functional Requirements
+
+- Yes business processes like stage gates and approval states must be supported
+- I think this will be the CMDB for IT Applications/systems - we need to be able to export data to various system for reporting.
+
+## Non-Functional Requirements
+
+- UI must be web based
+- SSO
+- role-based access
+- audit trail
+- search
+- filtering
+- performance (regular >1s for web page rendering)
+- availability >=99%
+
+## Acceptance Constraints
+
+- `acceptance-constraint-requirement-1` UI must be web based (semantics: normative; kind: non_functional_requirement; requirement: non_functional-requirement-1; readiness: ready; source: round 2 constraints)
+- `acceptance-constraint-requirement-2` SSO (semantics: normative; kind: non_functional_requirement; requirement: non_functional-requirement-1; readiness: ready; source: round 4 non_functional_requirements)
+- `acceptance-constraint-requirement-3` role-based access (semantics: normative; kind: non_functional_requirement; requirement: non_functional-requirement-2; readiness: ready; source: round 4 non_functional_requirements)
+- `acceptance-constraint-requirement-4` audit trail (semantics: normative; kind: non_functional_requirement; requirement: non_functional-requirement-3; readiness: ready; source: round 4 non_functional_requirements)
+- `acceptance-constraint-requirement-5` search (semantics: normative; kind: non_functional_requirement; requirement: non_functional-requirement-4; readiness: ready; source: round 4 non_functional_requirements)
+- `acceptance-constraint-requirement-6` filtering (semantics: normative; kind: non_functional_requirement; requirement: non_functional-requirement-5; readiness: ready; source: round 4 non_functional_requirements)
+- `acceptance-constraint-requirement-7` performance (regular >1s for web page rendering) (semantics: normative; kind: non_functional_requirement; requirement: non_functional-requirement-6; readiness: ready; source: round 4 non_functional_requirements)
+- `acceptance-constraint-requirement-8` availability >=99% (semantics: normative; kind: non_functional_requirement; requirement: non_functional-requirement-7; readiness: ready; source: round 4 non_functional_requirements)
+- `acceptance-constraint-success-1` Better planning of IT systems purchasing and life cycle (semantics: normative; kind: success_criterion; readiness: ready; source: round 2 success_criteria)
+
+
+## Logical View
+
+- `entity-system` System [source: round 5 domain_entities]
+- `entity-risk-assessment` Risk Assessment [source: round 5 domain_entities]
+- `entity-cost-record` Cost Record [source: round 5 domain_entities]
+- `entity-capability` Capability [source: round 5 domain_entities]
+- `entity-contract` Contract [source: round 5 domain_entities]
+- `entity-integration` Integration [source: round 5 domain_entities]
+
+
+## Relationships
+
+- `relationship-1` A System has one Business Owner [source: round 5 relationships]
+- `relationship-2` A System has one Technical Owner [source: round 5 relationships]
+- `relationship-3` A System has many Integrations [source: round 5 relationships]
+- `relationship-4` A System has many Capabilities [source: round 5 relationships]
+- `relationship-5` A System has one Contract [source: round 5 relationships]
+- `relationship-6` A System has many Risk Assessments [source: round 5 relationships]
+- `relationship-7` A System has many Cost Records [source: round 5 relationships]
+
+
+## Business Rules
+
+- `business-rule-1` A System must have a business owner before it becomes Active. [source: round 5 business_rules]
+- `business-rule-2` A System lifecycle state change requires approval for deprecation. [source: round 5 business_rules]
+- `business-rule-3` A System must record vendor and contract dates. [source: round 5 business_rules]
+
+
+## Process View
+
+- `state-entity-system` System {states: Proposed, Active, Retiring, Retired, Deprecated} [source: round 6 state_entities]
+
+
+## States and Transitions
+
+- `state-transition-1` System: Proposed -> Active -> Retiring -> Retired [source: round 6 states_and_transitions]
+- `state-transition-2` System: Proposed -> Active -> Retiring -> Retired [source: round 6 states_and_transitions]
+- `state-transition-3` System: Proposed -> Active -> Retiring -> Retired [source: round 6 states_and_transitions]
+- `state-transition-4` System: Active -> Deprecated [source: round 6 states_and_transitions]
+
+
+## Triggers and Approvals
+
+- `trigger-1` Deprecation approval requires enterprise architect review [source: round 6 triggers_and_approvals]
+- `trigger-2` Contract expiry triggers lifecycle review [source: round 6 triggers_and_approvals]
+
+
+## Architecture View
+
+- `component-system-inventory-web-app` System Inventory Web App [source: round 7 components_and_services]
+- `component-system-inventory-api` System Inventory API [source: round 7 components_and_services]
+- `component-reporting-consumers` Reporting Consumers [source: round 7 components_and_services]
+
+
+## Interfaces and Integrations
+
+- `interface-1` System Inventory Web App calls System Inventory API [source: round 7 interfaces_and_integrations]
+- `interface-2` System Inventory API sends Reporting Consumers [source: round 7 interfaces_and_integrations]
+
+
+## Runtime Boundaries
+
+- `runtime-boundary-1` System Inventory API runs separately from the UI [source: round 7 runtime_boundaries]
+
+
+
+## Use-Case To Analysis Traceability
+
+- `trace-uc-analysis-1` register-a-system -> entity-system (use-case text references analysis object name)
+- `trace-uc-analysis-2` register-a-system -> state-entity-system (use-case text references analysis object name)
+- `trace-uc-analysis-3` compare-overlapping-systems -> entity-system (use-case text references analysis object name)
+- `trace-uc-analysis-4` compare-overlapping-systems -> state-entity-system (use-case text references analysis object name)
+
+
+## Analysis To Design Traceability
+
+- `trace-analysis-design-1` entity-system -> component-system-inventory-web-app (design component name references analysis object name)
+- `trace-analysis-design-2` entity-system -> component-system-inventory-api (design component name references analysis object name)
+- `trace-analysis-design-3` state-entity-system -> component-system-inventory-web-app (design component name references analysis object name)
+- `trace-analysis-design-4` state-entity-system -> component-system-inventory-api (design component name references analysis object name)
+
+
+
+## Assumptions
+
+- None
+
+## Open Questions
+
+- None

--- a/examples/it-systems-inventory-v2/artifacts/formal/scenario-documents.md
+++ b/examples/it-systems-inventory-v2/artifacts/formal/scenario-documents.md
@@ -1,0 +1,3 @@
+# Scenario Documents
+
+No scenarios documented.

--- a/examples/it-systems-inventory-v2/artifacts/formal/state-model.md
+++ b/examples/it-systems-inventory-v2/artifacts/formal/state-model.md
@@ -1,0 +1,83 @@
+# State Model
+
+## Project
+
+- Name: A system to manage inventory of IT Systems themselves.
+- Domain: Unspecified
+
+## Scope
+
+All IT systems
+
+## State Entities
+
+- `state-entity-system` System {states: Proposed, Active, Retiring, Retired, Deprecated} [source: round 6 state_entities]
+
+
+## State Transitions
+
+- `state-transition-1` Proposed -> Active (entity: System) [source: round 6 states_and_transitions]
+- `state-transition-2` Active -> Retiring (entity: System) [source: round 6 states_and_transitions]
+- `state-transition-3` Retiring -> Retired (entity: System) [source: round 6 states_and_transitions]
+- `state-transition-4` Active -> Deprecated (entity: System) [source: round 6 states_and_transitions]
+
+
+## Triggers and Approvals
+
+- `trigger-1` Deprecation approval requires enterprise architect review (event: Deprecation approval; type: approval; approval required) [source: round 6 triggers_and_approvals]
+- `trigger-2` Contract expiry triggers lifecycle review (event: Contract expiry; type: event) [source: round 6 triggers_and_approvals]
+
+
+## State Invariants
+
+- `state-invariant-1` A System must have a business owner before it becomes Active. (semantics: normative; business rule: business-rule-1; states: state-entity-system; readiness: ready; source: round 5 business_rules)
+- `state-invariant-2` A System lifecycle state change requires approval for deprecation. (semantics: normative; business rule: business-rule-2; states: state-entity-system; readiness: ready; source: round 5 business_rules)
+- `state-invariant-3` A System must record vendor and contract dates. (semantics: normative; business rule: business-rule-3; states: state-entity-system; readiness: ready; source: round 5 business_rules)
+
+
+## Guard Conditions
+
+- `guard-condition-1` Deprecation approval requires enterprise architect review (semantics: normative; trigger: trigger-1; readiness: blocked; source: round 6 triggers_and_approvals)
+- `guard-condition-2` Contract expiry triggers lifecycle review (semantics: normative; trigger: trigger-2; readiness: blocked; source: round 6 triggers_and_approvals)
+
+
+
+## Use-Case To State Traceability
+
+- `trace-uc-analysis-2` register-a-system -> state-entity-system (use-case text references analysis object name)
+- `trace-uc-analysis-4` compare-overlapping-systems -> state-entity-system (use-case text references analysis object name)
+
+
+## State Invariant To State Traceability
+
+- `trace-state-invariant-state-1` state-invariant-1 -> state-entity-system (state invariant scope references state entity)
+- `trace-state-invariant-state-2` state-invariant-2 -> state-entity-system (state invariant scope references state entity)
+- `trace-state-invariant-state-3` state-invariant-3 -> state-entity-system (state invariant scope references state entity)
+
+
+
+
+## State To Design Traceability
+
+- `trace-analysis-design-1` entity-system -> component-system-inventory-web-app (design component name references analysis object name)
+- `trace-analysis-design-2` entity-system -> component-system-inventory-api (design component name references analysis object name)
+- `trace-analysis-design-3` state-entity-system -> component-system-inventory-web-app (design component name references analysis object name)
+- `trace-analysis-design-4` state-entity-system -> component-system-inventory-api (design component name references analysis object name)
+
+
+
+## Artifact Lineage
+
+- `trace-artifact-state-model-state-entities-state-entity-system` state-entity-system -> state-model.md#state entities (canonical state entities object renders into state-model.md)
+- `trace-artifact-state-model-state-transitions-state-transition-1` state-transition-1 -> state-model.md#state transitions (canonical state transitions object renders into state-model.md)
+- `trace-artifact-state-model-state-transitions-state-transition-2` state-transition-2 -> state-model.md#state transitions (canonical state transitions object renders into state-model.md)
+- `trace-artifact-state-model-state-transitions-state-transition-3` state-transition-3 -> state-model.md#state transitions (canonical state transitions object renders into state-model.md)
+- `trace-artifact-state-model-state-transitions-state-transition-4` state-transition-4 -> state-model.md#state transitions (canonical state transitions object renders into state-model.md)
+- `trace-artifact-state-model-triggers-and-approvals-trigger-1` trigger-1 -> state-model.md#triggers and approvals (canonical triggers and approvals object renders into state-model.md)
+- `trace-artifact-state-model-triggers-and-approvals-trigger-2` trigger-2 -> state-model.md#triggers and approvals (canonical triggers and approvals object renders into state-model.md)
+- `trace-artifact-state-model-state-invariants-state-invariant-1` state-invariant-1 -> state-model.md#state invariants (canonical state invariants object renders into state-model.md)
+- `trace-artifact-state-model-state-invariants-state-invariant-2` state-invariant-2 -> state-model.md#state invariants (canonical state invariants object renders into state-model.md)
+- `trace-artifact-state-model-state-invariants-state-invariant-3` state-invariant-3 -> state-model.md#state invariants (canonical state invariants object renders into state-model.md)
+- `trace-artifact-state-model-guard-conditions-guard-condition-1` guard-condition-1 -> state-model.md#guard conditions (canonical guard conditions object renders into state-model.md)
+- `trace-artifact-state-model-guard-conditions-guard-condition-2` guard-condition-2 -> state-model.md#guard conditions (canonical guard conditions object renders into state-model.md)
+

--- a/examples/it-systems-inventory-v2/artifacts/formal/system-document.md
+++ b/examples/it-systems-inventory-v2/artifacts/formal/system-document.md
@@ -1,0 +1,73 @@
+# System / Subsystem Document
+
+## System Name
+
+A system to manage inventory of IT Systems themselves.
+
+## Brief Description
+
+We have many IT Systems and some overlap, some are free, some are expensive, all are slightly different.
+
+All IT systems
+
+## Risk Factors
+
+- None
+
+## System-Level Use Cases
+
+- `register-a-system` Register a system (actor: Unspecified): Register a system
+- `edit-metadata` edit metadata (actor: Unspecified): edit metadata
+- `compare-overlapping-systems` compare overlapping systems (actor: Unspecified): compare overlapping systems
+- `track-lifecycle-state` track lifecycle state (actor: Unspecified): track lifecycle state
+- `review-risks` review risks (actor: Unspecified): review risks
+- `see-costs` see costs (actor: Unspecified): see costs
+- `approve-deprecation` approve deprecation (actor: Unspecified): approve deprecation
+- `report-portfolio-gaps` report portfolio gaps (actor: Unspecified): report portfolio gaps
+
+## System-Level Diagram References
+
+- `use-case-model.md` for the detailed system-level use-case view
+- `deployment-model.md` for the detailed architecture and runtime view
+
+
+## Architecture Overview
+
+- `component-system-inventory-web-app` System Inventory Web App [source: round 7 components_and_services]
+- `component-system-inventory-api` System Inventory API [source: round 7 components_and_services]
+- `component-reporting-consumers` Reporting Consumers [source: round 7 components_and_services]
+
+
+## Interfaces and Integrations
+
+- `interface-1` System Inventory Web App calls System Inventory API [source: round 7 interfaces_and_integrations]
+- `interface-2` System Inventory API sends Reporting Consumers [source: round 7 interfaces_and_integrations]
+
+
+## Runtime Boundaries
+
+- `runtime-boundary-1` System Inventory API runs separately from the UI [source: round 7 runtime_boundaries]
+
+## Subsystem Descriptions
+
+- `component-system-inventory-web-app` System Inventory Web App [source: round 7 components_and_services]
+- `component-system-inventory-api` System Inventory API [source: round 7 components_and_services]
+- `component-reporting-consumers` Reporting Consumers [source: round 7 components_and_services]
+
+## Artifact Lineage
+
+- `trace-artifact-system-document-system-level-use-cases-register-a-system` register-a-system -> system-document.md#system-level use cases (canonical system-level use cases object renders into system-document.md)
+- `trace-artifact-system-document-system-level-use-cases-edit-metadata` edit-metadata -> system-document.md#system-level use cases (canonical system-level use cases object renders into system-document.md)
+- `trace-artifact-system-document-system-level-use-cases-compare-overlapping-systems` compare-overlapping-systems -> system-document.md#system-level use cases (canonical system-level use cases object renders into system-document.md)
+- `trace-artifact-system-document-system-level-use-cases-track-lifecycle-state` track-lifecycle-state -> system-document.md#system-level use cases (canonical system-level use cases object renders into system-document.md)
+- `trace-artifact-system-document-system-level-use-cases-review-risks` review-risks -> system-document.md#system-level use cases (canonical system-level use cases object renders into system-document.md)
+- `trace-artifact-system-document-system-level-use-cases-see-costs` see-costs -> system-document.md#system-level use cases (canonical system-level use cases object renders into system-document.md)
+- `trace-artifact-system-document-system-level-use-cases-approve-deprecation` approve-deprecation -> system-document.md#system-level use cases (canonical system-level use cases object renders into system-document.md)
+- `trace-artifact-system-document-system-level-use-cases-report-portfolio-gaps` report-portfolio-gaps -> system-document.md#system-level use cases (canonical system-level use cases object renders into system-document.md)
+- `trace-artifact-system-document-architecture-overview-component-system-inventory-web-app` component-system-inventory-web-app -> system-document.md#architecture overview (canonical architecture overview object renders into system-document.md)
+- `trace-artifact-system-document-architecture-overview-component-system-inventory-api` component-system-inventory-api -> system-document.md#architecture overview (canonical architecture overview object renders into system-document.md)
+- `trace-artifact-system-document-architecture-overview-component-reporting-consumers` component-reporting-consumers -> system-document.md#architecture overview (canonical architecture overview object renders into system-document.md)
+- `trace-artifact-system-document-interfaces-and-integrations-interface-1` interface-1 -> system-document.md#interfaces and integrations (canonical interfaces and integrations object renders into system-document.md)
+- `trace-artifact-system-document-interfaces-and-integrations-interface-2` interface-2 -> system-document.md#interfaces and integrations (canonical interfaces and integrations object renders into system-document.md)
+- `trace-artifact-system-document-runtime-boundaries-runtime-boundary-1` runtime-boundary-1 -> system-document.md#runtime boundaries (canonical runtime boundaries object renders into system-document.md)
+

--- a/examples/it-systems-inventory-v2/artifacts/formal/use-case-documents.md
+++ b/examples/it-systems-inventory-v2/artifacts/formal/use-case-documents.md
@@ -1,0 +1,669 @@
+# Use-Case Documents
+
+## Register a system
+
+- ID: `register-a-system`
+- Primary Actor: Unspecified
+- Supporting Actors: None
+- Priority: Unspecified
+- Status: Unspecified
+- Content Semantics: normative
+- Readiness: blocked
+- Complexity: average
+- Goal: Register a system
+- Trigger: Unspecified
+- Source: round 3 use_cases
+
+### Brief Description
+
+Register a system
+
+### Preconditions
+
+- None
+
+### Postconditions
+
+- None
+
+### Extension Points
+
+- None
+
+### Used Use Cases
+
+- None
+
+### Subordinate Use Cases
+
+- None
+
+### Flow of Events
+
+1. No main success scenario documented.
+
+### Extensions
+
+- None
+
+### Secondary Scenarios
+
+No named scenarios documented.
+
+### User Interface
+
+- None
+
+### View of Participating Classes
+
+- `entity-system` System [source: round 5 domain_entities]
+- `state-entity-system` System [source: round 6 state_entities]
+
+### Sequence and Interaction Notes
+
+#### Register a system
+
+- Participants: Unspecified
+
+##### Realization Steps
+
+1. No realization steps documented.
+
+
+### Linked Requirements
+
+- None
+
+### Other Artifacts
+
+- None
+
+
+## Use-Case To Analysis Traceability
+
+- `trace-uc-analysis-1` register-a-system -> entity-system (use-case text references analysis object name)
+- `trace-uc-analysis-2` register-a-system -> state-entity-system (use-case text references analysis object name)
+- `trace-uc-analysis-3` compare-overlapping-systems -> entity-system (use-case text references analysis object name)
+- `trace-uc-analysis-4` compare-overlapping-systems -> state-entity-system (use-case text references analysis object name)
+
+
+
+## edit metadata
+
+- ID: `edit-metadata`
+- Primary Actor: Unspecified
+- Supporting Actors: None
+- Priority: Unspecified
+- Status: Unspecified
+- Content Semantics: normative
+- Readiness: blocked
+- Complexity: simple
+- Goal: edit metadata
+- Trigger: Unspecified
+- Source: round 3 use_cases
+
+### Brief Description
+
+edit metadata
+
+### Preconditions
+
+- None
+
+### Postconditions
+
+- None
+
+### Extension Points
+
+- None
+
+### Used Use Cases
+
+- None
+
+### Subordinate Use Cases
+
+- None
+
+### Flow of Events
+
+1. No main success scenario documented.
+
+### Extensions
+
+- None
+
+### Secondary Scenarios
+
+No named scenarios documented.
+
+### User Interface
+
+- None
+
+### View of Participating Classes
+
+- None
+
+### Sequence and Interaction Notes
+
+#### edit metadata
+
+- Participants: Unspecified
+
+##### Realization Steps
+
+1. No realization steps documented.
+
+
+### Linked Requirements
+
+- None
+
+### Other Artifacts
+
+- None
+
+
+
+
+## compare overlapping systems
+
+- ID: `compare-overlapping-systems`
+- Primary Actor: Unspecified
+- Supporting Actors: None
+- Priority: Unspecified
+- Status: Unspecified
+- Content Semantics: normative
+- Readiness: blocked
+- Complexity: average
+- Goal: compare overlapping systems
+- Trigger: Unspecified
+- Source: round 3 use_cases
+
+### Brief Description
+
+compare overlapping systems
+
+### Preconditions
+
+- None
+
+### Postconditions
+
+- None
+
+### Extension Points
+
+- None
+
+### Used Use Cases
+
+- None
+
+### Subordinate Use Cases
+
+- None
+
+### Flow of Events
+
+1. No main success scenario documented.
+
+### Extensions
+
+- None
+
+### Secondary Scenarios
+
+No named scenarios documented.
+
+### User Interface
+
+- None
+
+### View of Participating Classes
+
+- `entity-system` System [source: round 5 domain_entities]
+- `state-entity-system` System [source: round 6 state_entities]
+
+### Sequence and Interaction Notes
+
+#### compare overlapping systems
+
+- Participants: Unspecified
+
+##### Realization Steps
+
+1. No realization steps documented.
+
+
+### Linked Requirements
+
+- None
+
+### Other Artifacts
+
+- None
+
+
+## Use-Case To Analysis Traceability
+
+- `trace-uc-analysis-1` register-a-system -> entity-system (use-case text references analysis object name)
+- `trace-uc-analysis-2` register-a-system -> state-entity-system (use-case text references analysis object name)
+- `trace-uc-analysis-3` compare-overlapping-systems -> entity-system (use-case text references analysis object name)
+- `trace-uc-analysis-4` compare-overlapping-systems -> state-entity-system (use-case text references analysis object name)
+
+
+
+## track lifecycle state
+
+- ID: `track-lifecycle-state`
+- Primary Actor: Unspecified
+- Supporting Actors: None
+- Priority: Unspecified
+- Status: Unspecified
+- Content Semantics: normative
+- Readiness: blocked
+- Complexity: average
+- Goal: track lifecycle state
+- Trigger: Unspecified
+- Source: round 3 use_cases
+
+### Brief Description
+
+track lifecycle state
+
+### Preconditions
+
+- None
+
+### Postconditions
+
+- None
+
+### Extension Points
+
+- None
+
+### Used Use Cases
+
+- None
+
+### Subordinate Use Cases
+
+- None
+
+### Flow of Events
+
+1. No main success scenario documented.
+
+### Extensions
+
+- None
+
+### Secondary Scenarios
+
+No named scenarios documented.
+
+### User Interface
+
+- None
+
+### View of Participating Classes
+
+- None
+
+### Sequence and Interaction Notes
+
+#### track lifecycle state
+
+- Participants: Unspecified
+
+##### Realization Steps
+
+1. No realization steps documented.
+
+
+### Linked Requirements
+
+- None
+
+### Other Artifacts
+
+- None
+
+
+
+
+## review risks
+
+- ID: `review-risks`
+- Primary Actor: Unspecified
+- Supporting Actors: None
+- Priority: Unspecified
+- Status: Unspecified
+- Content Semantics: normative
+- Readiness: blocked
+- Complexity: simple
+- Goal: review risks
+- Trigger: Unspecified
+- Source: round 3 use_cases
+
+### Brief Description
+
+review risks
+
+### Preconditions
+
+- None
+
+### Postconditions
+
+- None
+
+### Extension Points
+
+- None
+
+### Used Use Cases
+
+- None
+
+### Subordinate Use Cases
+
+- None
+
+### Flow of Events
+
+1. No main success scenario documented.
+
+### Extensions
+
+- None
+
+### Secondary Scenarios
+
+No named scenarios documented.
+
+### User Interface
+
+- None
+
+### View of Participating Classes
+
+- None
+
+### Sequence and Interaction Notes
+
+#### review risks
+
+- Participants: Unspecified
+
+##### Realization Steps
+
+1. No realization steps documented.
+
+
+### Linked Requirements
+
+- None
+
+### Other Artifacts
+
+- None
+
+
+
+
+## see costs
+
+- ID: `see-costs`
+- Primary Actor: Unspecified
+- Supporting Actors: None
+- Priority: Unspecified
+- Status: Unspecified
+- Content Semantics: normative
+- Readiness: blocked
+- Complexity: simple
+- Goal: see costs
+- Trigger: Unspecified
+- Source: round 3 use_cases
+
+### Brief Description
+
+see costs
+
+### Preconditions
+
+- None
+
+### Postconditions
+
+- None
+
+### Extension Points
+
+- None
+
+### Used Use Cases
+
+- None
+
+### Subordinate Use Cases
+
+- None
+
+### Flow of Events
+
+1. No main success scenario documented.
+
+### Extensions
+
+- None
+
+### Secondary Scenarios
+
+No named scenarios documented.
+
+### User Interface
+
+- None
+
+### View of Participating Classes
+
+- None
+
+### Sequence and Interaction Notes
+
+#### see costs
+
+- Participants: Unspecified
+
+##### Realization Steps
+
+1. No realization steps documented.
+
+
+### Linked Requirements
+
+- None
+
+### Other Artifacts
+
+- None
+
+
+
+
+## approve deprecation
+
+- ID: `approve-deprecation`
+- Primary Actor: Unspecified
+- Supporting Actors: None
+- Priority: Unspecified
+- Status: Unspecified
+- Content Semantics: normative
+- Readiness: blocked
+- Complexity: average
+- Goal: approve deprecation
+- Trigger: Unspecified
+- Source: round 3 use_cases
+
+### Brief Description
+
+approve deprecation
+
+### Preconditions
+
+- None
+
+### Postconditions
+
+- None
+
+### Extension Points
+
+- None
+
+### Used Use Cases
+
+- None
+
+### Subordinate Use Cases
+
+- None
+
+### Flow of Events
+
+1. No main success scenario documented.
+
+### Extensions
+
+- None
+
+### Secondary Scenarios
+
+No named scenarios documented.
+
+### User Interface
+
+- None
+
+### View of Participating Classes
+
+- None
+
+### Sequence and Interaction Notes
+
+#### approve deprecation
+
+- Participants: Unspecified
+
+##### Realization Steps
+
+1. No realization steps documented.
+
+
+### Linked Requirements
+
+- None
+
+### Other Artifacts
+
+- None
+
+
+
+
+## report portfolio gaps
+
+- ID: `report-portfolio-gaps`
+- Primary Actor: Unspecified
+- Supporting Actors: None
+- Priority: Unspecified
+- Status: Unspecified
+- Content Semantics: normative
+- Readiness: blocked
+- Complexity: average
+- Goal: report portfolio gaps
+- Trigger: Unspecified
+- Source: round 3 use_cases
+
+### Brief Description
+
+report portfolio gaps
+
+### Preconditions
+
+- None
+
+### Postconditions
+
+- None
+
+### Extension Points
+
+- None
+
+### Used Use Cases
+
+- None
+
+### Subordinate Use Cases
+
+- None
+
+### Flow of Events
+
+1. No main success scenario documented.
+
+### Extensions
+
+- None
+
+### Secondary Scenarios
+
+No named scenarios documented.
+
+### User Interface
+
+- None
+
+### View of Participating Classes
+
+- None
+
+### Sequence and Interaction Notes
+
+#### report portfolio gaps
+
+- Participants: Unspecified
+
+##### Realization Steps
+
+1. No realization steps documented.
+
+
+### Linked Requirements
+
+- None
+
+### Other Artifacts
+
+- None
+
+
+
+
+## Artifact Lineage
+
+- `trace-artifact-use-case-documents-use-case-documents-register-a-system` register-a-system -> use-case-documents.md#use-case documents (canonical use-case documents object renders into use-case-documents.md)
+- `trace-artifact-use-case-documents-use-case-documents-edit-metadata` edit-metadata -> use-case-documents.md#use-case documents (canonical use-case documents object renders into use-case-documents.md)
+- `trace-artifact-use-case-documents-use-case-documents-compare-overlapping-systems` compare-overlapping-systems -> use-case-documents.md#use-case documents (canonical use-case documents object renders into use-case-documents.md)
+- `trace-artifact-use-case-documents-use-case-documents-track-lifecycle-state` track-lifecycle-state -> use-case-documents.md#use-case documents (canonical use-case documents object renders into use-case-documents.md)
+- `trace-artifact-use-case-documents-use-case-documents-review-risks` review-risks -> use-case-documents.md#use-case documents (canonical use-case documents object renders into use-case-documents.md)
+- `trace-artifact-use-case-documents-use-case-documents-see-costs` see-costs -> use-case-documents.md#use-case documents (canonical use-case documents object renders into use-case-documents.md)
+- `trace-artifact-use-case-documents-use-case-documents-approve-deprecation` approve-deprecation -> use-case-documents.md#use-case documents (canonical use-case documents object renders into use-case-documents.md)
+- `trace-artifact-use-case-documents-use-case-documents-report-portfolio-gaps` report-portfolio-gaps -> use-case-documents.md#use-case documents (canonical use-case documents object renders into use-case-documents.md)
+

--- a/examples/it-systems-inventory-v2/artifacts/formal/use-case-model.md
+++ b/examples/it-systems-inventory-v2/artifacts/formal/use-case-model.md
@@ -1,0 +1,172 @@
+# Use-Case Model
+
+## Actors
+
+- `business-owners` Business owners (human, complex):  [source: round 3 actors]
+- `technical-owners` technical owners (human, complex):  [source: round 3 actors]
+- `enterprise-architects` enterprise architects (human, complex):  [source: round 3 actors]
+- `procurement` procurement (human, average):  [source: round 3 actors]
+- `security` security (human, average):  [source: round 3 actors]
+- `finance` finance (human, average):  [source: round 3 actors]
+- `application-owners` application owners (human, complex):  [source: round 3 actors]
+- `integration-system-owners` integration system owners (system, average):  [source: round 3 actors]
+
+## Use Cases
+
+### Register a system
+
+- ID: `register-a-system`
+- Primary actor: Unspecified
+- Complexity: average
+- Goal: Register a system
+- Source: round 3 use_cases
+
+#### Main Success Scenario
+
+1. No main success scenario documented.
+
+#### Extensions
+
+- None
+
+### edit metadata
+
+- ID: `edit-metadata`
+- Primary actor: Unspecified
+- Complexity: simple
+- Goal: edit metadata
+- Source: round 3 use_cases
+
+#### Main Success Scenario
+
+1. No main success scenario documented.
+
+#### Extensions
+
+- None
+
+### compare overlapping systems
+
+- ID: `compare-overlapping-systems`
+- Primary actor: Unspecified
+- Complexity: average
+- Goal: compare overlapping systems
+- Source: round 3 use_cases
+
+#### Main Success Scenario
+
+1. No main success scenario documented.
+
+#### Extensions
+
+- None
+
+### track lifecycle state
+
+- ID: `track-lifecycle-state`
+- Primary actor: Unspecified
+- Complexity: average
+- Goal: track lifecycle state
+- Source: round 3 use_cases
+
+#### Main Success Scenario
+
+1. No main success scenario documented.
+
+#### Extensions
+
+- None
+
+### review risks
+
+- ID: `review-risks`
+- Primary actor: Unspecified
+- Complexity: simple
+- Goal: review risks
+- Source: round 3 use_cases
+
+#### Main Success Scenario
+
+1. No main success scenario documented.
+
+#### Extensions
+
+- None
+
+### see costs
+
+- ID: `see-costs`
+- Primary actor: Unspecified
+- Complexity: simple
+- Goal: see costs
+- Source: round 3 use_cases
+
+#### Main Success Scenario
+
+1. No main success scenario documented.
+
+#### Extensions
+
+- None
+
+### approve deprecation
+
+- ID: `approve-deprecation`
+- Primary actor: Unspecified
+- Complexity: average
+- Goal: approve deprecation
+- Source: round 3 use_cases
+
+#### Main Success Scenario
+
+1. No main success scenario documented.
+
+#### Extensions
+
+- None
+
+### report portfolio gaps
+
+- ID: `report-portfolio-gaps`
+- Primary actor: Unspecified
+- Complexity: average
+- Goal: report portfolio gaps
+- Source: round 3 use_cases
+
+#### Main Success Scenario
+
+1. No main success scenario documented.
+
+#### Extensions
+
+- None
+
+
+## States and Transitions
+
+- `state-transition-1` System: Proposed -> Active -> Retiring -> Retired [source: round 6 states_and_transitions]
+- `state-transition-2` System: Proposed -> Active -> Retiring -> Retired [source: round 6 states_and_transitions]
+- `state-transition-3` System: Proposed -> Active -> Retiring -> Retired [source: round 6 states_and_transitions]
+- `state-transition-4` System: Active -> Deprecated [source: round 6 states_and_transitions]
+
+
+## Triggers and Approvals
+
+- `trigger-1` Deprecation approval requires enterprise architect review [source: round 6 triggers_and_approvals]
+- `trigger-2` Contract expiry triggers lifecycle review [source: round 6 triggers_and_approvals]
+
+
+## Interfaces and Integrations
+
+- `interface-1` System Inventory Web App calls System Inventory API [source: round 7 interfaces_and_integrations]
+- `interface-2` System Inventory API sends Reporting Consumers [source: round 7 interfaces_and_integrations]
+
+
+
+## Use-Case To Analysis Traceability
+
+- `trace-uc-analysis-1` register-a-system -> entity-system (use-case text references analysis object name)
+- `trace-uc-analysis-2` register-a-system -> state-entity-system (use-case text references analysis object name)
+- `trace-uc-analysis-3` compare-overlapping-systems -> entity-system (use-case text references analysis object name)
+- `trace-uc-analysis-4` compare-overlapping-systems -> state-entity-system (use-case text references analysis object name)
+

--- a/examples/it-systems-inventory-v2/artifacts/mermaid/deployment-model.mmd
+++ b/examples/it-systems-inventory-v2/artifacts/mermaid/deployment-model.mmd
@@ -1,0 +1,7 @@
+flowchart LR
+System_Inventory_Web_App["System Inventory Web App"]
+System_Inventory_API["System Inventory API"]
+Reporting_Consumers["Reporting Consumers"]
+System_Inventory_Web_App -->|"System Inventory Web App calls System Inventory API"| System_Inventory_API
+System_Inventory_API -->|"System Inventory API sends Reporting Consumers"| Reporting_Consumers
+RuntimeBoundary_1["System Inventory API runs separately from the UI"]

--- a/examples/it-systems-inventory-v2/artifacts/mermaid/domain-model.mmd
+++ b/examples/it-systems-inventory-v2/artifacts/mermaid/domain-model.mmd
@@ -1,0 +1,16 @@
+classDiagram
+class System {
+}
+class Risk_Assessment {
+}
+class Cost_Record {
+}
+class Capability {
+}
+class Contract {
+}
+class Integration {
+}
+System "1" --> "*" Integration : has_many
+System "1" --> "*" Risk_Assessment : has_many
+System "1" --> "*" Cost_Record : has_many

--- a/examples/it-systems-inventory-v2/artifacts/mermaid/interaction-model.mmd
+++ b/examples/it-systems-inventory-v2/artifacts/mermaid/interaction-model.mmd
@@ -1,0 +1,6 @@
+sequenceDiagram
+participant System_Inventory_Web_App as "System Inventory Web App"
+participant System_Inventory_API as "System Inventory API"
+participant Reporting_Consumers as "Reporting Consumers"
+System_Inventory_Web_App->>System_Inventory_API: System Inventory Web App calls System Inventory API
+System_Inventory_API->>Reporting_Consumers: System Inventory API sends Reporting Consumers

--- a/examples/it-systems-inventory-v2/artifacts/mermaid/state-model.mmd
+++ b/examples/it-systems-inventory-v2/artifacts/mermaid/state-model.mmd
@@ -1,0 +1,12 @@
+stateDiagram-v2
+state "System" as lifecycle {
+  state "Proposed" as Proposed
+  state "Active" as Active
+  state "Retiring" as Retiring
+  state "Retired" as Retired
+  state "Deprecated" as Deprecated
+  Proposed --> Active
+  Active --> Retiring
+  Retiring --> Retired
+  Active --> Deprecated
+}

--- a/examples/it-systems-inventory-v2/artifacts/ucp/ucp-estimate.md
+++ b/examples/it-systems-inventory-v2/artifacts/ucp/ucp-estimate.md
@@ -1,0 +1,29 @@
+# UCP Estimate
+
+## Project
+
+A system to manage inventory of IT Systems themselves.
+
+## Summary
+
+- `UAW`: 20.00
+- `UUCW`: 65.00
+- `UUCP`: 85.00
+- `TCF`: 0.990
+- `EF`: 0.860
+- `UCP`: 72.369
+- `Effort Hours`: 1447.38
+
+## Inputs
+
+- Technical factor weighted sum: 39.00
+- Environmental factor weighted sum: 18.00
+- Productivity hours per UCP: 20.00
+
+## Assumptions
+
+- None
+
+## Open Questions
+
+- None

--- a/examples/it-systems-inventory-v2/bundle-manifest.json
+++ b/examples/it-systems-inventory-v2/bundle-manifest.json
@@ -1,0 +1,54 @@
+{
+  "bundle_metadata": {
+    "bundle_kind": "rupify_specification_publication_bundle",
+    "generated_artifact_families": [
+      "formal",
+      "ucp",
+      "domain-mermaid",
+      "interaction-mermaid",
+      "deployment-mermaid",
+      "state-mermaid",
+      "speckify-planning-export"
+    ],
+    "schema_version": 1,
+    "source_model_change_metadata": {
+      "change_source": "normalize_replay_to_model",
+      "last_changed_at": "",
+      "regenerated_from_version": "",
+      "semantic_hash": "2f3ec68a35e9678e",
+      "semantic_version": 1,
+      "supersedes": []
+    },
+    "source_model_semantic_id": "rupify-model"
+  },
+  "layout": {
+    "formal_artifacts": [
+      "artifacts/formal/deployment-model.md",
+      "artifacts/formal/domain-model.md",
+      "artifacts/formal/interaction-model.md",
+      "artifacts/formal/requirements-spec.md",
+      "artifacts/formal/scenario-documents.md",
+      "artifacts/formal/state-model.md",
+      "artifacts/formal/system-document.md",
+      "artifacts/formal/use-case-documents.md",
+      "artifacts/formal/use-case-model.md"
+    ],
+    "mermaid_artifacts": [
+      "artifacts/mermaid/deployment-model.mmd",
+      "artifacts/mermaid/domain-model.mmd",
+      "artifacts/mermaid/interaction-model.mmd",
+      "artifacts/mermaid/state-model.mmd"
+    ],
+    "model": "model/rupify-model.json",
+    "planning_export": "exports/speckify-planning-export.json",
+    "ucp_artifacts": [
+      "artifacts/ucp/ucp-estimate.md"
+    ]
+  },
+  "summary": {
+    "file_count": 17,
+    "formal_artifact_count": 9,
+    "mermaid_artifact_count": 4,
+    "ucp_artifact_count": 1
+  }
+}

--- a/examples/it-systems-inventory-v2/exports/speckify-planning-export.json
+++ b/examples/it-systems-inventory-v2/exports/speckify-planning-export.json
@@ -1,0 +1,5096 @@
+{
+  "blocking_ambiguities": [],
+  "elements": [
+    {
+      "attributes": {
+        "constraint_kind": "non_functional_requirement",
+        "source_requirement_id": "non_functional-requirement-1"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_acceptance_constraints",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "926a0e8b7f0d0604",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "acceptance_constraints",
+      "id": "acceptance-constraint-requirement-1",
+      "missing_fields": [],
+      "name": "Acceptance Constraint 1",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "acceptance-constraint-requirement-1",
+      "source_key": "constraints",
+      "source_round": 2,
+      "text": "UI must be web based"
+    },
+    {
+      "attributes": {
+        "constraint_kind": "non_functional_requirement",
+        "source_requirement_id": "non_functional-requirement-1"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_acceptance_constraints",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "ea270a270fd5ae0a",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "acceptance_constraints",
+      "id": "acceptance-constraint-requirement-2",
+      "missing_fields": [],
+      "name": "Acceptance Constraint 2",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "acceptance-constraint-requirement-2",
+      "source_key": "non_functional_requirements",
+      "source_round": 4,
+      "text": "SSO"
+    },
+    {
+      "attributes": {
+        "constraint_kind": "non_functional_requirement",
+        "source_requirement_id": "non_functional-requirement-2"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_acceptance_constraints",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "cc94e38b4882a356",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "acceptance_constraints",
+      "id": "acceptance-constraint-requirement-3",
+      "missing_fields": [],
+      "name": "Acceptance Constraint 3",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "acceptance-constraint-requirement-3",
+      "source_key": "non_functional_requirements",
+      "source_round": 4,
+      "text": "role-based access"
+    },
+    {
+      "attributes": {
+        "constraint_kind": "non_functional_requirement",
+        "source_requirement_id": "non_functional-requirement-3"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_acceptance_constraints",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "e3b5c94d9e1c0566",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "acceptance_constraints",
+      "id": "acceptance-constraint-requirement-4",
+      "missing_fields": [],
+      "name": "Acceptance Constraint 4",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "acceptance-constraint-requirement-4",
+      "source_key": "non_functional_requirements",
+      "source_round": 4,
+      "text": "audit trail"
+    },
+    {
+      "attributes": {
+        "constraint_kind": "non_functional_requirement",
+        "source_requirement_id": "non_functional-requirement-4"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_acceptance_constraints",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "9c5f49ef585cd8db",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "acceptance_constraints",
+      "id": "acceptance-constraint-requirement-5",
+      "missing_fields": [],
+      "name": "Acceptance Constraint 5",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "acceptance-constraint-requirement-5",
+      "source_key": "non_functional_requirements",
+      "source_round": 4,
+      "text": "search"
+    },
+    {
+      "attributes": {
+        "constraint_kind": "non_functional_requirement",
+        "source_requirement_id": "non_functional-requirement-5"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_acceptance_constraints",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "6e001e4c4833adf7",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "acceptance_constraints",
+      "id": "acceptance-constraint-requirement-6",
+      "missing_fields": [],
+      "name": "Acceptance Constraint 6",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "acceptance-constraint-requirement-6",
+      "source_key": "non_functional_requirements",
+      "source_round": 4,
+      "text": "filtering"
+    },
+    {
+      "attributes": {
+        "constraint_kind": "non_functional_requirement",
+        "source_requirement_id": "non_functional-requirement-6"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_acceptance_constraints",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "714fad84b7076d46",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "acceptance_constraints",
+      "id": "acceptance-constraint-requirement-7",
+      "missing_fields": [],
+      "name": "Acceptance Constraint 7",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "acceptance-constraint-requirement-7",
+      "source_key": "non_functional_requirements",
+      "source_round": 4,
+      "text": "performance (regular >1s for web page rendering)"
+    },
+    {
+      "attributes": {
+        "constraint_kind": "non_functional_requirement",
+        "source_requirement_id": "non_functional-requirement-7"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_acceptance_constraints",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "93c0bedbff37f4c7",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "acceptance_constraints",
+      "id": "acceptance-constraint-requirement-8",
+      "missing_fields": [],
+      "name": "Acceptance Constraint 8",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "acceptance-constraint-requirement-8",
+      "source_key": "non_functional_requirements",
+      "source_round": 4,
+      "text": "availability >=99%"
+    },
+    {
+      "attributes": {
+        "constraint_kind": "success_criterion"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_acceptance_constraints",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "f58f7d91234137ac",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "acceptance_constraints",
+      "id": "acceptance-constraint-success-1",
+      "missing_fields": [],
+      "name": "Success Criterion 1",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "acceptance-constraint-success-1",
+      "source_key": "success_criteria",
+      "source_round": 2,
+      "text": "Better planning of IT systems purchasing and life cycle"
+    },
+    {
+      "attributes": {
+        "complexity": "complex"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_3",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "d12ffaeea8ac1e65",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "informative",
+      "family": "actors",
+      "id": "application-owners",
+      "missing_fields": [],
+      "name": "application owners",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "application-owners",
+      "source_key": "actors",
+      "source_round": 3,
+      "text": "application owners"
+    },
+    {
+      "attributes": {
+        "complexity": "complex"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_3",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "84d72a310d252de3",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "informative",
+      "family": "actors",
+      "id": "business-owners",
+      "missing_fields": [],
+      "name": "Business owners",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "business-owners",
+      "source_key": "actors",
+      "source_round": 3,
+      "text": "Business owners"
+    },
+    {
+      "attributes": {
+        "complexity": "complex"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_3",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "f02cd6d546b426cf",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "informative",
+      "family": "actors",
+      "id": "enterprise-architects",
+      "missing_fields": [],
+      "name": "enterprise architects",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "enterprise-architects",
+      "source_key": "actors",
+      "source_round": 3,
+      "text": "enterprise architects"
+    },
+    {
+      "attributes": {
+        "complexity": "average"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_3",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "382f8466b20e4667",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "informative",
+      "family": "actors",
+      "id": "finance",
+      "missing_fields": [],
+      "name": "finance",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "finance",
+      "source_key": "actors",
+      "source_round": 3,
+      "text": "finance"
+    },
+    {
+      "attributes": {
+        "complexity": "average"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_3",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "96320ed7d1c1720c",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "informative",
+      "family": "actors",
+      "id": "integration-system-owners",
+      "missing_fields": [],
+      "name": "integration system owners",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "integration-system-owners",
+      "source_key": "actors",
+      "source_round": 3,
+      "text": "integration system owners"
+    },
+    {
+      "attributes": {
+        "complexity": "average"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_3",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "1e4c525208fa8f46",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "informative",
+      "family": "actors",
+      "id": "procurement",
+      "missing_fields": [],
+      "name": "procurement",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "procurement",
+      "source_key": "actors",
+      "source_round": 3,
+      "text": "procurement"
+    },
+    {
+      "attributes": {
+        "complexity": "average"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_3",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "8b2987df0c86958f",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "informative",
+      "family": "actors",
+      "id": "security",
+      "missing_fields": [],
+      "name": "security",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "security",
+      "source_key": "actors",
+      "source_round": 3,
+      "text": "security"
+    },
+    {
+      "attributes": {
+        "complexity": "complex"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_3",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "d36f7237d6859555",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "informative",
+      "family": "actors",
+      "id": "technical-owners",
+      "missing_fields": [],
+      "name": "technical owners",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "technical-owners",
+      "source_key": "actors",
+      "source_round": 3,
+      "text": "technical owners"
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_5",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "39d0fe629127c7ed",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "business_rules",
+      "id": "business-rule-1",
+      "missing_fields": [],
+      "name": "Rule 1",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "business-rule-1",
+      "source_key": "business_rules",
+      "source_round": 5,
+      "text": "A System must have a business owner before it becomes Active."
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_5",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "68c0c8b8aeec81ca",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "business_rules",
+      "id": "business-rule-2",
+      "missing_fields": [],
+      "name": "Rule 2",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "business-rule-2",
+      "source_key": "business_rules",
+      "source_round": 5,
+      "text": "A System lifecycle state change requires approval for deprecation."
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_5",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "79c6a2ee0ae3e1ec",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "business_rules",
+      "id": "business-rule-3",
+      "missing_fields": [],
+      "name": "Rule 3",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "business-rule-3",
+      "source_key": "business_rules",
+      "source_round": 5,
+      "text": "A System must record vendor and contract dates."
+    },
+    {
+      "attributes": {
+        "component_kind": "component"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_7",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "cc52e8a061d76cd0",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "informative",
+      "family": "components",
+      "id": "component-reporting-consumers",
+      "missing_fields": [],
+      "name": "Reporting Consumers",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "component-reporting-consumers",
+      "source_key": "components_and_services",
+      "source_round": 7,
+      "text": "Reporting Consumers"
+    },
+    {
+      "attributes": {
+        "component_kind": "api"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_7",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "3a1c7a77493fbaf6",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "informative",
+      "family": "components",
+      "id": "component-system-inventory-api",
+      "missing_fields": [],
+      "name": "System Inventory API",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "component-system-inventory-api",
+      "source_key": "components_and_services",
+      "source_round": 7,
+      "text": "System Inventory API"
+    },
+    {
+      "attributes": {
+        "component_kind": "application"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_7",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "7270b4d71f732879",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "informative",
+      "family": "components",
+      "id": "component-system-inventory-web-app",
+      "missing_fields": [],
+      "name": "System Inventory Web App",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "component-system-inventory-web-app",
+      "source_key": "components_and_services",
+      "source_round": 7,
+      "text": "System Inventory Web App"
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_5",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "09258b7496344799",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "domain_entities",
+      "id": "entity-capability",
+      "missing_fields": [],
+      "name": "Capability",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "entity-capability",
+      "source_key": "domain_entities",
+      "source_round": 5,
+      "text": "Capability"
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_5",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "d5474b4336ad506b",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "domain_entities",
+      "id": "entity-contract",
+      "missing_fields": [],
+      "name": "Contract",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "entity-contract",
+      "source_key": "domain_entities",
+      "source_round": 5,
+      "text": "Contract"
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_5",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "1c046a800433e10b",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "domain_entities",
+      "id": "entity-cost-record",
+      "missing_fields": [],
+      "name": "Cost Record",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "entity-cost-record",
+      "source_key": "domain_entities",
+      "source_round": 5,
+      "text": "Cost Record"
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_5",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "eb58d30f221513d9",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "domain_entities",
+      "id": "entity-integration",
+      "missing_fields": [],
+      "name": "Integration",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "entity-integration",
+      "source_key": "domain_entities",
+      "source_round": 5,
+      "text": "Integration"
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_5",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "a57ef4a16cb94f26",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "domain_entities",
+      "id": "entity-risk-assessment",
+      "missing_fields": [],
+      "name": "Risk Assessment",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "entity-risk-assessment",
+      "source_key": "domain_entities",
+      "source_round": 5,
+      "text": "Risk Assessment"
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_5",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "1577db3f693c63c0",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "domain_entities",
+      "id": "entity-system",
+      "missing_fields": [],
+      "name": "System",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "entity-system",
+      "source_key": "domain_entities",
+      "source_round": 5,
+      "text": "System"
+    },
+    {
+      "attributes": {
+        "scope_entity_ids": [
+          "entity-system"
+        ],
+        "source_business_rule_id": "business-rule-1"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_domain_invariants",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "a0838e2d92556587",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "domain_invariants",
+      "id": "domain-invariant-1",
+      "missing_fields": [],
+      "name": "Rule 1",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "domain-invariant-1",
+      "source_key": "business_rules",
+      "source_round": 5,
+      "text": "A System must have a business owner before it becomes Active."
+    },
+    {
+      "attributes": {
+        "scope_entity_ids": [
+          "entity-system"
+        ],
+        "source_business_rule_id": "business-rule-2"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_domain_invariants",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "0faa9d909ed4effe",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "domain_invariants",
+      "id": "domain-invariant-2",
+      "missing_fields": [],
+      "name": "Rule 2",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "domain-invariant-2",
+      "source_key": "business_rules",
+      "source_round": 5,
+      "text": "A System lifecycle state change requires approval for deprecation."
+    },
+    {
+      "attributes": {
+        "scope_entity_ids": [
+          "entity-system",
+          "entity-contract"
+        ],
+        "source_business_rule_id": "business-rule-3"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_domain_invariants",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "ae58a8512d9d5819",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "domain_invariants",
+      "id": "domain-invariant-3",
+      "missing_fields": [],
+      "name": "Rule 3",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "domain-invariant-3",
+      "source_key": "business_rules",
+      "source_round": 5,
+      "text": "A System must record vendor and contract dates."
+    },
+    {
+      "attributes": {
+        "requirement_kind": "functional"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "requirements",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "b817426cb7205235",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "functional_requirements",
+      "id": "functional-requirement-1",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "functional-requirement-1",
+      "source_key": "workflow_scope",
+      "source_round": 4,
+      "text": "Yes business processes like stage gates and approval states must be supported"
+    },
+    {
+      "attributes": {
+        "requirement_kind": "functional"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "requirements",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "139e2490d0d43a69",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "functional_requirements",
+      "id": "functional-requirement-1",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "functional-requirement-1",
+      "source_key": "integrations",
+      "source_round": 3,
+      "text": "I think this will be the CMDB for IT Applications/systems - we need to be able to export data to various system for reporting."
+    },
+    {
+      "attributes": {
+        "source_trigger_id": "trigger-1"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_guard_conditions",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "065fe600e6dfe1f2",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "guard_conditions",
+      "id": "guard-condition-1",
+      "missing_fields": [
+        "related_transition_ids"
+      ],
+      "name": "Deprecation approval",
+      "normative_ready": false,
+      "readiness_status": "blocked",
+      "semantic_id": "guard-condition-1",
+      "source_key": "triggers_and_approvals",
+      "source_round": 6,
+      "text": "Deprecation approval requires enterprise architect review"
+    },
+    {
+      "attributes": {
+        "source_trigger_id": "trigger-2"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_guard_conditions",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "bed0aa2ab2818dc4",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "guard_conditions",
+      "id": "guard-condition-2",
+      "missing_fields": [
+        "related_transition_ids"
+      ],
+      "name": "Contract expiry",
+      "normative_ready": false,
+      "readiness_status": "blocked",
+      "semantic_id": "guard-condition-2",
+      "source_key": "triggers_and_approvals",
+      "source_round": 6,
+      "text": "Contract expiry triggers lifecycle review"
+    },
+    {
+      "attributes": {
+        "interaction_verb": "calls",
+        "source_component_id": "component-system-inventory-web-app",
+        "target_component_id": "component-system-inventory-api"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_7",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "69a03a26d6ed27f2",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "informative",
+      "family": "interfaces",
+      "id": "interface-1",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "interface-1",
+      "source_key": "interfaces_and_integrations",
+      "source_round": 7,
+      "text": "System Inventory Web App calls System Inventory API"
+    },
+    {
+      "attributes": {
+        "interaction_verb": "sends",
+        "source_component_id": "component-system-inventory-api",
+        "target_component_id": "component-reporting-consumers"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_7",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "44e4a4a42d3319ec",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "informative",
+      "family": "interfaces",
+      "id": "interface-2",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "interface-2",
+      "source_key": "interfaces_and_integrations",
+      "source_round": 7,
+      "text": "System Inventory API sends Reporting Consumers"
+    },
+    {
+      "attributes": {
+        "requirement_kind": "non_functional"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "requirements",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "35140189626f3690",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "non_functional_requirements",
+      "id": "non_functional-requirement-1",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "non_functional-requirement-1",
+      "source_key": "constraints",
+      "source_round": 2,
+      "text": "UI must be web based"
+    },
+    {
+      "attributes": {
+        "requirement_kind": "non_functional"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "requirements",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "a8315094eda0a9ee",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "non_functional_requirements",
+      "id": "non_functional-requirement-1",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "non_functional-requirement-1",
+      "source_key": "non_functional_requirements",
+      "source_round": 4,
+      "text": "SSO"
+    },
+    {
+      "attributes": {
+        "requirement_kind": "non_functional"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "requirements",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "653fcfd7e5d0f72d",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "non_functional_requirements",
+      "id": "non_functional-requirement-2",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "non_functional-requirement-2",
+      "source_key": "non_functional_requirements",
+      "source_round": 4,
+      "text": "role-based access"
+    },
+    {
+      "attributes": {
+        "requirement_kind": "non_functional"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "requirements",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "1e1efba12799e966",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "non_functional_requirements",
+      "id": "non_functional-requirement-3",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "non_functional-requirement-3",
+      "source_key": "non_functional_requirements",
+      "source_round": 4,
+      "text": "audit trail"
+    },
+    {
+      "attributes": {
+        "requirement_kind": "non_functional"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "requirements",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "e4dde9ea3c5c65ff",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "non_functional_requirements",
+      "id": "non_functional-requirement-4",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "non_functional-requirement-4",
+      "source_key": "non_functional_requirements",
+      "source_round": 4,
+      "text": "search"
+    },
+    {
+      "attributes": {
+        "requirement_kind": "non_functional"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "requirements",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "2da660a4b12b3c4f",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "non_functional_requirements",
+      "id": "non_functional-requirement-5",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "non_functional-requirement-5",
+      "source_key": "non_functional_requirements",
+      "source_round": 4,
+      "text": "filtering"
+    },
+    {
+      "attributes": {
+        "requirement_kind": "non_functional"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "requirements",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "2425258393a5de78",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "non_functional_requirements",
+      "id": "non_functional-requirement-6",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "non_functional-requirement-6",
+      "source_key": "non_functional_requirements",
+      "source_round": 4,
+      "text": "performance (regular >1s for web page rendering)"
+    },
+    {
+      "attributes": {
+        "requirement_kind": "non_functional"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "requirements",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "a77d5256a7d4bfcb",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "non_functional_requirements",
+      "id": "non_functional-requirement-7",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "non_functional-requirement-7",
+      "source_key": "non_functional_requirements",
+      "source_round": 4,
+      "text": "availability >=99%"
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_5",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "00b251588522b7b6",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "relationships",
+      "id": "relationship-1",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "relationship-1",
+      "source_key": "relationships",
+      "source_round": 5,
+      "text": "A System has one Business Owner"
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_5",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "360538e5dcd99cae",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "relationships",
+      "id": "relationship-2",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "relationship-2",
+      "source_key": "relationships",
+      "source_round": 5,
+      "text": "A System has one Technical Owner"
+    },
+    {
+      "attributes": {
+        "source_entity_id": "entity-system",
+        "target_entity_id": "entity-integration"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_5",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "934f71080e23519e",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "relationships",
+      "id": "relationship-3",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "relationship-3",
+      "source_key": "relationships",
+      "source_round": 5,
+      "text": "A System has many Integrations"
+    },
+    {
+      "attributes": {
+        "source_entity_id": "entity-system"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_5",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "ab39194c2a6358f7",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "relationships",
+      "id": "relationship-4",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "relationship-4",
+      "source_key": "relationships",
+      "source_round": 5,
+      "text": "A System has many Capabilities"
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_5",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "805991d9f16d4aa5",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "relationships",
+      "id": "relationship-5",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "relationship-5",
+      "source_key": "relationships",
+      "source_round": 5,
+      "text": "A System has one Contract"
+    },
+    {
+      "attributes": {
+        "source_entity_id": "entity-system",
+        "target_entity_id": "entity-risk-assessment"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_5",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "fa8309800cc5f504",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "relationships",
+      "id": "relationship-6",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "relationship-6",
+      "source_key": "relationships",
+      "source_round": 5,
+      "text": "A System has many Risk Assessments"
+    },
+    {
+      "attributes": {
+        "source_entity_id": "entity-system",
+        "target_entity_id": "entity-cost-record"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_5",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "ec019fec6642681e",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "relationships",
+      "id": "relationship-7",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "relationship-7",
+      "source_key": "relationships",
+      "source_round": 5,
+      "text": "A System has many Cost Records"
+    },
+    {
+      "attributes": {
+        "boundary_type": "runtime_separation"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_7",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "c7d34ba59a95bc4d",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "informative",
+      "family": "runtime_boundaries",
+      "id": "runtime-boundary-1",
+      "missing_fields": [],
+      "name": "Runtime Boundary 1",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "runtime-boundary-1",
+      "source_key": "runtime_boundaries",
+      "source_round": 7,
+      "text": "System Inventory API runs separately from the UI"
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_6",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "87ced495451bbf64",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "state_entities",
+      "id": "state-entity-system",
+      "missing_fields": [],
+      "name": "System",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "state-entity-system",
+      "source_key": "state_entities",
+      "source_round": 6,
+      "text": "System"
+    },
+    {
+      "attributes": {
+        "source_business_rule_id": "business-rule-1",
+        "state_entity_ids": [
+          "state-entity-system"
+        ]
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_state_invariants",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "e99d374908167c66",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "state_invariants",
+      "id": "state-invariant-1",
+      "missing_fields": [],
+      "name": "Rule 1",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "state-invariant-1",
+      "source_key": "business_rules",
+      "source_round": 5,
+      "text": "A System must have a business owner before it becomes Active."
+    },
+    {
+      "attributes": {
+        "source_business_rule_id": "business-rule-2",
+        "state_entity_ids": [
+          "state-entity-system"
+        ]
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_state_invariants",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "d3f0734ba4f5d238",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "state_invariants",
+      "id": "state-invariant-2",
+      "missing_fields": [],
+      "name": "Rule 2",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "state-invariant-2",
+      "source_key": "business_rules",
+      "source_round": 5,
+      "text": "A System lifecycle state change requires approval for deprecation."
+    },
+    {
+      "attributes": {
+        "source_business_rule_id": "business-rule-3",
+        "state_entity_ids": [
+          "state-entity-system"
+        ]
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_state_invariants",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "86c22df4bc630d1b",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "state_invariants",
+      "id": "state-invariant-3",
+      "missing_fields": [],
+      "name": "Rule 3",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "state-invariant-3",
+      "source_key": "business_rules",
+      "source_round": 5,
+      "text": "A System must record vendor and contract dates."
+    },
+    {
+      "attributes": {
+        "from_state": "Proposed",
+        "state_entity_id": "state-entity-system",
+        "to_state": "Active"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_6",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "79c9acbe984baf73",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "state_transitions",
+      "id": "state-transition-1",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "state-transition-1",
+      "source_key": "states_and_transitions",
+      "source_round": 6,
+      "text": "System: Proposed -> Active -> Retiring -> Retired"
+    },
+    {
+      "attributes": {
+        "from_state": "Active",
+        "state_entity_id": "state-entity-system",
+        "to_state": "Retiring"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_6",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "105b7f94b43109c5",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "state_transitions",
+      "id": "state-transition-2",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "state-transition-2",
+      "source_key": "states_and_transitions",
+      "source_round": 6,
+      "text": "System: Proposed -> Active -> Retiring -> Retired"
+    },
+    {
+      "attributes": {
+        "from_state": "Retiring",
+        "state_entity_id": "state-entity-system",
+        "to_state": "Retired"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_6",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "3f1c2199aa90c5fa",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "state_transitions",
+      "id": "state-transition-3",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "state-transition-3",
+      "source_key": "states_and_transitions",
+      "source_round": 6,
+      "text": "System: Proposed -> Active -> Retiring -> Retired"
+    },
+    {
+      "attributes": {
+        "from_state": "Active",
+        "state_entity_id": "state-entity-system",
+        "to_state": "Deprecated"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_6",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "e6ebcb7b94af23fb",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "state_transitions",
+      "id": "state-transition-4",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "state-transition-4",
+      "source_key": "states_and_transitions",
+      "source_round": 6,
+      "text": "System: Active -> Deprecated"
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_6",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "abe96f51c19ab7b3",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "triggers",
+      "id": "trigger-1",
+      "missing_fields": [],
+      "name": "Deprecation approval",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "trigger-1",
+      "source_key": "triggers_and_approvals",
+      "source_round": 6,
+      "text": "Deprecation approval requires enterprise architect review"
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_6",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "42de2ee3bbe7dfa8",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "triggers",
+      "id": "trigger-2",
+      "missing_fields": [],
+      "name": "Contract expiry",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "trigger-2",
+      "source_key": "triggers_and_approvals",
+      "source_round": 6,
+      "text": "Contract expiry triggers lifecycle review"
+    },
+    {
+      "attributes": {
+        "complexity": "average"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_3",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "1bc75c3cb13f6dc9",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_cases",
+      "id": "approve-deprecation",
+      "missing_fields": [
+        "main_success_scenario"
+      ],
+      "name": "approve deprecation",
+      "normative_ready": false,
+      "readiness_status": "blocked",
+      "semantic_id": "approve-deprecation",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "approve deprecation"
+    },
+    {
+      "attributes": {
+        "complexity": "average"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_3",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "97a5cb95cc045fb5",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_cases",
+      "id": "compare-overlapping-systems",
+      "missing_fields": [
+        "main_success_scenario"
+      ],
+      "name": "compare overlapping systems",
+      "normative_ready": false,
+      "readiness_status": "blocked",
+      "semantic_id": "compare-overlapping-systems",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "compare overlapping systems"
+    },
+    {
+      "attributes": {
+        "complexity": "simple"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_3",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "49b57b797dfb65d8",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_cases",
+      "id": "edit-metadata",
+      "missing_fields": [
+        "main_success_scenario"
+      ],
+      "name": "edit metadata",
+      "normative_ready": false,
+      "readiness_status": "blocked",
+      "semantic_id": "edit-metadata",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "edit metadata"
+    },
+    {
+      "attributes": {
+        "complexity": "average"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_3",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "d145a19075179f4d",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_cases",
+      "id": "register-a-system",
+      "missing_fields": [
+        "main_success_scenario"
+      ],
+      "name": "Register a system",
+      "normative_ready": false,
+      "readiness_status": "blocked",
+      "semantic_id": "register-a-system",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "Register a system"
+    },
+    {
+      "attributes": {
+        "complexity": "average"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_3",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "073a5935f13208c1",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_cases",
+      "id": "report-portfolio-gaps",
+      "missing_fields": [
+        "main_success_scenario"
+      ],
+      "name": "report portfolio gaps",
+      "normative_ready": false,
+      "readiness_status": "blocked",
+      "semantic_id": "report-portfolio-gaps",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "report portfolio gaps"
+    },
+    {
+      "attributes": {
+        "complexity": "simple"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_3",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "c5b1951eeada9174",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_cases",
+      "id": "review-risks",
+      "missing_fields": [
+        "main_success_scenario"
+      ],
+      "name": "review risks",
+      "normative_ready": false,
+      "readiness_status": "blocked",
+      "semantic_id": "review-risks",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "review risks"
+    },
+    {
+      "attributes": {
+        "complexity": "simple"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_3",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "6373ef70fd6e12c5",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_cases",
+      "id": "see-costs",
+      "missing_fields": [
+        "main_success_scenario"
+      ],
+      "name": "see costs",
+      "normative_ready": false,
+      "readiness_status": "blocked",
+      "semantic_id": "see-costs",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "see costs"
+    },
+    {
+      "attributes": {
+        "complexity": "average"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_3",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "6077961c843c1a2e",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_cases",
+      "id": "track-lifecycle-state",
+      "missing_fields": [
+        "main_success_scenario"
+      ],
+      "name": "track lifecycle state",
+      "normative_ready": false,
+      "readiness_status": "blocked",
+      "semantic_id": "track-lifecycle-state",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "track lifecycle state"
+    }
+  ],
+  "export_metadata": {
+    "export_kind": "speckify_planning_export",
+    "schema_version": 1,
+    "source_model_change_metadata": {
+      "change_source": "normalize_replay_to_model",
+      "last_changed_at": "",
+      "regenerated_from_version": "",
+      "semantic_hash": "2f3ec68a35e9678e",
+      "semantic_version": 1,
+      "supersedes": []
+    },
+    "source_model_semantic_id": "rupify-model"
+  },
+  "ready_normative_elements": [
+    {
+      "attributes": {
+        "constraint_kind": "non_functional_requirement",
+        "source_requirement_id": "non_functional-requirement-1"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_acceptance_constraints",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "926a0e8b7f0d0604",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "acceptance_constraints",
+      "id": "acceptance-constraint-requirement-1",
+      "missing_fields": [],
+      "name": "Acceptance Constraint 1",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "acceptance-constraint-requirement-1",
+      "source_key": "constraints",
+      "source_round": 2,
+      "text": "UI must be web based"
+    },
+    {
+      "attributes": {
+        "constraint_kind": "non_functional_requirement",
+        "source_requirement_id": "non_functional-requirement-1"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_acceptance_constraints",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "ea270a270fd5ae0a",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "acceptance_constraints",
+      "id": "acceptance-constraint-requirement-2",
+      "missing_fields": [],
+      "name": "Acceptance Constraint 2",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "acceptance-constraint-requirement-2",
+      "source_key": "non_functional_requirements",
+      "source_round": 4,
+      "text": "SSO"
+    },
+    {
+      "attributes": {
+        "constraint_kind": "non_functional_requirement",
+        "source_requirement_id": "non_functional-requirement-2"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_acceptance_constraints",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "cc94e38b4882a356",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "acceptance_constraints",
+      "id": "acceptance-constraint-requirement-3",
+      "missing_fields": [],
+      "name": "Acceptance Constraint 3",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "acceptance-constraint-requirement-3",
+      "source_key": "non_functional_requirements",
+      "source_round": 4,
+      "text": "role-based access"
+    },
+    {
+      "attributes": {
+        "constraint_kind": "non_functional_requirement",
+        "source_requirement_id": "non_functional-requirement-3"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_acceptance_constraints",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "e3b5c94d9e1c0566",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "acceptance_constraints",
+      "id": "acceptance-constraint-requirement-4",
+      "missing_fields": [],
+      "name": "Acceptance Constraint 4",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "acceptance-constraint-requirement-4",
+      "source_key": "non_functional_requirements",
+      "source_round": 4,
+      "text": "audit trail"
+    },
+    {
+      "attributes": {
+        "constraint_kind": "non_functional_requirement",
+        "source_requirement_id": "non_functional-requirement-4"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_acceptance_constraints",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "9c5f49ef585cd8db",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "acceptance_constraints",
+      "id": "acceptance-constraint-requirement-5",
+      "missing_fields": [],
+      "name": "Acceptance Constraint 5",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "acceptance-constraint-requirement-5",
+      "source_key": "non_functional_requirements",
+      "source_round": 4,
+      "text": "search"
+    },
+    {
+      "attributes": {
+        "constraint_kind": "non_functional_requirement",
+        "source_requirement_id": "non_functional-requirement-5"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_acceptance_constraints",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "6e001e4c4833adf7",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "acceptance_constraints",
+      "id": "acceptance-constraint-requirement-6",
+      "missing_fields": [],
+      "name": "Acceptance Constraint 6",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "acceptance-constraint-requirement-6",
+      "source_key": "non_functional_requirements",
+      "source_round": 4,
+      "text": "filtering"
+    },
+    {
+      "attributes": {
+        "constraint_kind": "non_functional_requirement",
+        "source_requirement_id": "non_functional-requirement-6"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_acceptance_constraints",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "714fad84b7076d46",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "acceptance_constraints",
+      "id": "acceptance-constraint-requirement-7",
+      "missing_fields": [],
+      "name": "Acceptance Constraint 7",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "acceptance-constraint-requirement-7",
+      "source_key": "non_functional_requirements",
+      "source_round": 4,
+      "text": "performance (regular >1s for web page rendering)"
+    },
+    {
+      "attributes": {
+        "constraint_kind": "non_functional_requirement",
+        "source_requirement_id": "non_functional-requirement-7"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_acceptance_constraints",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "93c0bedbff37f4c7",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "acceptance_constraints",
+      "id": "acceptance-constraint-requirement-8",
+      "missing_fields": [],
+      "name": "Acceptance Constraint 8",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "acceptance-constraint-requirement-8",
+      "source_key": "non_functional_requirements",
+      "source_round": 4,
+      "text": "availability >=99%"
+    },
+    {
+      "attributes": {
+        "constraint_kind": "success_criterion"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_acceptance_constraints",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "f58f7d91234137ac",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "acceptance_constraints",
+      "id": "acceptance-constraint-success-1",
+      "missing_fields": [],
+      "name": "Success Criterion 1",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "acceptance-constraint-success-1",
+      "source_key": "success_criteria",
+      "source_round": 2,
+      "text": "Better planning of IT systems purchasing and life cycle"
+    },
+    {
+      "attributes": {
+        "scope_entity_ids": [
+          "entity-system"
+        ],
+        "source_business_rule_id": "business-rule-1"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_domain_invariants",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "a0838e2d92556587",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "domain_invariants",
+      "id": "domain-invariant-1",
+      "missing_fields": [],
+      "name": "Rule 1",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "domain-invariant-1",
+      "source_key": "business_rules",
+      "source_round": 5,
+      "text": "A System must have a business owner before it becomes Active."
+    },
+    {
+      "attributes": {
+        "scope_entity_ids": [
+          "entity-system"
+        ],
+        "source_business_rule_id": "business-rule-2"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_domain_invariants",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "0faa9d909ed4effe",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "domain_invariants",
+      "id": "domain-invariant-2",
+      "missing_fields": [],
+      "name": "Rule 2",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "domain-invariant-2",
+      "source_key": "business_rules",
+      "source_round": 5,
+      "text": "A System lifecycle state change requires approval for deprecation."
+    },
+    {
+      "attributes": {
+        "scope_entity_ids": [
+          "entity-system",
+          "entity-contract"
+        ],
+        "source_business_rule_id": "business-rule-3"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_domain_invariants",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "ae58a8512d9d5819",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "domain_invariants",
+      "id": "domain-invariant-3",
+      "missing_fields": [],
+      "name": "Rule 3",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "domain-invariant-3",
+      "source_key": "business_rules",
+      "source_round": 5,
+      "text": "A System must record vendor and contract dates."
+    },
+    {
+      "attributes": {
+        "requirement_kind": "functional"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "requirements",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "b817426cb7205235",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "functional_requirements",
+      "id": "functional-requirement-1",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "functional-requirement-1",
+      "source_key": "workflow_scope",
+      "source_round": 4,
+      "text": "Yes business processes like stage gates and approval states must be supported"
+    },
+    {
+      "attributes": {
+        "requirement_kind": "functional"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "requirements",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "139e2490d0d43a69",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "functional_requirements",
+      "id": "functional-requirement-1",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "functional-requirement-1",
+      "source_key": "integrations",
+      "source_round": 3,
+      "text": "I think this will be the CMDB for IT Applications/systems - we need to be able to export data to various system for reporting."
+    },
+    {
+      "attributes": {
+        "requirement_kind": "non_functional"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "requirements",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "35140189626f3690",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "non_functional_requirements",
+      "id": "non_functional-requirement-1",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "non_functional-requirement-1",
+      "source_key": "constraints",
+      "source_round": 2,
+      "text": "UI must be web based"
+    },
+    {
+      "attributes": {
+        "requirement_kind": "non_functional"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "requirements",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "a8315094eda0a9ee",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "non_functional_requirements",
+      "id": "non_functional-requirement-1",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "non_functional-requirement-1",
+      "source_key": "non_functional_requirements",
+      "source_round": 4,
+      "text": "SSO"
+    },
+    {
+      "attributes": {
+        "requirement_kind": "non_functional"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "requirements",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "653fcfd7e5d0f72d",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "non_functional_requirements",
+      "id": "non_functional-requirement-2",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "non_functional-requirement-2",
+      "source_key": "non_functional_requirements",
+      "source_round": 4,
+      "text": "role-based access"
+    },
+    {
+      "attributes": {
+        "requirement_kind": "non_functional"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "requirements",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "1e1efba12799e966",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "non_functional_requirements",
+      "id": "non_functional-requirement-3",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "non_functional-requirement-3",
+      "source_key": "non_functional_requirements",
+      "source_round": 4,
+      "text": "audit trail"
+    },
+    {
+      "attributes": {
+        "requirement_kind": "non_functional"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "requirements",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "e4dde9ea3c5c65ff",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "non_functional_requirements",
+      "id": "non_functional-requirement-4",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "non_functional-requirement-4",
+      "source_key": "non_functional_requirements",
+      "source_round": 4,
+      "text": "search"
+    },
+    {
+      "attributes": {
+        "requirement_kind": "non_functional"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "requirements",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "2da660a4b12b3c4f",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "non_functional_requirements",
+      "id": "non_functional-requirement-5",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "non_functional-requirement-5",
+      "source_key": "non_functional_requirements",
+      "source_round": 4,
+      "text": "filtering"
+    },
+    {
+      "attributes": {
+        "requirement_kind": "non_functional"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "requirements",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "2425258393a5de78",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "non_functional_requirements",
+      "id": "non_functional-requirement-6",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "non_functional-requirement-6",
+      "source_key": "non_functional_requirements",
+      "source_round": 4,
+      "text": "performance (regular >1s for web page rendering)"
+    },
+    {
+      "attributes": {
+        "requirement_kind": "non_functional"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "requirements",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "a77d5256a7d4bfcb",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "non_functional_requirements",
+      "id": "non_functional-requirement-7",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "non_functional-requirement-7",
+      "source_key": "non_functional_requirements",
+      "source_round": 4,
+      "text": "availability >=99%"
+    },
+    {
+      "attributes": {
+        "source_business_rule_id": "business-rule-1",
+        "state_entity_ids": [
+          "state-entity-system"
+        ]
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_state_invariants",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "e99d374908167c66",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "state_invariants",
+      "id": "state-invariant-1",
+      "missing_fields": [],
+      "name": "Rule 1",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "state-invariant-1",
+      "source_key": "business_rules",
+      "source_round": 5,
+      "text": "A System must have a business owner before it becomes Active."
+    },
+    {
+      "attributes": {
+        "source_business_rule_id": "business-rule-2",
+        "state_entity_ids": [
+          "state-entity-system"
+        ]
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_state_invariants",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "d3f0734ba4f5d238",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "state_invariants",
+      "id": "state-invariant-2",
+      "missing_fields": [],
+      "name": "Rule 2",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "state-invariant-2",
+      "source_key": "business_rules",
+      "source_round": 5,
+      "text": "A System lifecycle state change requires approval for deprecation."
+    },
+    {
+      "attributes": {
+        "source_business_rule_id": "business-rule-3",
+        "state_entity_ids": [
+          "state-entity-system"
+        ]
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_state_invariants",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "86c22df4bc630d1b",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "state_invariants",
+      "id": "state-invariant-3",
+      "missing_fields": [],
+      "name": "Rule 3",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "state-invariant-3",
+      "source_key": "business_rules",
+      "source_round": 5,
+      "text": "A System must record vendor and contract dates."
+    },
+    {
+      "attributes": {
+        "from_state": "Proposed",
+        "state_entity_id": "state-entity-system",
+        "to_state": "Active"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_6",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "79c9acbe984baf73",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "state_transitions",
+      "id": "state-transition-1",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "state-transition-1",
+      "source_key": "states_and_transitions",
+      "source_round": 6,
+      "text": "System: Proposed -> Active -> Retiring -> Retired"
+    },
+    {
+      "attributes": {
+        "from_state": "Active",
+        "state_entity_id": "state-entity-system",
+        "to_state": "Retiring"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_6",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "105b7f94b43109c5",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "state_transitions",
+      "id": "state-transition-2",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "state-transition-2",
+      "source_key": "states_and_transitions",
+      "source_round": 6,
+      "text": "System: Proposed -> Active -> Retiring -> Retired"
+    },
+    {
+      "attributes": {
+        "from_state": "Retiring",
+        "state_entity_id": "state-entity-system",
+        "to_state": "Retired"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_6",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "3f1c2199aa90c5fa",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "state_transitions",
+      "id": "state-transition-3",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "state-transition-3",
+      "source_key": "states_and_transitions",
+      "source_round": 6,
+      "text": "System: Proposed -> Active -> Retiring -> Retired"
+    },
+    {
+      "attributes": {
+        "from_state": "Active",
+        "state_entity_id": "state-entity-system",
+        "to_state": "Deprecated"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_6",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "e6ebcb7b94af23fb",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "state_transitions",
+      "id": "state-transition-4",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "state-transition-4",
+      "source_key": "states_and_transitions",
+      "source_round": 6,
+      "text": "System: Active -> Deprecated"
+    }
+  ],
+  "summary": {
+    "blocking_ambiguity_count": 0,
+    "blocking_ambiguity_ids": [],
+    "element_count": 72,
+    "partial_or_blocked_normative_ids": [
+      "business-rule-1",
+      "business-rule-2",
+      "business-rule-3",
+      "entity-capability",
+      "entity-contract",
+      "entity-cost-record",
+      "entity-integration",
+      "entity-risk-assessment",
+      "entity-system",
+      "guard-condition-1",
+      "guard-condition-2",
+      "relationship-1",
+      "relationship-2",
+      "relationship-3",
+      "relationship-4",
+      "relationship-5",
+      "relationship-6",
+      "relationship-7",
+      "state-entity-system",
+      "trigger-1",
+      "trigger-2",
+      "approve-deprecation",
+      "compare-overlapping-systems",
+      "edit-metadata",
+      "register-a-system",
+      "report-portfolio-gaps",
+      "review-risks",
+      "see-costs",
+      "track-lifecycle-state"
+    ],
+    "ready_normative_count": 29,
+    "ready_normative_ids": [
+      "acceptance-constraint-requirement-1",
+      "acceptance-constraint-requirement-2",
+      "acceptance-constraint-requirement-3",
+      "acceptance-constraint-requirement-4",
+      "acceptance-constraint-requirement-5",
+      "acceptance-constraint-requirement-6",
+      "acceptance-constraint-requirement-7",
+      "acceptance-constraint-requirement-8",
+      "acceptance-constraint-success-1",
+      "domain-invariant-1",
+      "domain-invariant-2",
+      "domain-invariant-3",
+      "functional-requirement-1",
+      "functional-requirement-1",
+      "non_functional-requirement-1",
+      "non_functional-requirement-1",
+      "non_functional-requirement-2",
+      "non_functional-requirement-3",
+      "non_functional-requirement-4",
+      "non_functional-requirement-5",
+      "non_functional-requirement-6",
+      "non_functional-requirement-7",
+      "state-invariant-1",
+      "state-invariant-2",
+      "state-invariant-3",
+      "state-transition-1",
+      "state-transition-2",
+      "state-transition-3",
+      "state-transition-4"
+    ],
+    "trace_link_count": 127
+  },
+  "trace_links": [
+    {
+      "artifact_section": "",
+      "basis": "acceptance constraint is derived from canonical requirement",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "f499408c812a5b1f",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "acceptance_constraint_to_requirement",
+      "from_id": "acceptance-constraint-requirement-1",
+      "id": "trace-acceptance-constraint-requirement-1",
+      "link_type": "acceptance_constraint_to_requirement",
+      "semantic_id": "trace-acceptance-constraint-requirement-1",
+      "to_artifact": "",
+      "to_id": "non_functional-requirement-1"
+    },
+    {
+      "artifact_section": "",
+      "basis": "acceptance constraint is derived from canonical requirement",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "7f685b8d92b945df",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "acceptance_constraint_to_requirement",
+      "from_id": "acceptance-constraint-requirement-2",
+      "id": "trace-acceptance-constraint-requirement-2",
+      "link_type": "acceptance_constraint_to_requirement",
+      "semantic_id": "trace-acceptance-constraint-requirement-2",
+      "to_artifact": "",
+      "to_id": "non_functional-requirement-1"
+    },
+    {
+      "artifact_section": "",
+      "basis": "acceptance constraint is derived from canonical requirement",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "649c3fbca5601731",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "acceptance_constraint_to_requirement",
+      "from_id": "acceptance-constraint-requirement-3",
+      "id": "trace-acceptance-constraint-requirement-3",
+      "link_type": "acceptance_constraint_to_requirement",
+      "semantic_id": "trace-acceptance-constraint-requirement-3",
+      "to_artifact": "",
+      "to_id": "non_functional-requirement-2"
+    },
+    {
+      "artifact_section": "",
+      "basis": "acceptance constraint is derived from canonical requirement",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "91ac10d7368a9a9f",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "acceptance_constraint_to_requirement",
+      "from_id": "acceptance-constraint-requirement-4",
+      "id": "trace-acceptance-constraint-requirement-4",
+      "link_type": "acceptance_constraint_to_requirement",
+      "semantic_id": "trace-acceptance-constraint-requirement-4",
+      "to_artifact": "",
+      "to_id": "non_functional-requirement-3"
+    },
+    {
+      "artifact_section": "",
+      "basis": "acceptance constraint is derived from canonical requirement",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "a099510c537d1d22",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "acceptance_constraint_to_requirement",
+      "from_id": "acceptance-constraint-requirement-5",
+      "id": "trace-acceptance-constraint-requirement-5",
+      "link_type": "acceptance_constraint_to_requirement",
+      "semantic_id": "trace-acceptance-constraint-requirement-5",
+      "to_artifact": "",
+      "to_id": "non_functional-requirement-4"
+    },
+    {
+      "artifact_section": "",
+      "basis": "acceptance constraint is derived from canonical requirement",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "c37c99b080232b78",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "acceptance_constraint_to_requirement",
+      "from_id": "acceptance-constraint-requirement-6",
+      "id": "trace-acceptance-constraint-requirement-6",
+      "link_type": "acceptance_constraint_to_requirement",
+      "semantic_id": "trace-acceptance-constraint-requirement-6",
+      "to_artifact": "",
+      "to_id": "non_functional-requirement-5"
+    },
+    {
+      "artifact_section": "",
+      "basis": "acceptance constraint is derived from canonical requirement",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "c91c61b275d7fab9",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "acceptance_constraint_to_requirement",
+      "from_id": "acceptance-constraint-requirement-7",
+      "id": "trace-acceptance-constraint-requirement-7",
+      "link_type": "acceptance_constraint_to_requirement",
+      "semantic_id": "trace-acceptance-constraint-requirement-7",
+      "to_artifact": "",
+      "to_id": "non_functional-requirement-6"
+    },
+    {
+      "artifact_section": "",
+      "basis": "acceptance constraint is derived from canonical requirement",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "f1b8057e436d3a6c",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "acceptance_constraint_to_requirement",
+      "from_id": "acceptance-constraint-requirement-8",
+      "id": "trace-acceptance-constraint-requirement-8",
+      "link_type": "acceptance_constraint_to_requirement",
+      "semantic_id": "trace-acceptance-constraint-requirement-8",
+      "to_artifact": "",
+      "to_id": "non_functional-requirement-7"
+    },
+    {
+      "artifact_section": "",
+      "basis": "design component name references analysis object name",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "4bb19f288d292010",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "analysis_to_design",
+      "from_id": "entity-system",
+      "id": "trace-analysis-design-1",
+      "link_type": "analysis_to_design",
+      "semantic_id": "trace-analysis-design-1",
+      "to_artifact": "",
+      "to_id": "component-system-inventory-web-app"
+    },
+    {
+      "artifact_section": "",
+      "basis": "design component name references analysis object name",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "6cde672c8271c7eb",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "analysis_to_design",
+      "from_id": "entity-system",
+      "id": "trace-analysis-design-2",
+      "link_type": "analysis_to_design",
+      "semantic_id": "trace-analysis-design-2",
+      "to_artifact": "",
+      "to_id": "component-system-inventory-api"
+    },
+    {
+      "artifact_section": "",
+      "basis": "design component name references analysis object name",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "ad163be4082bd704",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "analysis_to_design",
+      "from_id": "state-entity-system",
+      "id": "trace-analysis-design-3",
+      "link_type": "analysis_to_design",
+      "semantic_id": "trace-analysis-design-3",
+      "to_artifact": "",
+      "to_id": "component-system-inventory-web-app"
+    },
+    {
+      "artifact_section": "",
+      "basis": "design component name references analysis object name",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "fbb12644b7b75844",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "analysis_to_design",
+      "from_id": "state-entity-system",
+      "id": "trace-analysis-design-4",
+      "link_type": "analysis_to_design",
+      "semantic_id": "trace-analysis-design-4",
+      "to_artifact": "",
+      "to_id": "component-system-inventory-api"
+    },
+    {
+      "artifact_section": "components",
+      "basis": "canonical components object renders into deployment-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "ae76c9098925962d",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "component-reporting-consumers",
+      "id": "trace-artifact-deployment-model-components-component-reporting-consumers",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-deployment-model-components-component-reporting-consumers",
+      "to_artifact": "deployment-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "components",
+      "basis": "canonical components object renders into deployment-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "a69efcf70a5d3768",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "component-system-inventory-api",
+      "id": "trace-artifact-deployment-model-components-component-system-inventory-api",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-deployment-model-components-component-system-inventory-api",
+      "to_artifact": "deployment-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "components",
+      "basis": "canonical components object renders into deployment-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "ec6a144b856a508f",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "component-system-inventory-web-app",
+      "id": "trace-artifact-deployment-model-components-component-system-inventory-web-app",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-deployment-model-components-component-system-inventory-web-app",
+      "to_artifact": "deployment-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "interfaces and integrations",
+      "basis": "canonical interfaces and integrations object renders into deployment-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "4185f4411a623540",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "interface-1",
+      "id": "trace-artifact-deployment-model-interfaces-and-integrations-interface-1",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-deployment-model-interfaces-and-integrations-interface-1",
+      "to_artifact": "deployment-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "interfaces and integrations",
+      "basis": "canonical interfaces and integrations object renders into deployment-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "a17ccea49d467835",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "interface-2",
+      "id": "trace-artifact-deployment-model-interfaces-and-integrations-interface-2",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-deployment-model-interfaces-and-integrations-interface-2",
+      "to_artifact": "deployment-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "runtime boundaries",
+      "basis": "canonical runtime boundaries object renders into deployment-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "be72109b76fcb841",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "runtime-boundary-1",
+      "id": "trace-artifact-deployment-model-runtime-boundaries-runtime-boundary-1",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-deployment-model-runtime-boundaries-runtime-boundary-1",
+      "to_artifact": "deployment-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "business rules",
+      "basis": "canonical business rules object renders into domain-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "78dc7ea16d834a20",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "business-rule-1",
+      "id": "trace-artifact-domain-model-business-rules-business-rule-1",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-domain-model-business-rules-business-rule-1",
+      "to_artifact": "domain-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "business rules",
+      "basis": "canonical business rules object renders into domain-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "e6182870d05b9f7a",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "business-rule-2",
+      "id": "trace-artifact-domain-model-business-rules-business-rule-2",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-domain-model-business-rules-business-rule-2",
+      "to_artifact": "domain-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "business rules",
+      "basis": "canonical business rules object renders into domain-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "db08e5f8695442da",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "business-rule-3",
+      "id": "trace-artifact-domain-model-business-rules-business-rule-3",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-domain-model-business-rules-business-rule-3",
+      "to_artifact": "domain-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "domain entities",
+      "basis": "canonical domain entities object renders into domain-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "789a2483947d840f",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "entity-capability",
+      "id": "trace-artifact-domain-model-domain-entities-entity-capability",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-domain-model-domain-entities-entity-capability",
+      "to_artifact": "domain-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "domain entities",
+      "basis": "canonical domain entities object renders into domain-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "59f8ec7cc794e555",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "entity-contract",
+      "id": "trace-artifact-domain-model-domain-entities-entity-contract",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-domain-model-domain-entities-entity-contract",
+      "to_artifact": "domain-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "domain entities",
+      "basis": "canonical domain entities object renders into domain-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "dbb9b5a0b9436260",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "entity-cost-record",
+      "id": "trace-artifact-domain-model-domain-entities-entity-cost-record",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-domain-model-domain-entities-entity-cost-record",
+      "to_artifact": "domain-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "domain entities",
+      "basis": "canonical domain entities object renders into domain-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "586636070ce25971",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "entity-integration",
+      "id": "trace-artifact-domain-model-domain-entities-entity-integration",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-domain-model-domain-entities-entity-integration",
+      "to_artifact": "domain-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "domain entities",
+      "basis": "canonical domain entities object renders into domain-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "62ef26eab7f16102",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "entity-risk-assessment",
+      "id": "trace-artifact-domain-model-domain-entities-entity-risk-assessment",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-domain-model-domain-entities-entity-risk-assessment",
+      "to_artifact": "domain-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "domain entities",
+      "basis": "canonical domain entities object renders into domain-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "887037ab9531f5ef",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "entity-system",
+      "id": "trace-artifact-domain-model-domain-entities-entity-system",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-domain-model-domain-entities-entity-system",
+      "to_artifact": "domain-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "domain invariants",
+      "basis": "canonical domain invariants object renders into domain-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "a90aa119fd188cdf",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "domain-invariant-1",
+      "id": "trace-artifact-domain-model-domain-invariants-domain-invariant-1",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-domain-model-domain-invariants-domain-invariant-1",
+      "to_artifact": "domain-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "domain invariants",
+      "basis": "canonical domain invariants object renders into domain-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "c954802ff4fd4b50",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "domain-invariant-2",
+      "id": "trace-artifact-domain-model-domain-invariants-domain-invariant-2",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-domain-model-domain-invariants-domain-invariant-2",
+      "to_artifact": "domain-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "domain invariants",
+      "basis": "canonical domain invariants object renders into domain-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "122fe94f2ccfd8f9",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "domain-invariant-3",
+      "id": "trace-artifact-domain-model-domain-invariants-domain-invariant-3",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-domain-model-domain-invariants-domain-invariant-3",
+      "to_artifact": "domain-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "relationships",
+      "basis": "canonical relationships object renders into domain-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "3f9d110e45e868b3",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "relationship-1",
+      "id": "trace-artifact-domain-model-relationships-relationship-1",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-domain-model-relationships-relationship-1",
+      "to_artifact": "domain-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "relationships",
+      "basis": "canonical relationships object renders into domain-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "82d26cc72fe3d665",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "relationship-2",
+      "id": "trace-artifact-domain-model-relationships-relationship-2",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-domain-model-relationships-relationship-2",
+      "to_artifact": "domain-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "relationships",
+      "basis": "canonical relationships object renders into domain-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "aed3828f4d7ff3e1",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "relationship-3",
+      "id": "trace-artifact-domain-model-relationships-relationship-3",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-domain-model-relationships-relationship-3",
+      "to_artifact": "domain-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "relationships",
+      "basis": "canonical relationships object renders into domain-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "f87566d9edb20283",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "relationship-4",
+      "id": "trace-artifact-domain-model-relationships-relationship-4",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-domain-model-relationships-relationship-4",
+      "to_artifact": "domain-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "relationships",
+      "basis": "canonical relationships object renders into domain-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "aa3eb4ffa7b6066e",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "relationship-5",
+      "id": "trace-artifact-domain-model-relationships-relationship-5",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-domain-model-relationships-relationship-5",
+      "to_artifact": "domain-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "relationships",
+      "basis": "canonical relationships object renders into domain-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "7e39e463e9002a76",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "relationship-6",
+      "id": "trace-artifact-domain-model-relationships-relationship-6",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-domain-model-relationships-relationship-6",
+      "to_artifact": "domain-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "relationships",
+      "basis": "canonical relationships object renders into domain-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "8fa95fb213bf3e7d",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "relationship-7",
+      "id": "trace-artifact-domain-model-relationships-relationship-7",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-domain-model-relationships-relationship-7",
+      "to_artifact": "domain-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "message flows",
+      "basis": "canonical message flows object renders into interaction-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "0b3a7106bfe418b7",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "interaction-message-1",
+      "id": "trace-artifact-interaction-model-message-flows-interaction-message-1",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-interaction-model-message-flows-interaction-message-1",
+      "to_artifact": "interaction-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "message flows",
+      "basis": "canonical message flows object renders into interaction-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "7b943cc11b7a8f88",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "interaction-message-2",
+      "id": "trace-artifact-interaction-model-message-flows-interaction-message-2",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-interaction-model-message-flows-interaction-message-2",
+      "to_artifact": "interaction-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "use-case realizations",
+      "basis": "canonical use-case realizations object renders into interaction-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "c1b6823d2aeeb87a",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "interaction-realization-1",
+      "id": "trace-artifact-interaction-model-use-case-realizations-interaction-realization-1",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-interaction-model-use-case-realizations-interaction-realization-1",
+      "to_artifact": "interaction-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "use-case realizations",
+      "basis": "canonical use-case realizations object renders into interaction-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "ff275c3ef6eda3ed",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "interaction-realization-2",
+      "id": "trace-artifact-interaction-model-use-case-realizations-interaction-realization-2",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-interaction-model-use-case-realizations-interaction-realization-2",
+      "to_artifact": "interaction-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "use-case realizations",
+      "basis": "canonical use-case realizations object renders into interaction-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "7e4fb0b4c67991c7",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "interaction-realization-3",
+      "id": "trace-artifact-interaction-model-use-case-realizations-interaction-realization-3",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-interaction-model-use-case-realizations-interaction-realization-3",
+      "to_artifact": "interaction-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "use-case realizations",
+      "basis": "canonical use-case realizations object renders into interaction-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "19f77e4577165002",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "interaction-realization-4",
+      "id": "trace-artifact-interaction-model-use-case-realizations-interaction-realization-4",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-interaction-model-use-case-realizations-interaction-realization-4",
+      "to_artifact": "interaction-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "use-case realizations",
+      "basis": "canonical use-case realizations object renders into interaction-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "c9a030230c311202",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "interaction-realization-5",
+      "id": "trace-artifact-interaction-model-use-case-realizations-interaction-realization-5",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-interaction-model-use-case-realizations-interaction-realization-5",
+      "to_artifact": "interaction-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "use-case realizations",
+      "basis": "canonical use-case realizations object renders into interaction-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "04f88acefe82b1c5",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "interaction-realization-6",
+      "id": "trace-artifact-interaction-model-use-case-realizations-interaction-realization-6",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-interaction-model-use-case-realizations-interaction-realization-6",
+      "to_artifact": "interaction-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "use-case realizations",
+      "basis": "canonical use-case realizations object renders into interaction-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "e54d055255df10f0",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "interaction-realization-7",
+      "id": "trace-artifact-interaction-model-use-case-realizations-interaction-realization-7",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-interaction-model-use-case-realizations-interaction-realization-7",
+      "to_artifact": "interaction-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "use-case realizations",
+      "basis": "canonical use-case realizations object renders into interaction-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "bf6e29c9d8c1ca38",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "interaction-realization-8",
+      "id": "trace-artifact-interaction-model-use-case-realizations-interaction-realization-8",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-interaction-model-use-case-realizations-interaction-realization-8",
+      "to_artifact": "interaction-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "acceptance constraints",
+      "basis": "canonical acceptance constraints object renders into requirements-spec.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "b9a087737158f727",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "acceptance-constraint-requirement-1",
+      "id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-1",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-1",
+      "to_artifact": "requirements-spec.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "acceptance constraints",
+      "basis": "canonical acceptance constraints object renders into requirements-spec.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "b2270d7e957c58fa",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "acceptance-constraint-requirement-2",
+      "id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-2",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-2",
+      "to_artifact": "requirements-spec.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "acceptance constraints",
+      "basis": "canonical acceptance constraints object renders into requirements-spec.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "8180562a372ad219",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "acceptance-constraint-requirement-3",
+      "id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-3",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-3",
+      "to_artifact": "requirements-spec.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "acceptance constraints",
+      "basis": "canonical acceptance constraints object renders into requirements-spec.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "46ebf22f963fa28d",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "acceptance-constraint-requirement-4",
+      "id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-4",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-4",
+      "to_artifact": "requirements-spec.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "acceptance constraints",
+      "basis": "canonical acceptance constraints object renders into requirements-spec.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "9434a1c4a8ceb824",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "acceptance-constraint-requirement-5",
+      "id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-5",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-5",
+      "to_artifact": "requirements-spec.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "acceptance constraints",
+      "basis": "canonical acceptance constraints object renders into requirements-spec.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "d855358cded4ea44",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "acceptance-constraint-requirement-6",
+      "id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-6",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-6",
+      "to_artifact": "requirements-spec.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "acceptance constraints",
+      "basis": "canonical acceptance constraints object renders into requirements-spec.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "ea6de4221e2055e8",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "acceptance-constraint-requirement-7",
+      "id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-7",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-7",
+      "to_artifact": "requirements-spec.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "acceptance constraints",
+      "basis": "canonical acceptance constraints object renders into requirements-spec.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "6b96bb58a515b323",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "acceptance-constraint-requirement-8",
+      "id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-8",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-8",
+      "to_artifact": "requirements-spec.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "acceptance constraints",
+      "basis": "canonical acceptance constraints object renders into requirements-spec.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "9a069ddc773b3326",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "acceptance-constraint-success-1",
+      "id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-success-1",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-success-1",
+      "to_artifact": "requirements-spec.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "functional requirements",
+      "basis": "canonical functional requirements object renders into requirements-spec.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "fec25440bb6afe79",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "functional-requirement-1",
+      "id": "trace-artifact-requirements-spec-functional-requirements-functional-requirement-1",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-requirements-spec-functional-requirements-functional-requirement-1",
+      "to_artifact": "requirements-spec.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "functional requirements",
+      "basis": "canonical functional requirements object renders into requirements-spec.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "fec25440bb6afe79",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "functional-requirement-1",
+      "id": "trace-artifact-requirements-spec-functional-requirements-functional-requirement-1",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-requirements-spec-functional-requirements-functional-requirement-1",
+      "to_artifact": "requirements-spec.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "functional requirements",
+      "basis": "canonical functional requirements object renders into requirements-spec.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "366d3df1f215edf6",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "non_functional-requirement-1",
+      "id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-1",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-1",
+      "to_artifact": "requirements-spec.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "functional requirements",
+      "basis": "canonical functional requirements object renders into requirements-spec.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "366d3df1f215edf6",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "non_functional-requirement-1",
+      "id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-1",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-1",
+      "to_artifact": "requirements-spec.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "functional requirements",
+      "basis": "canonical functional requirements object renders into requirements-spec.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "553fc29268eb54af",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "non_functional-requirement-2",
+      "id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-2",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-2",
+      "to_artifact": "requirements-spec.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "functional requirements",
+      "basis": "canonical functional requirements object renders into requirements-spec.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "45842652ab1a37ac",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "non_functional-requirement-3",
+      "id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-3",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-3",
+      "to_artifact": "requirements-spec.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "functional requirements",
+      "basis": "canonical functional requirements object renders into requirements-spec.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "deffbd4b51a070ad",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "non_functional-requirement-4",
+      "id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-4",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-4",
+      "to_artifact": "requirements-spec.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "functional requirements",
+      "basis": "canonical functional requirements object renders into requirements-spec.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "5d7714100200c16f",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "non_functional-requirement-5",
+      "id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-5",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-5",
+      "to_artifact": "requirements-spec.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "functional requirements",
+      "basis": "canonical functional requirements object renders into requirements-spec.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "f3c17e6b06f0c694",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "non_functional-requirement-6",
+      "id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-6",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-6",
+      "to_artifact": "requirements-spec.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "functional requirements",
+      "basis": "canonical functional requirements object renders into requirements-spec.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "515decfb51f1bc20",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "non_functional-requirement-7",
+      "id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-7",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-7",
+      "to_artifact": "requirements-spec.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "guard conditions",
+      "basis": "canonical guard conditions object renders into state-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "e6c1be629fc829cf",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "guard-condition-1",
+      "id": "trace-artifact-state-model-guard-conditions-guard-condition-1",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-state-model-guard-conditions-guard-condition-1",
+      "to_artifact": "state-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "guard conditions",
+      "basis": "canonical guard conditions object renders into state-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "0135f82024c2d563",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "guard-condition-2",
+      "id": "trace-artifact-state-model-guard-conditions-guard-condition-2",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-state-model-guard-conditions-guard-condition-2",
+      "to_artifact": "state-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "state entities",
+      "basis": "canonical state entities object renders into state-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "ec77547d2b28ffa3",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "state-entity-system",
+      "id": "trace-artifact-state-model-state-entities-state-entity-system",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-state-model-state-entities-state-entity-system",
+      "to_artifact": "state-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "state invariants",
+      "basis": "canonical state invariants object renders into state-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "0fc9afd4b2b4d208",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "state-invariant-1",
+      "id": "trace-artifact-state-model-state-invariants-state-invariant-1",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-state-model-state-invariants-state-invariant-1",
+      "to_artifact": "state-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "state invariants",
+      "basis": "canonical state invariants object renders into state-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "7ca8114c140d58c2",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "state-invariant-2",
+      "id": "trace-artifact-state-model-state-invariants-state-invariant-2",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-state-model-state-invariants-state-invariant-2",
+      "to_artifact": "state-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "state invariants",
+      "basis": "canonical state invariants object renders into state-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "4e3750dae2e4baa3",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "state-invariant-3",
+      "id": "trace-artifact-state-model-state-invariants-state-invariant-3",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-state-model-state-invariants-state-invariant-3",
+      "to_artifact": "state-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "state transitions",
+      "basis": "canonical state transitions object renders into state-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "5e3bb5d335f535a0",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "state-transition-1",
+      "id": "trace-artifact-state-model-state-transitions-state-transition-1",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-state-model-state-transitions-state-transition-1",
+      "to_artifact": "state-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "state transitions",
+      "basis": "canonical state transitions object renders into state-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "3c2aa5a1b7def9a0",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "state-transition-2",
+      "id": "trace-artifact-state-model-state-transitions-state-transition-2",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-state-model-state-transitions-state-transition-2",
+      "to_artifact": "state-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "state transitions",
+      "basis": "canonical state transitions object renders into state-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "1af79bac5dae50d9",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "state-transition-3",
+      "id": "trace-artifact-state-model-state-transitions-state-transition-3",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-state-model-state-transitions-state-transition-3",
+      "to_artifact": "state-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "state transitions",
+      "basis": "canonical state transitions object renders into state-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "facb3d54f01b3e57",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "state-transition-4",
+      "id": "trace-artifact-state-model-state-transitions-state-transition-4",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-state-model-state-transitions-state-transition-4",
+      "to_artifact": "state-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "triggers and approvals",
+      "basis": "canonical triggers and approvals object renders into state-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "c82280ef83063a38",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "trigger-1",
+      "id": "trace-artifact-state-model-triggers-and-approvals-trigger-1",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-state-model-triggers-and-approvals-trigger-1",
+      "to_artifact": "state-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "triggers and approvals",
+      "basis": "canonical triggers and approvals object renders into state-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "826c99d687ec2f69",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "trigger-2",
+      "id": "trace-artifact-state-model-triggers-and-approvals-trigger-2",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-state-model-triggers-and-approvals-trigger-2",
+      "to_artifact": "state-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "architecture overview",
+      "basis": "canonical architecture overview object renders into system-document.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "7d707f3fec7a9d2f",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "component-reporting-consumers",
+      "id": "trace-artifact-system-document-architecture-overview-component-reporting-consumers",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-system-document-architecture-overview-component-reporting-consumers",
+      "to_artifact": "system-document.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "architecture overview",
+      "basis": "canonical architecture overview object renders into system-document.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "00e094380860061c",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "component-system-inventory-api",
+      "id": "trace-artifact-system-document-architecture-overview-component-system-inventory-api",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-system-document-architecture-overview-component-system-inventory-api",
+      "to_artifact": "system-document.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "architecture overview",
+      "basis": "canonical architecture overview object renders into system-document.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "f69c81a8f2400595",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "component-system-inventory-web-app",
+      "id": "trace-artifact-system-document-architecture-overview-component-system-inventory-web-app",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-system-document-architecture-overview-component-system-inventory-web-app",
+      "to_artifact": "system-document.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "interfaces and integrations",
+      "basis": "canonical interfaces and integrations object renders into system-document.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "91eece8d26d5ed9b",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "interface-1",
+      "id": "trace-artifact-system-document-interfaces-and-integrations-interface-1",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-system-document-interfaces-and-integrations-interface-1",
+      "to_artifact": "system-document.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "interfaces and integrations",
+      "basis": "canonical interfaces and integrations object renders into system-document.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "3f042eff6cee48d3",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "interface-2",
+      "id": "trace-artifact-system-document-interfaces-and-integrations-interface-2",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-system-document-interfaces-and-integrations-interface-2",
+      "to_artifact": "system-document.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "runtime boundaries",
+      "basis": "canonical runtime boundaries object renders into system-document.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "fdf54dd2f5e1e22b",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "runtime-boundary-1",
+      "id": "trace-artifact-system-document-runtime-boundaries-runtime-boundary-1",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-system-document-runtime-boundaries-runtime-boundary-1",
+      "to_artifact": "system-document.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "system-level use cases",
+      "basis": "canonical system-level use cases object renders into system-document.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "da8c98fe1261eaea",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "approve-deprecation",
+      "id": "trace-artifact-system-document-system-level-use-cases-approve-deprecation",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-system-document-system-level-use-cases-approve-deprecation",
+      "to_artifact": "system-document.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "system-level use cases",
+      "basis": "canonical system-level use cases object renders into system-document.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "70377adc9535beef",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "compare-overlapping-systems",
+      "id": "trace-artifact-system-document-system-level-use-cases-compare-overlapping-systems",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-system-document-system-level-use-cases-compare-overlapping-systems",
+      "to_artifact": "system-document.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "system-level use cases",
+      "basis": "canonical system-level use cases object renders into system-document.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "b03a08f7eb0ce929",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "edit-metadata",
+      "id": "trace-artifact-system-document-system-level-use-cases-edit-metadata",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-system-document-system-level-use-cases-edit-metadata",
+      "to_artifact": "system-document.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "system-level use cases",
+      "basis": "canonical system-level use cases object renders into system-document.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "57eb8d9690d0fa91",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "register-a-system",
+      "id": "trace-artifact-system-document-system-level-use-cases-register-a-system",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-system-document-system-level-use-cases-register-a-system",
+      "to_artifact": "system-document.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "system-level use cases",
+      "basis": "canonical system-level use cases object renders into system-document.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "914c00a38c1a598b",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "report-portfolio-gaps",
+      "id": "trace-artifact-system-document-system-level-use-cases-report-portfolio-gaps",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-system-document-system-level-use-cases-report-portfolio-gaps",
+      "to_artifact": "system-document.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "system-level use cases",
+      "basis": "canonical system-level use cases object renders into system-document.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "8e9c907d80fbc3d2",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "review-risks",
+      "id": "trace-artifact-system-document-system-level-use-cases-review-risks",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-system-document-system-level-use-cases-review-risks",
+      "to_artifact": "system-document.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "system-level use cases",
+      "basis": "canonical system-level use cases object renders into system-document.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "6ce17b1b8b27c10a",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "see-costs",
+      "id": "trace-artifact-system-document-system-level-use-cases-see-costs",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-system-document-system-level-use-cases-see-costs",
+      "to_artifact": "system-document.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "system-level use cases",
+      "basis": "canonical system-level use cases object renders into system-document.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "a7b2e5a77d9c1982",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "track-lifecycle-state",
+      "id": "trace-artifact-system-document-system-level-use-cases-track-lifecycle-state",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-system-document-system-level-use-cases-track-lifecycle-state",
+      "to_artifact": "system-document.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "use-case documents",
+      "basis": "canonical use-case documents object renders into use-case-documents.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "d8181a547db101b5",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "approve-deprecation",
+      "id": "trace-artifact-use-case-documents-use-case-documents-approve-deprecation",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-use-case-documents-use-case-documents-approve-deprecation",
+      "to_artifact": "use-case-documents.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "use-case documents",
+      "basis": "canonical use-case documents object renders into use-case-documents.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "91f865980aa3f429",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "compare-overlapping-systems",
+      "id": "trace-artifact-use-case-documents-use-case-documents-compare-overlapping-systems",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-use-case-documents-use-case-documents-compare-overlapping-systems",
+      "to_artifact": "use-case-documents.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "use-case documents",
+      "basis": "canonical use-case documents object renders into use-case-documents.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "d9d43f5b16d37400",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "edit-metadata",
+      "id": "trace-artifact-use-case-documents-use-case-documents-edit-metadata",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-use-case-documents-use-case-documents-edit-metadata",
+      "to_artifact": "use-case-documents.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "use-case documents",
+      "basis": "canonical use-case documents object renders into use-case-documents.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "1727802b3c9ffae2",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "register-a-system",
+      "id": "trace-artifact-use-case-documents-use-case-documents-register-a-system",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-use-case-documents-use-case-documents-register-a-system",
+      "to_artifact": "use-case-documents.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "use-case documents",
+      "basis": "canonical use-case documents object renders into use-case-documents.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "c09fec63092a31b0",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "report-portfolio-gaps",
+      "id": "trace-artifact-use-case-documents-use-case-documents-report-portfolio-gaps",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-use-case-documents-use-case-documents-report-portfolio-gaps",
+      "to_artifact": "use-case-documents.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "use-case documents",
+      "basis": "canonical use-case documents object renders into use-case-documents.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "e120797b94e90a85",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "review-risks",
+      "id": "trace-artifact-use-case-documents-use-case-documents-review-risks",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-use-case-documents-use-case-documents-review-risks",
+      "to_artifact": "use-case-documents.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "use-case documents",
+      "basis": "canonical use-case documents object renders into use-case-documents.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "f0bb5d43cf2eb791",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "see-costs",
+      "id": "trace-artifact-use-case-documents-use-case-documents-see-costs",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-use-case-documents-use-case-documents-see-costs",
+      "to_artifact": "use-case-documents.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "use-case documents",
+      "basis": "canonical use-case documents object renders into use-case-documents.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "97cad07ceb7a9d7a",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "track-lifecycle-state",
+      "id": "trace-artifact-use-case-documents-use-case-documents-track-lifecycle-state",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-use-case-documents-use-case-documents-track-lifecycle-state",
+      "to_artifact": "use-case-documents.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "use cases",
+      "basis": "canonical use cases object renders into use-case-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "4060af26dba9ac0d",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "approve-deprecation",
+      "id": "trace-artifact-use-case-model-use-cases-approve-deprecation",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-use-case-model-use-cases-approve-deprecation",
+      "to_artifact": "use-case-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "use cases",
+      "basis": "canonical use cases object renders into use-case-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "36db17fdd50fb1b0",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "compare-overlapping-systems",
+      "id": "trace-artifact-use-case-model-use-cases-compare-overlapping-systems",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-use-case-model-use-cases-compare-overlapping-systems",
+      "to_artifact": "use-case-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "use cases",
+      "basis": "canonical use cases object renders into use-case-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "04de38aac3563833",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "edit-metadata",
+      "id": "trace-artifact-use-case-model-use-cases-edit-metadata",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-use-case-model-use-cases-edit-metadata",
+      "to_artifact": "use-case-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "use cases",
+      "basis": "canonical use cases object renders into use-case-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "f1d60233868e7209",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "register-a-system",
+      "id": "trace-artifact-use-case-model-use-cases-register-a-system",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-use-case-model-use-cases-register-a-system",
+      "to_artifact": "use-case-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "use cases",
+      "basis": "canonical use cases object renders into use-case-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "fe2f43ca885c899d",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "report-portfolio-gaps",
+      "id": "trace-artifact-use-case-model-use-cases-report-portfolio-gaps",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-use-case-model-use-cases-report-portfolio-gaps",
+      "to_artifact": "use-case-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "use cases",
+      "basis": "canonical use cases object renders into use-case-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "081f034e4463efc3",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "review-risks",
+      "id": "trace-artifact-use-case-model-use-cases-review-risks",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-use-case-model-use-cases-review-risks",
+      "to_artifact": "use-case-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "use cases",
+      "basis": "canonical use cases object renders into use-case-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "5add62a9f7896397",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "see-costs",
+      "id": "trace-artifact-use-case-model-use-cases-see-costs",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-use-case-model-use-cases-see-costs",
+      "to_artifact": "use-case-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "use cases",
+      "basis": "canonical use cases object renders into use-case-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "f3f7448e4959324c",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "track-lifecycle-state",
+      "id": "trace-artifact-use-case-model-use-cases-track-lifecycle-state",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-use-case-model-use-cases-track-lifecycle-state",
+      "to_artifact": "use-case-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "",
+      "basis": "business rule scope references state transition text",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "8330b21dc06c3215",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "business_rule_to_transition",
+      "from_id": "business-rule-1",
+      "id": "trace-rule-transition-1",
+      "link_type": "business_rule_to_transition",
+      "semantic_id": "trace-rule-transition-1",
+      "to_artifact": "",
+      "to_id": "state-transition-1"
+    },
+    {
+      "artifact_section": "",
+      "basis": "business rule scope references state transition text",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "38ebf4886c4cbd8a",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "business_rule_to_transition",
+      "from_id": "business-rule-1",
+      "id": "trace-rule-transition-2",
+      "link_type": "business_rule_to_transition",
+      "semantic_id": "trace-rule-transition-2",
+      "to_artifact": "",
+      "to_id": "state-transition-2"
+    },
+    {
+      "artifact_section": "",
+      "basis": "business rule scope references state transition text",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "2de406aa503c0e3c",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "business_rule_to_transition",
+      "from_id": "business-rule-1",
+      "id": "trace-rule-transition-3",
+      "link_type": "business_rule_to_transition",
+      "semantic_id": "trace-rule-transition-3",
+      "to_artifact": "",
+      "to_id": "state-transition-3"
+    },
+    {
+      "artifact_section": "",
+      "basis": "business rule scope references state transition text",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "f37c64bb2964c748",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "business_rule_to_transition",
+      "from_id": "business-rule-1",
+      "id": "trace-rule-transition-4",
+      "link_type": "business_rule_to_transition",
+      "semantic_id": "trace-rule-transition-4",
+      "to_artifact": "",
+      "to_id": "state-transition-4"
+    },
+    {
+      "artifact_section": "",
+      "basis": "business rule scope references state transition text",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "ff930d94cc08c88b",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "business_rule_to_transition",
+      "from_id": "business-rule-3",
+      "id": "trace-rule-transition-5",
+      "link_type": "business_rule_to_transition",
+      "semantic_id": "trace-rule-transition-5",
+      "to_artifact": "",
+      "to_id": "state-transition-1"
+    },
+    {
+      "artifact_section": "",
+      "basis": "business rule scope references state transition text",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "f75fceaaa7c248ca",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "business_rule_to_transition",
+      "from_id": "business-rule-3",
+      "id": "trace-rule-transition-6",
+      "link_type": "business_rule_to_transition",
+      "semantic_id": "trace-rule-transition-6",
+      "to_artifact": "",
+      "to_id": "state-transition-2"
+    },
+    {
+      "artifact_section": "",
+      "basis": "business rule scope references state transition text",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "a2b8426741530711",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "business_rule_to_transition",
+      "from_id": "business-rule-3",
+      "id": "trace-rule-transition-7",
+      "link_type": "business_rule_to_transition",
+      "semantic_id": "trace-rule-transition-7",
+      "to_artifact": "",
+      "to_id": "state-transition-3"
+    },
+    {
+      "artifact_section": "",
+      "basis": "business rule scope references state transition text",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "1f50adb69526d9e9",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "business_rule_to_transition",
+      "from_id": "business-rule-3",
+      "id": "trace-rule-transition-8",
+      "link_type": "business_rule_to_transition",
+      "semantic_id": "trace-rule-transition-8",
+      "to_artifact": "",
+      "to_id": "state-transition-4"
+    },
+    {
+      "artifact_section": "",
+      "basis": "domain invariant scope references domain entity",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "c23910b6713e30ea",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "domain_invariant_to_entity",
+      "from_id": "domain-invariant-1",
+      "id": "trace-domain-invariant-entity-1",
+      "link_type": "domain_invariant_to_entity",
+      "semantic_id": "trace-domain-invariant-entity-1",
+      "to_artifact": "",
+      "to_id": "entity-system"
+    },
+    {
+      "artifact_section": "",
+      "basis": "domain invariant scope references domain entity",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "f9b0aeac127ec23a",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "domain_invariant_to_entity",
+      "from_id": "domain-invariant-2",
+      "id": "trace-domain-invariant-entity-2",
+      "link_type": "domain_invariant_to_entity",
+      "semantic_id": "trace-domain-invariant-entity-2",
+      "to_artifact": "",
+      "to_id": "entity-system"
+    },
+    {
+      "artifact_section": "",
+      "basis": "domain invariant scope references domain entity",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "a077454bbc453b48",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "domain_invariant_to_entity",
+      "from_id": "domain-invariant-3",
+      "id": "trace-domain-invariant-entity-3",
+      "link_type": "domain_invariant_to_entity",
+      "semantic_id": "trace-domain-invariant-entity-3",
+      "to_artifact": "",
+      "to_id": "entity-system"
+    },
+    {
+      "artifact_section": "",
+      "basis": "domain invariant scope references domain entity",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "7d1e630599a59661",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "domain_invariant_to_entity",
+      "from_id": "domain-invariant-3",
+      "id": "trace-domain-invariant-entity-4",
+      "link_type": "domain_invariant_to_entity",
+      "semantic_id": "trace-domain-invariant-entity-4",
+      "to_artifact": "",
+      "to_id": "entity-contract"
+    },
+    {
+      "artifact_section": "",
+      "basis": "state invariant scope references state entity",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "a7293ec5dae6d460",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "state_invariant_to_state",
+      "from_id": "state-invariant-1",
+      "id": "trace-state-invariant-state-1",
+      "link_type": "state_invariant_to_state",
+      "semantic_id": "trace-state-invariant-state-1",
+      "to_artifact": "",
+      "to_id": "state-entity-system"
+    },
+    {
+      "artifact_section": "",
+      "basis": "state invariant scope references state entity",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "4a08ee79d9656d34",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "state_invariant_to_state",
+      "from_id": "state-invariant-2",
+      "id": "trace-state-invariant-state-2",
+      "link_type": "state_invariant_to_state",
+      "semantic_id": "trace-state-invariant-state-2",
+      "to_artifact": "",
+      "to_id": "state-entity-system"
+    },
+    {
+      "artifact_section": "",
+      "basis": "state invariant scope references state entity",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "79abcaa321b80e68",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "state_invariant_to_state",
+      "from_id": "state-invariant-3",
+      "id": "trace-state-invariant-state-3",
+      "link_type": "state_invariant_to_state",
+      "semantic_id": "trace-state-invariant-state-3",
+      "to_artifact": "",
+      "to_id": "state-entity-system"
+    },
+    {
+      "artifact_section": "",
+      "basis": "use-case text references analysis object name",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "e3594e9f3a257337",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "use_case_to_analysis",
+      "from_id": "register-a-system",
+      "id": "trace-uc-analysis-1",
+      "link_type": "use_case_to_analysis",
+      "semantic_id": "trace-uc-analysis-1",
+      "to_artifact": "",
+      "to_id": "entity-system"
+    },
+    {
+      "artifact_section": "",
+      "basis": "use-case text references analysis object name",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "2a59a5943a0158f5",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "use_case_to_analysis",
+      "from_id": "register-a-system",
+      "id": "trace-uc-analysis-2",
+      "link_type": "use_case_to_analysis",
+      "semantic_id": "trace-uc-analysis-2",
+      "to_artifact": "",
+      "to_id": "state-entity-system"
+    },
+    {
+      "artifact_section": "",
+      "basis": "use-case text references analysis object name",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "d33c8769568faeb1",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "use_case_to_analysis",
+      "from_id": "compare-overlapping-systems",
+      "id": "trace-uc-analysis-3",
+      "link_type": "use_case_to_analysis",
+      "semantic_id": "trace-uc-analysis-3",
+      "to_artifact": "",
+      "to_id": "entity-system"
+    },
+    {
+      "artifact_section": "",
+      "basis": "use-case text references analysis object name",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "7ea3d3efb49a9f45",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "use_case_to_analysis",
+      "from_id": "compare-overlapping-systems",
+      "id": "trace-uc-analysis-4",
+      "link_type": "use_case_to_analysis",
+      "semantic_id": "trace-uc-analysis-4",
+      "to_artifact": "",
+      "to_id": "state-entity-system"
+    }
+  ]
+}

--- a/examples/it-systems-inventory-v2/model/rupify-model.json
+++ b/examples/it-systems-inventory-v2/model/rupify-model.json
@@ -1,0 +1,7807 @@
+{
+  "actors": [
+    {
+      "change_metadata": {
+        "change_source": "round_3",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "84d72a310d252de3",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "complexity": "complex",
+      "complexity_trace": {
+        "source_key": "actor_complexity",
+        "source_round": 8
+      },
+      "content_semantics": "informative",
+      "description": "",
+      "id": "business-owners",
+      "interaction_style": "user_interface",
+      "model_layer": "analysis",
+      "name": "Business owners",
+      "responsibilities": [],
+      "semantic_id": "business-owners",
+      "trace": {
+        "source_key": "actors",
+        "source_round": 3
+      },
+      "type": "human"
+    },
+    {
+      "change_metadata": {
+        "change_source": "round_3",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "d36f7237d6859555",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "complexity": "complex",
+      "complexity_trace": {
+        "source_key": "actor_complexity",
+        "source_round": 8
+      },
+      "content_semantics": "informative",
+      "description": "",
+      "id": "technical-owners",
+      "interaction_style": "user_interface",
+      "model_layer": "analysis",
+      "name": "technical owners",
+      "responsibilities": [],
+      "semantic_id": "technical-owners",
+      "trace": {
+        "source_key": "actors",
+        "source_round": 3
+      },
+      "type": "human"
+    },
+    {
+      "change_metadata": {
+        "change_source": "round_3",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "f02cd6d546b426cf",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "complexity": "complex",
+      "complexity_trace": {
+        "source_key": "actor_complexity",
+        "source_round": 8
+      },
+      "content_semantics": "informative",
+      "description": "",
+      "id": "enterprise-architects",
+      "interaction_style": "user_interface",
+      "model_layer": "analysis",
+      "name": "enterprise architects",
+      "responsibilities": [],
+      "semantic_id": "enterprise-architects",
+      "trace": {
+        "source_key": "actors",
+        "source_round": 3
+      },
+      "type": "human"
+    },
+    {
+      "change_metadata": {
+        "change_source": "round_3",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "1e4c525208fa8f46",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "complexity": "average",
+      "complexity_trace": {
+        "source_key": "actor_complexity",
+        "source_round": 8
+      },
+      "content_semantics": "informative",
+      "description": "",
+      "id": "procurement",
+      "interaction_style": "user_interface",
+      "model_layer": "analysis",
+      "name": "procurement",
+      "responsibilities": [],
+      "semantic_id": "procurement",
+      "trace": {
+        "source_key": "actors",
+        "source_round": 3
+      },
+      "type": "human"
+    },
+    {
+      "change_metadata": {
+        "change_source": "round_3",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "8b2987df0c86958f",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "complexity": "average",
+      "complexity_trace": {
+        "source_key": "actor_complexity",
+        "source_round": 8
+      },
+      "content_semantics": "informative",
+      "description": "",
+      "id": "security",
+      "interaction_style": "user_interface",
+      "model_layer": "analysis",
+      "name": "security",
+      "responsibilities": [],
+      "semantic_id": "security",
+      "trace": {
+        "source_key": "actors",
+        "source_round": 3
+      },
+      "type": "human"
+    },
+    {
+      "change_metadata": {
+        "change_source": "round_3",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "382f8466b20e4667",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "complexity": "average",
+      "complexity_trace": {
+        "source_key": "actor_complexity",
+        "source_round": 8
+      },
+      "content_semantics": "informative",
+      "description": "",
+      "id": "finance",
+      "interaction_style": "user_interface",
+      "model_layer": "analysis",
+      "name": "finance",
+      "responsibilities": [],
+      "semantic_id": "finance",
+      "trace": {
+        "source_key": "actors",
+        "source_round": 3
+      },
+      "type": "human"
+    },
+    {
+      "change_metadata": {
+        "change_source": "round_3",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "d12ffaeea8ac1e65",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "complexity": "complex",
+      "complexity_trace": {
+        "source_key": "actor_complexity",
+        "source_round": 8
+      },
+      "content_semantics": "informative",
+      "description": "",
+      "id": "application-owners",
+      "interaction_style": "user_interface",
+      "model_layer": "analysis",
+      "name": "application owners",
+      "responsibilities": [],
+      "semantic_id": "application-owners",
+      "trace": {
+        "source_key": "actors",
+        "source_round": 3
+      },
+      "type": "human"
+    },
+    {
+      "change_metadata": {
+        "change_source": "round_3",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "96320ed7d1c1720c",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "complexity": "average",
+      "complexity_trace": {
+        "source_key": "actor_complexity",
+        "source_round": 8
+      },
+      "content_semantics": "informative",
+      "description": "",
+      "id": "integration-system-owners",
+      "interaction_style": "system_interface",
+      "model_layer": "analysis",
+      "name": "integration system owners",
+      "responsibilities": [],
+      "semantic_id": "integration-system-owners",
+      "trace": {
+        "source_key": "actors",
+        "source_round": 3
+      },
+      "type": "system"
+    }
+  ],
+  "ambiguities": [],
+  "analysis_view": {
+    "acceptance_constraint_ids": [
+      "acceptance-constraint-requirement-1",
+      "acceptance-constraint-requirement-2",
+      "acceptance-constraint-requirement-3",
+      "acceptance-constraint-requirement-4",
+      "acceptance-constraint-requirement-5",
+      "acceptance-constraint-requirement-6",
+      "acceptance-constraint-requirement-7",
+      "acceptance-constraint-requirement-8",
+      "acceptance-constraint-success-1"
+    ],
+    "acceptance_constraint_objects": [
+      {
+        "change_metadata": {
+          "change_source": "derived_acceptance_constraints",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "926a0e8b7f0d0604",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint_kind": "non_functional_requirement",
+        "content_semantics": "normative",
+        "description": "UI must be web based",
+        "id": "acceptance-constraint-requirement-1",
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "name": "Acceptance Constraint 1",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-requirement-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "acceptance-constraint-requirement-1",
+        "source_requirement_id": "non_functional-requirement-1",
+        "trace": {
+          "source_key": "constraints",
+          "source_round": 2
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_acceptance_constraints",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "ea270a270fd5ae0a",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint_kind": "non_functional_requirement",
+        "content_semantics": "normative",
+        "description": "SSO",
+        "id": "acceptance-constraint-requirement-2",
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "name": "Acceptance Constraint 2",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-requirement-2",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "acceptance-constraint-requirement-2",
+        "source_requirement_id": "non_functional-requirement-1",
+        "trace": {
+          "source_key": "non_functional_requirements",
+          "source_round": 4
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_acceptance_constraints",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "cc94e38b4882a356",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint_kind": "non_functional_requirement",
+        "content_semantics": "normative",
+        "description": "role-based access",
+        "id": "acceptance-constraint-requirement-3",
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "name": "Acceptance Constraint 3",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-requirement-3",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "acceptance-constraint-requirement-3",
+        "source_requirement_id": "non_functional-requirement-2",
+        "trace": {
+          "source_key": "non_functional_requirements",
+          "source_round": 4
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_acceptance_constraints",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "e3b5c94d9e1c0566",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint_kind": "non_functional_requirement",
+        "content_semantics": "normative",
+        "description": "audit trail",
+        "id": "acceptance-constraint-requirement-4",
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "name": "Acceptance Constraint 4",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-requirement-4",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "acceptance-constraint-requirement-4",
+        "source_requirement_id": "non_functional-requirement-3",
+        "trace": {
+          "source_key": "non_functional_requirements",
+          "source_round": 4
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_acceptance_constraints",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "9c5f49ef585cd8db",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint_kind": "non_functional_requirement",
+        "content_semantics": "normative",
+        "description": "search",
+        "id": "acceptance-constraint-requirement-5",
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "name": "Acceptance Constraint 5",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-requirement-5",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "acceptance-constraint-requirement-5",
+        "source_requirement_id": "non_functional-requirement-4",
+        "trace": {
+          "source_key": "non_functional_requirements",
+          "source_round": 4
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_acceptance_constraints",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "6e001e4c4833adf7",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint_kind": "non_functional_requirement",
+        "content_semantics": "normative",
+        "description": "filtering",
+        "id": "acceptance-constraint-requirement-6",
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "name": "Acceptance Constraint 6",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-requirement-6",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "acceptance-constraint-requirement-6",
+        "source_requirement_id": "non_functional-requirement-5",
+        "trace": {
+          "source_key": "non_functional_requirements",
+          "source_round": 4
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_acceptance_constraints",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "714fad84b7076d46",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint_kind": "non_functional_requirement",
+        "content_semantics": "normative",
+        "description": "performance (regular >1s for web page rendering)",
+        "id": "acceptance-constraint-requirement-7",
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "name": "Acceptance Constraint 7",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-requirement-7",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "acceptance-constraint-requirement-7",
+        "source_requirement_id": "non_functional-requirement-6",
+        "trace": {
+          "source_key": "non_functional_requirements",
+          "source_round": 4
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_acceptance_constraints",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "93c0bedbff37f4c7",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint_kind": "non_functional_requirement",
+        "content_semantics": "normative",
+        "description": "availability >=99%",
+        "id": "acceptance-constraint-requirement-8",
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "name": "Acceptance Constraint 8",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-requirement-8",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "acceptance-constraint-requirement-8",
+        "source_requirement_id": "non_functional-requirement-7",
+        "trace": {
+          "source_key": "non_functional_requirements",
+          "source_round": 4
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_acceptance_constraints",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "f58f7d91234137ac",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint_kind": "success_criterion",
+        "content_semantics": "normative",
+        "description": "Better planning of IT systems purchasing and life cycle",
+        "id": "acceptance-constraint-success-1",
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "name": "Success Criterion 1",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-success-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "acceptance-constraint-success-1",
+        "source_requirement_id": "",
+        "trace": {
+          "source_key": "success_criteria",
+          "source_round": 2
+        }
+      }
+    ],
+    "actor_ids": [
+      "business-owners",
+      "technical-owners",
+      "enterprise-architects",
+      "procurement",
+      "security",
+      "finance",
+      "application-owners",
+      "integration-system-owners"
+    ],
+    "actors": [
+      {
+        "change_metadata": {
+          "change_source": "round_3",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "84d72a310d252de3",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "complexity": "complex",
+        "complexity_trace": {
+          "source_key": "actor_complexity",
+          "source_round": 8
+        },
+        "content_semantics": "informative",
+        "description": "",
+        "id": "business-owners",
+        "interaction_style": "user_interface",
+        "model_layer": "analysis",
+        "name": "Business owners",
+        "responsibilities": [],
+        "semantic_id": "business-owners",
+        "trace": {
+          "source_key": "actors",
+          "source_round": 3
+        },
+        "type": "human"
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_3",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "d36f7237d6859555",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "complexity": "complex",
+        "complexity_trace": {
+          "source_key": "actor_complexity",
+          "source_round": 8
+        },
+        "content_semantics": "informative",
+        "description": "",
+        "id": "technical-owners",
+        "interaction_style": "user_interface",
+        "model_layer": "analysis",
+        "name": "technical owners",
+        "responsibilities": [],
+        "semantic_id": "technical-owners",
+        "trace": {
+          "source_key": "actors",
+          "source_round": 3
+        },
+        "type": "human"
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_3",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "f02cd6d546b426cf",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "complexity": "complex",
+        "complexity_trace": {
+          "source_key": "actor_complexity",
+          "source_round": 8
+        },
+        "content_semantics": "informative",
+        "description": "",
+        "id": "enterprise-architects",
+        "interaction_style": "user_interface",
+        "model_layer": "analysis",
+        "name": "enterprise architects",
+        "responsibilities": [],
+        "semantic_id": "enterprise-architects",
+        "trace": {
+          "source_key": "actors",
+          "source_round": 3
+        },
+        "type": "human"
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_3",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "1e4c525208fa8f46",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "complexity": "average",
+        "complexity_trace": {
+          "source_key": "actor_complexity",
+          "source_round": 8
+        },
+        "content_semantics": "informative",
+        "description": "",
+        "id": "procurement",
+        "interaction_style": "user_interface",
+        "model_layer": "analysis",
+        "name": "procurement",
+        "responsibilities": [],
+        "semantic_id": "procurement",
+        "trace": {
+          "source_key": "actors",
+          "source_round": 3
+        },
+        "type": "human"
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_3",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "8b2987df0c86958f",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "complexity": "average",
+        "complexity_trace": {
+          "source_key": "actor_complexity",
+          "source_round": 8
+        },
+        "content_semantics": "informative",
+        "description": "",
+        "id": "security",
+        "interaction_style": "user_interface",
+        "model_layer": "analysis",
+        "name": "security",
+        "responsibilities": [],
+        "semantic_id": "security",
+        "trace": {
+          "source_key": "actors",
+          "source_round": 3
+        },
+        "type": "human"
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_3",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "382f8466b20e4667",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "complexity": "average",
+        "complexity_trace": {
+          "source_key": "actor_complexity",
+          "source_round": 8
+        },
+        "content_semantics": "informative",
+        "description": "",
+        "id": "finance",
+        "interaction_style": "user_interface",
+        "model_layer": "analysis",
+        "name": "finance",
+        "responsibilities": [],
+        "semantic_id": "finance",
+        "trace": {
+          "source_key": "actors",
+          "source_round": 3
+        },
+        "type": "human"
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_3",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "d12ffaeea8ac1e65",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "complexity": "complex",
+        "complexity_trace": {
+          "source_key": "actor_complexity",
+          "source_round": 8
+        },
+        "content_semantics": "informative",
+        "description": "",
+        "id": "application-owners",
+        "interaction_style": "user_interface",
+        "model_layer": "analysis",
+        "name": "application owners",
+        "responsibilities": [],
+        "semantic_id": "application-owners",
+        "trace": {
+          "source_key": "actors",
+          "source_round": 3
+        },
+        "type": "human"
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_3",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "96320ed7d1c1720c",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "complexity": "average",
+        "complexity_trace": {
+          "source_key": "actor_complexity",
+          "source_round": 8
+        },
+        "content_semantics": "informative",
+        "description": "",
+        "id": "integration-system-owners",
+        "interaction_style": "system_interface",
+        "model_layer": "analysis",
+        "name": "integration system owners",
+        "responsibilities": [],
+        "semantic_id": "integration-system-owners",
+        "trace": {
+          "source_key": "actors",
+          "source_round": 3
+        },
+        "type": "system"
+      }
+    ],
+    "ambiguity_ids": [],
+    "ambiguity_objects": [],
+    "business_rule_ids": [
+      "business-rule-1",
+      "business-rule-2",
+      "business-rule-3"
+    ],
+    "business_rule_objects": [
+      {
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "39d0fe629127c7ed",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "id": "business-rule-1",
+        "model_layer": "analysis",
+        "name": "Rule 1",
+        "rule_text": "A System must have a business owner before it becomes Active.",
+        "scope": "A System",
+        "semantic_id": "business-rule-1",
+        "trace": {
+          "source_key": "business_rules",
+          "source_round": 5
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "68c0c8b8aeec81ca",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "id": "business-rule-2",
+        "model_layer": "analysis",
+        "name": "Rule 2",
+        "rule_text": "A System lifecycle state change requires approval for deprecation.",
+        "scope": "A System lifecycle state change",
+        "semantic_id": "business-rule-2",
+        "trace": {
+          "source_key": "business_rules",
+          "source_round": 5
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "79c6a2ee0ae3e1ec",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "id": "business-rule-3",
+        "model_layer": "analysis",
+        "name": "Rule 3",
+        "rule_text": "A System must record vendor and contract dates.",
+        "scope": "A System",
+        "semantic_id": "business-rule-3",
+        "trace": {
+          "source_key": "business_rules",
+          "source_round": 5
+        }
+      }
+    ],
+    "domain_entity_ids": [
+      "entity-system",
+      "entity-risk-assessment",
+      "entity-cost-record",
+      "entity-capability",
+      "entity-contract",
+      "entity-integration"
+    ],
+    "domain_entity_objects": [
+      {
+        "attributes": [],
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "1577db3f693c63c0",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "",
+        "entity_type": "domain_entity",
+        "id": "entity-system",
+        "model_layer": "analysis",
+        "name": "System",
+        "responsibilities": [],
+        "semantic_id": "entity-system",
+        "trace": {
+          "source_key": "domain_entities",
+          "source_round": 5
+        }
+      },
+      {
+        "attributes": [],
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "a57ef4a16cb94f26",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "",
+        "entity_type": "domain_entity",
+        "id": "entity-risk-assessment",
+        "model_layer": "analysis",
+        "name": "Risk Assessment",
+        "responsibilities": [],
+        "semantic_id": "entity-risk-assessment",
+        "trace": {
+          "source_key": "domain_entities",
+          "source_round": 5
+        }
+      },
+      {
+        "attributes": [],
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "1c046a800433e10b",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "",
+        "entity_type": "domain_entity",
+        "id": "entity-cost-record",
+        "model_layer": "analysis",
+        "name": "Cost Record",
+        "responsibilities": [],
+        "semantic_id": "entity-cost-record",
+        "trace": {
+          "source_key": "domain_entities",
+          "source_round": 5
+        }
+      },
+      {
+        "attributes": [],
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "09258b7496344799",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "",
+        "entity_type": "domain_entity",
+        "id": "entity-capability",
+        "model_layer": "analysis",
+        "name": "Capability",
+        "responsibilities": [],
+        "semantic_id": "entity-capability",
+        "trace": {
+          "source_key": "domain_entities",
+          "source_round": 5
+        }
+      },
+      {
+        "attributes": [],
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "d5474b4336ad506b",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "",
+        "entity_type": "domain_entity",
+        "id": "entity-contract",
+        "model_layer": "analysis",
+        "name": "Contract",
+        "responsibilities": [],
+        "semantic_id": "entity-contract",
+        "trace": {
+          "source_key": "domain_entities",
+          "source_round": 5
+        }
+      },
+      {
+        "attributes": [],
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "eb58d30f221513d9",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "",
+        "entity_type": "domain_entity",
+        "id": "entity-integration",
+        "model_layer": "analysis",
+        "name": "Integration",
+        "responsibilities": [],
+        "semantic_id": "entity-integration",
+        "trace": {
+          "source_key": "domain_entities",
+          "source_round": 5
+        }
+      }
+    ],
+    "domain_invariant_ids": [
+      "domain-invariant-1",
+      "domain-invariant-2",
+      "domain-invariant-3"
+    ],
+    "domain_invariant_objects": [
+      {
+        "change_metadata": {
+          "change_source": "derived_domain_invariants",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "a0838e2d92556587",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "A System must have a business owner before it becomes Active.",
+        "id": "domain-invariant-1",
+        "model_layer": "analysis",
+        "name": "Rule 1",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "domain_invariants",
+          "id": "domain-invariant-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "scope_entity_ids": [
+          "entity-system"
+        ],
+        "semantic_id": "domain-invariant-1",
+        "source_business_rule_id": "business-rule-1",
+        "trace": {
+          "source_key": "business_rules",
+          "source_round": 5
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_domain_invariants",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "0faa9d909ed4effe",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "A System lifecycle state change requires approval for deprecation.",
+        "id": "domain-invariant-2",
+        "model_layer": "analysis",
+        "name": "Rule 2",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "domain_invariants",
+          "id": "domain-invariant-2",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "scope_entity_ids": [
+          "entity-system"
+        ],
+        "semantic_id": "domain-invariant-2",
+        "source_business_rule_id": "business-rule-2",
+        "trace": {
+          "source_key": "business_rules",
+          "source_round": 5
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_domain_invariants",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "ae58a8512d9d5819",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "A System must record vendor and contract dates.",
+        "id": "domain-invariant-3",
+        "model_layer": "analysis",
+        "name": "Rule 3",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "domain_invariants",
+          "id": "domain-invariant-3",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "scope_entity_ids": [
+          "entity-system",
+          "entity-contract"
+        ],
+        "semantic_id": "domain-invariant-3",
+        "source_business_rule_id": "business-rule-3",
+        "trace": {
+          "source_key": "business_rules",
+          "source_round": 5
+        }
+      }
+    ],
+    "forbidden_transition_ids": [],
+    "forbidden_transition_objects": [],
+    "guard_condition_ids": [
+      "guard-condition-1",
+      "guard-condition-2"
+    ],
+    "guard_condition_objects": [
+      {
+        "change_metadata": {
+          "change_source": "derived_guard_conditions",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "065fe600e6dfe1f2",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "condition_text": "Deprecation approval requires enterprise architect review",
+        "content_semantics": "normative",
+        "description": "Deprecation approval requires enterprise architect review",
+        "id": "guard-condition-1",
+        "model_layer": "analysis",
+        "name": "Deprecation approval",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "guard_conditions",
+          "id": "guard-condition-1",
+          "missing_fields": [
+            "related_transition_ids"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
+        },
+        "related_transition_ids": [],
+        "semantic_id": "guard-condition-1",
+        "source_trigger_id": "trigger-1",
+        "state_entity_ids": [],
+        "trace": {
+          "source_key": "triggers_and_approvals",
+          "source_round": 6
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_guard_conditions",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "bed0aa2ab2818dc4",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "condition_text": "Contract expiry triggers lifecycle review",
+        "content_semantics": "normative",
+        "description": "Contract expiry triggers lifecycle review",
+        "id": "guard-condition-2",
+        "model_layer": "analysis",
+        "name": "Contract expiry",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "guard_conditions",
+          "id": "guard-condition-2",
+          "missing_fields": [
+            "related_transition_ids"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
+        },
+        "related_transition_ids": [],
+        "semantic_id": "guard-condition-2",
+        "source_trigger_id": "trigger-2",
+        "state_entity_ids": [],
+        "trace": {
+          "source_key": "triggers_and_approvals",
+          "source_round": 6
+        }
+      }
+    ],
+    "relationship_ids": [
+      "relationship-1",
+      "relationship-2",
+      "relationship-3",
+      "relationship-4",
+      "relationship-5",
+      "relationship-6",
+      "relationship-7"
+    ],
+    "relationship_objects": [
+      {
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "00b251588522b7b6",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "A System has one Business Owner",
+        "id": "relationship-1",
+        "model_layer": "analysis",
+        "relationship_type": "",
+        "semantic_id": "relationship-1",
+        "source_entity_id": "",
+        "source_multiplicity": "",
+        "source_name": "",
+        "source_role_name": "",
+        "target_entity_id": "",
+        "target_multiplicity": "",
+        "target_name": "",
+        "target_role_name": "",
+        "trace": {
+          "source_key": "relationships",
+          "source_round": 5
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "360538e5dcd99cae",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "A System has one Technical Owner",
+        "id": "relationship-2",
+        "model_layer": "analysis",
+        "relationship_type": "",
+        "semantic_id": "relationship-2",
+        "source_entity_id": "",
+        "source_multiplicity": "",
+        "source_name": "",
+        "source_role_name": "",
+        "target_entity_id": "",
+        "target_multiplicity": "",
+        "target_name": "",
+        "target_role_name": "",
+        "trace": {
+          "source_key": "relationships",
+          "source_round": 5
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "934f71080e23519e",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "A System has many Integrations",
+        "id": "relationship-3",
+        "model_layer": "analysis",
+        "relationship_type": "has_many",
+        "semantic_id": "relationship-3",
+        "source_entity_id": "entity-system",
+        "source_multiplicity": "1",
+        "source_name": "A System",
+        "source_role_name": "integrations",
+        "target_entity_id": "entity-integration",
+        "target_multiplicity": "*",
+        "target_name": "Integrations",
+        "target_role_name": "a_system",
+        "trace": {
+          "source_key": "relationships",
+          "source_round": 5
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "ab39194c2a6358f7",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "A System has many Capabilities",
+        "id": "relationship-4",
+        "model_layer": "analysis",
+        "relationship_type": "has_many",
+        "semantic_id": "relationship-4",
+        "source_entity_id": "entity-system",
+        "source_multiplicity": "1",
+        "source_name": "A System",
+        "source_role_name": "capabilities",
+        "target_entity_id": "",
+        "target_multiplicity": "*",
+        "target_name": "Capabilities",
+        "target_role_name": "a_system",
+        "trace": {
+          "source_key": "relationships",
+          "source_round": 5
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "805991d9f16d4aa5",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "A System has one Contract",
+        "id": "relationship-5",
+        "model_layer": "analysis",
+        "relationship_type": "",
+        "semantic_id": "relationship-5",
+        "source_entity_id": "",
+        "source_multiplicity": "",
+        "source_name": "",
+        "source_role_name": "",
+        "target_entity_id": "",
+        "target_multiplicity": "",
+        "target_name": "",
+        "target_role_name": "",
+        "trace": {
+          "source_key": "relationships",
+          "source_round": 5
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "fa8309800cc5f504",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "A System has many Risk Assessments",
+        "id": "relationship-6",
+        "model_layer": "analysis",
+        "relationship_type": "has_many",
+        "semantic_id": "relationship-6",
+        "source_entity_id": "entity-system",
+        "source_multiplicity": "1",
+        "source_name": "A System",
+        "source_role_name": "risk_assessments",
+        "target_entity_id": "entity-risk-assessment",
+        "target_multiplicity": "*",
+        "target_name": "Risk Assessments",
+        "target_role_name": "a_system",
+        "trace": {
+          "source_key": "relationships",
+          "source_round": 5
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "ec019fec6642681e",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "A System has many Cost Records",
+        "id": "relationship-7",
+        "model_layer": "analysis",
+        "relationship_type": "has_many",
+        "semantic_id": "relationship-7",
+        "source_entity_id": "entity-system",
+        "source_multiplicity": "1",
+        "source_name": "A System",
+        "source_role_name": "cost_records",
+        "target_entity_id": "entity-cost-record",
+        "target_multiplicity": "*",
+        "target_name": "Cost Records",
+        "target_role_name": "a_system",
+        "trace": {
+          "source_key": "relationships",
+          "source_round": 5
+        }
+      }
+    ],
+    "requirement_ids": [
+      "functional-requirement-1",
+      "functional-requirement-1",
+      "non_functional-requirement-1",
+      "non_functional-requirement-1",
+      "non_functional-requirement-2",
+      "non_functional-requirement-3",
+      "non_functional-requirement-4",
+      "non_functional-requirement-5",
+      "non_functional-requirement-6",
+      "non_functional-requirement-7"
+    ],
+    "requirement_objects": [
+      {
+        "change_metadata": {
+          "change_source": "requirements",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "b817426cb7205235",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "fit_criterion": "",
+        "id": "functional-requirement-1",
+        "linked_step_ids": [],
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "quality_attribute": "",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "functional-requirement-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "requirement_kind": "functional",
+        "semantic_id": "functional-requirement-1",
+        "statement": "Yes business processes like stage gates and approval states must be supported",
+        "trace": {
+          "source_key": "workflow_scope",
+          "source_round": 4
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "requirements",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "139e2490d0d43a69",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "fit_criterion": "",
+        "id": "functional-requirement-1",
+        "linked_step_ids": [],
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "quality_attribute": "",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "functional-requirement-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "requirement_kind": "functional",
+        "semantic_id": "functional-requirement-1",
+        "statement": "I think this will be the CMDB for IT Applications/systems - we need to be able to export data to various system for reporting.",
+        "trace": {
+          "source_key": "integrations",
+          "source_round": 3
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "requirements",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "35140189626f3690",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "fit_criterion": "",
+        "id": "non_functional-requirement-1",
+        "linked_step_ids": [],
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "quality_attribute": "",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "non_functional-requirement-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "requirement_kind": "non_functional",
+        "semantic_id": "non_functional-requirement-1",
+        "statement": "UI must be web based",
+        "trace": {
+          "source_key": "constraints",
+          "source_round": 2
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "requirements",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "a8315094eda0a9ee",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "fit_criterion": "",
+        "id": "non_functional-requirement-1",
+        "linked_step_ids": [],
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "quality_attribute": "",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "non_functional-requirement-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "requirement_kind": "non_functional",
+        "semantic_id": "non_functional-requirement-1",
+        "statement": "SSO",
+        "trace": {
+          "source_key": "non_functional_requirements",
+          "source_round": 4
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "requirements",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "653fcfd7e5d0f72d",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "fit_criterion": "",
+        "id": "non_functional-requirement-2",
+        "linked_step_ids": [],
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "quality_attribute": "",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "non_functional-requirement-2",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "requirement_kind": "non_functional",
+        "semantic_id": "non_functional-requirement-2",
+        "statement": "role-based access",
+        "trace": {
+          "source_key": "non_functional_requirements",
+          "source_round": 4
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "requirements",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "1e1efba12799e966",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "fit_criterion": "",
+        "id": "non_functional-requirement-3",
+        "linked_step_ids": [],
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "quality_attribute": "",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "non_functional-requirement-3",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "requirement_kind": "non_functional",
+        "semantic_id": "non_functional-requirement-3",
+        "statement": "audit trail",
+        "trace": {
+          "source_key": "non_functional_requirements",
+          "source_round": 4
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "requirements",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "e4dde9ea3c5c65ff",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "fit_criterion": "",
+        "id": "non_functional-requirement-4",
+        "linked_step_ids": [],
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "quality_attribute": "",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "non_functional-requirement-4",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "requirement_kind": "non_functional",
+        "semantic_id": "non_functional-requirement-4",
+        "statement": "search",
+        "trace": {
+          "source_key": "non_functional_requirements",
+          "source_round": 4
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "requirements",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "2da660a4b12b3c4f",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "fit_criterion": "",
+        "id": "non_functional-requirement-5",
+        "linked_step_ids": [],
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "quality_attribute": "",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "non_functional-requirement-5",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "requirement_kind": "non_functional",
+        "semantic_id": "non_functional-requirement-5",
+        "statement": "filtering",
+        "trace": {
+          "source_key": "non_functional_requirements",
+          "source_round": 4
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "requirements",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "2425258393a5de78",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "fit_criterion": "",
+        "id": "non_functional-requirement-6",
+        "linked_step_ids": [],
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "quality_attribute": "",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "non_functional-requirement-6",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "requirement_kind": "non_functional",
+        "semantic_id": "non_functional-requirement-6",
+        "statement": "performance (regular >1s for web page rendering)",
+        "trace": {
+          "source_key": "non_functional_requirements",
+          "source_round": 4
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "requirements",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "a77d5256a7d4bfcb",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "fit_criterion": "",
+        "id": "non_functional-requirement-7",
+        "linked_step_ids": [],
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "quality_attribute": "",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "non_functional-requirement-7",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "requirement_kind": "non_functional",
+        "semantic_id": "non_functional-requirement-7",
+        "statement": "availability >=99%",
+        "trace": {
+          "source_key": "non_functional_requirements",
+          "source_round": 4
+        }
+      }
+    ],
+    "risk_ids": [],
+    "risk_objects": [],
+    "scenario_ids": [],
+    "scenario_objects": [],
+    "state_entity_ids": [
+      "state-entity-system"
+    ],
+    "state_entity_objects": [
+      {
+        "change_metadata": {
+          "change_source": "round_6",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "87ced495451bbf64",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "",
+        "entity_type": "stateful_entity",
+        "id": "state-entity-system",
+        "model_layer": "analysis",
+        "name": "System",
+        "semantic_id": "state-entity-system",
+        "states": [
+          "Proposed",
+          "Active",
+          "Retiring",
+          "Retired",
+          "Deprecated"
+        ],
+        "trace": {
+          "source_key": "state_entities",
+          "source_round": 6
+        }
+      }
+    ],
+    "state_invariant_ids": [
+      "state-invariant-1",
+      "state-invariant-2",
+      "state-invariant-3"
+    ],
+    "state_invariant_objects": [
+      {
+        "change_metadata": {
+          "change_source": "derived_state_invariants",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "e99d374908167c66",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "A System must have a business owner before it becomes Active.",
+        "id": "state-invariant-1",
+        "model_layer": "analysis",
+        "name": "Rule 1",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "state_invariants",
+          "id": "state-invariant-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "state-invariant-1",
+        "source_business_rule_id": "business-rule-1",
+        "state_entity_ids": [
+          "state-entity-system"
+        ],
+        "trace": {
+          "source_key": "business_rules",
+          "source_round": 5
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_state_invariants",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "d3f0734ba4f5d238",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "A System lifecycle state change requires approval for deprecation.",
+        "id": "state-invariant-2",
+        "model_layer": "analysis",
+        "name": "Rule 2",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "state_invariants",
+          "id": "state-invariant-2",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "state-invariant-2",
+        "source_business_rule_id": "business-rule-2",
+        "state_entity_ids": [
+          "state-entity-system"
+        ],
+        "trace": {
+          "source_key": "business_rules",
+          "source_round": 5
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_state_invariants",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "86c22df4bc630d1b",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "A System must record vendor and contract dates.",
+        "id": "state-invariant-3",
+        "model_layer": "analysis",
+        "name": "Rule 3",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "state_invariants",
+          "id": "state-invariant-3",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "state-invariant-3",
+        "source_business_rule_id": "business-rule-3",
+        "state_entity_ids": [
+          "state-entity-system"
+        ],
+        "trace": {
+          "source_key": "business_rules",
+          "source_round": 5
+        }
+      }
+    ],
+    "state_transition_ids": [
+      "state-transition-1",
+      "state-transition-2",
+      "state-transition-3",
+      "state-transition-4"
+    ],
+    "state_transition_objects": [
+      {
+        "change_metadata": {
+          "change_source": "round_6",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "79c9acbe984baf73",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint": "",
+        "content_semantics": "normative",
+        "description": "System: Proposed -> Active -> Retiring -> Retired",
+        "from_state": "Proposed",
+        "id": "state-transition-1",
+        "is_exception_flow": false,
+        "is_terminal_transition": false,
+        "model_layer": "analysis",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "state_transitions",
+          "id": "state-transition-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "state-transition-1",
+        "state_entity_id": "state-entity-system",
+        "state_entity_name": "System",
+        "to_state": "Active",
+        "trace": {
+          "source_key": "states_and_transitions",
+          "source_round": 6
+        },
+        "trigger": ""
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_6",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "105b7f94b43109c5",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint": "",
+        "content_semantics": "normative",
+        "description": "System: Proposed -> Active -> Retiring -> Retired",
+        "from_state": "Active",
+        "id": "state-transition-2",
+        "is_exception_flow": false,
+        "is_terminal_transition": false,
+        "model_layer": "analysis",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "state_transitions",
+          "id": "state-transition-2",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "state-transition-2",
+        "state_entity_id": "state-entity-system",
+        "state_entity_name": "System",
+        "to_state": "Retiring",
+        "trace": {
+          "source_key": "states_and_transitions",
+          "source_round": 6
+        },
+        "trigger": ""
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_6",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "3f1c2199aa90c5fa",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint": "",
+        "content_semantics": "normative",
+        "description": "System: Proposed -> Active -> Retiring -> Retired",
+        "from_state": "Retiring",
+        "id": "state-transition-3",
+        "is_exception_flow": false,
+        "is_terminal_transition": false,
+        "model_layer": "analysis",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "state_transitions",
+          "id": "state-transition-3",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "state-transition-3",
+        "state_entity_id": "state-entity-system",
+        "state_entity_name": "System",
+        "to_state": "Retired",
+        "trace": {
+          "source_key": "states_and_transitions",
+          "source_round": 6
+        },
+        "trigger": ""
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_6",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "e6ebcb7b94af23fb",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint": "",
+        "content_semantics": "normative",
+        "description": "System: Active -> Deprecated",
+        "from_state": "Active",
+        "id": "state-transition-4",
+        "is_exception_flow": false,
+        "is_terminal_transition": false,
+        "model_layer": "analysis",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "state_transitions",
+          "id": "state-transition-4",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "state-transition-4",
+        "state_entity_id": "state-entity-system",
+        "state_entity_name": "System",
+        "to_state": "Deprecated",
+        "trace": {
+          "source_key": "states_and_transitions",
+          "source_round": 6
+        },
+        "trigger": ""
+      }
+    ],
+    "trigger_ids": [
+      "trigger-1",
+      "trigger-2"
+    ],
+    "trigger_objects": [
+      {
+        "approval_required": true,
+        "change_metadata": {
+          "change_source": "round_6",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "abe96f51c19ab7b3",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint_type": "approval",
+        "content_semantics": "normative",
+        "description": "Deprecation approval requires enterprise architect review",
+        "event_name": "Deprecation approval",
+        "exceptional_behavior": false,
+        "id": "trigger-1",
+        "model_layer": "analysis",
+        "outcome": "enterprise architect review",
+        "semantic_id": "trigger-1",
+        "trace": {
+          "source_key": "triggers_and_approvals",
+          "source_round": 6
+        }
+      },
+      {
+        "approval_required": false,
+        "change_metadata": {
+          "change_source": "round_6",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "42de2ee3bbe7dfa8",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint_type": "event",
+        "content_semantics": "normative",
+        "description": "Contract expiry triggers lifecycle review",
+        "event_name": "Contract expiry",
+        "exceptional_behavior": false,
+        "id": "trigger-2",
+        "model_layer": "analysis",
+        "outcome": "lifecycle review",
+        "semantic_id": "trigger-2",
+        "trace": {
+          "source_key": "triggers_and_approvals",
+          "source_round": 6
+        }
+      }
+    ],
+    "use_case_ids": [
+      "register-a-system",
+      "edit-metadata",
+      "compare-overlapping-systems",
+      "track-lifecycle-state",
+      "review-risks",
+      "see-costs",
+      "approve-deprecation",
+      "report-portfolio-gaps"
+    ],
+    "use_case_step_ids": [],
+    "use_case_step_objects": [],
+    "use_cases": [
+      {
+        "change_metadata": {
+          "change_source": "round_3",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "d145a19075179f4d",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "complexity": "average",
+        "complexity_trace": {
+          "source_key": "use_case_complexity",
+          "source_round": 9
+        },
+        "content_semantics": "normative",
+        "extension_points": [],
+        "extensions": [],
+        "goal": "Register a system",
+        "id": "register-a-system",
+        "main_success_scenario": [],
+        "model_layer": "analysis",
+        "name": "Register a system",
+        "other_artifact_refs": [],
+        "other_requirement_ids": [],
+        "participating_analysis_object_ids": [
+          "entity-system",
+          "state-entity-system"
+        ],
+        "postconditions": [],
+        "preconditions": [],
+        "primary_actor": "Unspecified",
+        "primary_actor_id": "",
+        "priority": "",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_cases",
+          "id": "register-a-system",
+          "missing_fields": [
+            "main_success_scenario"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
+        },
+        "scenario_ids": [],
+        "semantic_id": "register-a-system",
+        "status": "",
+        "subordinate_use_case_ids": [],
+        "supporting_actor_ids": [],
+        "trace": {
+          "source_key": "use_cases",
+          "source_round": 3
+        },
+        "trigger": "",
+        "ui_notes": [],
+        "used_use_case_ids": []
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_3",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "49b57b797dfb65d8",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "complexity": "simple",
+        "complexity_trace": {
+          "source_key": "use_case_complexity",
+          "source_round": 9
+        },
+        "content_semantics": "normative",
+        "extension_points": [],
+        "extensions": [],
+        "goal": "edit metadata",
+        "id": "edit-metadata",
+        "main_success_scenario": [],
+        "model_layer": "analysis",
+        "name": "edit metadata",
+        "other_artifact_refs": [],
+        "other_requirement_ids": [],
+        "participating_analysis_object_ids": [],
+        "postconditions": [],
+        "preconditions": [],
+        "primary_actor": "Unspecified",
+        "primary_actor_id": "",
+        "priority": "",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_cases",
+          "id": "edit-metadata",
+          "missing_fields": [
+            "main_success_scenario"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
+        },
+        "scenario_ids": [],
+        "semantic_id": "edit-metadata",
+        "status": "",
+        "subordinate_use_case_ids": [],
+        "supporting_actor_ids": [],
+        "trace": {
+          "source_key": "use_cases",
+          "source_round": 3
+        },
+        "trigger": "",
+        "ui_notes": [],
+        "used_use_case_ids": []
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_3",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "97a5cb95cc045fb5",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "complexity": "average",
+        "complexity_trace": {
+          "source_key": "use_case_complexity",
+          "source_round": 9
+        },
+        "content_semantics": "normative",
+        "extension_points": [],
+        "extensions": [],
+        "goal": "compare overlapping systems",
+        "id": "compare-overlapping-systems",
+        "main_success_scenario": [],
+        "model_layer": "analysis",
+        "name": "compare overlapping systems",
+        "other_artifact_refs": [],
+        "other_requirement_ids": [],
+        "participating_analysis_object_ids": [
+          "entity-system",
+          "state-entity-system"
+        ],
+        "postconditions": [],
+        "preconditions": [],
+        "primary_actor": "Unspecified",
+        "primary_actor_id": "",
+        "priority": "",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_cases",
+          "id": "compare-overlapping-systems",
+          "missing_fields": [
+            "main_success_scenario"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
+        },
+        "scenario_ids": [],
+        "semantic_id": "compare-overlapping-systems",
+        "status": "",
+        "subordinate_use_case_ids": [],
+        "supporting_actor_ids": [],
+        "trace": {
+          "source_key": "use_cases",
+          "source_round": 3
+        },
+        "trigger": "",
+        "ui_notes": [],
+        "used_use_case_ids": []
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_3",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "6077961c843c1a2e",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "complexity": "average",
+        "complexity_trace": {
+          "source_key": "use_case_complexity",
+          "source_round": 9
+        },
+        "content_semantics": "normative",
+        "extension_points": [],
+        "extensions": [],
+        "goal": "track lifecycle state",
+        "id": "track-lifecycle-state",
+        "main_success_scenario": [],
+        "model_layer": "analysis",
+        "name": "track lifecycle state",
+        "other_artifact_refs": [],
+        "other_requirement_ids": [],
+        "participating_analysis_object_ids": [],
+        "postconditions": [],
+        "preconditions": [],
+        "primary_actor": "Unspecified",
+        "primary_actor_id": "",
+        "priority": "",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_cases",
+          "id": "track-lifecycle-state",
+          "missing_fields": [
+            "main_success_scenario"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
+        },
+        "scenario_ids": [],
+        "semantic_id": "track-lifecycle-state",
+        "status": "",
+        "subordinate_use_case_ids": [],
+        "supporting_actor_ids": [],
+        "trace": {
+          "source_key": "use_cases",
+          "source_round": 3
+        },
+        "trigger": "",
+        "ui_notes": [],
+        "used_use_case_ids": []
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_3",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "c5b1951eeada9174",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "complexity": "simple",
+        "complexity_trace": {
+          "source_key": "use_case_complexity",
+          "source_round": 9
+        },
+        "content_semantics": "normative",
+        "extension_points": [],
+        "extensions": [],
+        "goal": "review risks",
+        "id": "review-risks",
+        "main_success_scenario": [],
+        "model_layer": "analysis",
+        "name": "review risks",
+        "other_artifact_refs": [],
+        "other_requirement_ids": [],
+        "participating_analysis_object_ids": [],
+        "postconditions": [],
+        "preconditions": [],
+        "primary_actor": "Unspecified",
+        "primary_actor_id": "",
+        "priority": "",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_cases",
+          "id": "review-risks",
+          "missing_fields": [
+            "main_success_scenario"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
+        },
+        "scenario_ids": [],
+        "semantic_id": "review-risks",
+        "status": "",
+        "subordinate_use_case_ids": [],
+        "supporting_actor_ids": [],
+        "trace": {
+          "source_key": "use_cases",
+          "source_round": 3
+        },
+        "trigger": "",
+        "ui_notes": [],
+        "used_use_case_ids": []
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_3",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "6373ef70fd6e12c5",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "complexity": "simple",
+        "complexity_trace": {
+          "source_key": "use_case_complexity",
+          "source_round": 9
+        },
+        "content_semantics": "normative",
+        "extension_points": [],
+        "extensions": [],
+        "goal": "see costs",
+        "id": "see-costs",
+        "main_success_scenario": [],
+        "model_layer": "analysis",
+        "name": "see costs",
+        "other_artifact_refs": [],
+        "other_requirement_ids": [],
+        "participating_analysis_object_ids": [],
+        "postconditions": [],
+        "preconditions": [],
+        "primary_actor": "Unspecified",
+        "primary_actor_id": "",
+        "priority": "",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_cases",
+          "id": "see-costs",
+          "missing_fields": [
+            "main_success_scenario"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
+        },
+        "scenario_ids": [],
+        "semantic_id": "see-costs",
+        "status": "",
+        "subordinate_use_case_ids": [],
+        "supporting_actor_ids": [],
+        "trace": {
+          "source_key": "use_cases",
+          "source_round": 3
+        },
+        "trigger": "",
+        "ui_notes": [],
+        "used_use_case_ids": []
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_3",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "1bc75c3cb13f6dc9",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "complexity": "average",
+        "complexity_trace": {
+          "source_key": "use_case_complexity",
+          "source_round": 9
+        },
+        "content_semantics": "normative",
+        "extension_points": [],
+        "extensions": [],
+        "goal": "approve deprecation",
+        "id": "approve-deprecation",
+        "main_success_scenario": [],
+        "model_layer": "analysis",
+        "name": "approve deprecation",
+        "other_artifact_refs": [],
+        "other_requirement_ids": [],
+        "participating_analysis_object_ids": [],
+        "postconditions": [],
+        "preconditions": [],
+        "primary_actor": "Unspecified",
+        "primary_actor_id": "",
+        "priority": "",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_cases",
+          "id": "approve-deprecation",
+          "missing_fields": [
+            "main_success_scenario"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
+        },
+        "scenario_ids": [],
+        "semantic_id": "approve-deprecation",
+        "status": "",
+        "subordinate_use_case_ids": [],
+        "supporting_actor_ids": [],
+        "trace": {
+          "source_key": "use_cases",
+          "source_round": 3
+        },
+        "trigger": "",
+        "ui_notes": [],
+        "used_use_case_ids": []
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_3",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "073a5935f13208c1",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "complexity": "average",
+        "complexity_trace": {
+          "source_key": "use_case_complexity",
+          "source_round": 9
+        },
+        "content_semantics": "normative",
+        "extension_points": [],
+        "extensions": [],
+        "goal": "report portfolio gaps",
+        "id": "report-portfolio-gaps",
+        "main_success_scenario": [],
+        "model_layer": "analysis",
+        "name": "report portfolio gaps",
+        "other_artifact_refs": [],
+        "other_requirement_ids": [],
+        "participating_analysis_object_ids": [],
+        "postconditions": [],
+        "preconditions": [],
+        "primary_actor": "Unspecified",
+        "primary_actor_id": "",
+        "priority": "",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_cases",
+          "id": "report-portfolio-gaps",
+          "missing_fields": [
+            "main_success_scenario"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
+        },
+        "scenario_ids": [],
+        "semantic_id": "report-portfolio-gaps",
+        "status": "",
+        "subordinate_use_case_ids": [],
+        "supporting_actor_ids": [],
+        "trace": {
+          "source_key": "use_cases",
+          "source_round": 3
+        },
+        "trigger": "",
+        "ui_notes": [],
+        "used_use_case_ids": []
+      }
+    ]
+  },
+  "architecture_view": {
+    "component_objects": [
+      {
+        "change_metadata": {
+          "change_source": "round_7",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "7270b4d71f732879",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "component_kind": "application",
+        "content_semantics": "informative",
+        "id": "component-system-inventory-web-app",
+        "model_layer": "design",
+        "name": "System Inventory Web App",
+        "responsibility": "",
+        "runtime_environment": "",
+        "semantic_id": "component-system-inventory-web-app",
+        "trace": {
+          "source_key": "components_and_services",
+          "source_round": 7
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_7",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "3a1c7a77493fbaf6",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "component_kind": "api",
+        "content_semantics": "informative",
+        "id": "component-system-inventory-api",
+        "model_layer": "design",
+        "name": "System Inventory API",
+        "responsibility": "",
+        "runtime_environment": "",
+        "semantic_id": "component-system-inventory-api",
+        "trace": {
+          "source_key": "components_and_services",
+          "source_round": 7
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_7",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "cc52e8a061d76cd0",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "component_kind": "component",
+        "content_semantics": "informative",
+        "id": "component-reporting-consumers",
+        "model_layer": "design",
+        "name": "Reporting Consumers",
+        "responsibility": "",
+        "runtime_environment": "",
+        "semantic_id": "component-reporting-consumers",
+        "trace": {
+          "source_key": "components_and_services",
+          "source_round": 7
+        }
+      }
+    ],
+    "components_and_services": [
+      "System Inventory Web App",
+      "System Inventory API",
+      "Reporting Consumers"
+    ],
+    "interface_objects": [
+      {
+        "change_metadata": {
+          "change_source": "round_7",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "69a03a26d6ed27f2",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "informative",
+        "description": "System Inventory Web App calls System Inventory API",
+        "id": "interface-1",
+        "interaction_verb": "calls",
+        "model_layer": "design",
+        "protocol": "",
+        "semantic_id": "interface-1",
+        "source_component_id": "component-system-inventory-web-app",
+        "source_component_name": "System Inventory Web App",
+        "target_component_id": "component-system-inventory-api",
+        "target_component_name": "System Inventory API",
+        "trace": {
+          "source_key": "interfaces_and_integrations",
+          "source_round": 7
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_7",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "44e4a4a42d3319ec",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "informative",
+        "description": "System Inventory API sends Reporting Consumers",
+        "id": "interface-2",
+        "interaction_verb": "sends",
+        "model_layer": "design",
+        "protocol": "",
+        "semantic_id": "interface-2",
+        "source_component_id": "component-system-inventory-api",
+        "source_component_name": "System Inventory API",
+        "target_component_id": "component-reporting-consumers",
+        "target_component_name": "Reporting Consumers",
+        "trace": {
+          "source_key": "interfaces_and_integrations",
+          "source_round": 7
+        }
+      }
+    ],
+    "interfaces_and_integrations": [
+      "System Inventory Web App calls System Inventory API",
+      "System Inventory API sends Reporting Consumers"
+    ],
+    "runtime_boundaries": [
+      "System Inventory API runs separately from the UI"
+    ],
+    "runtime_boundary_objects": [
+      {
+        "boundary_type": "runtime_separation",
+        "change_metadata": {
+          "change_source": "round_7",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "c7d34ba59a95bc4d",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "informative",
+        "deployment_nodes": [],
+        "description": "System Inventory API runs separately from the UI",
+        "id": "runtime-boundary-1",
+        "model_layer": "design",
+        "name": "Runtime Boundary 1",
+        "semantic_id": "runtime-boundary-1",
+        "trace": {
+          "source_key": "runtime_boundaries",
+          "source_round": 7
+        }
+      }
+    ]
+  },
+  "assumptions": [],
+  "business_goals": [
+    "Better planning of IT systems purchasing and life cycle"
+  ],
+  "design_view": {
+    "component_ids": [
+      "component-system-inventory-web-app",
+      "component-system-inventory-api",
+      "component-reporting-consumers"
+    ],
+    "component_objects": [
+      {
+        "change_metadata": {
+          "change_source": "round_7",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "7270b4d71f732879",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "component_kind": "application",
+        "content_semantics": "informative",
+        "id": "component-system-inventory-web-app",
+        "model_layer": "design",
+        "name": "System Inventory Web App",
+        "responsibility": "",
+        "runtime_environment": "",
+        "semantic_id": "component-system-inventory-web-app",
+        "trace": {
+          "source_key": "components_and_services",
+          "source_round": 7
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_7",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "3a1c7a77493fbaf6",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "component_kind": "api",
+        "content_semantics": "informative",
+        "id": "component-system-inventory-api",
+        "model_layer": "design",
+        "name": "System Inventory API",
+        "responsibility": "",
+        "runtime_environment": "",
+        "semantic_id": "component-system-inventory-api",
+        "trace": {
+          "source_key": "components_and_services",
+          "source_round": 7
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_7",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "cc52e8a061d76cd0",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "component_kind": "component",
+        "content_semantics": "informative",
+        "id": "component-reporting-consumers",
+        "model_layer": "design",
+        "name": "Reporting Consumers",
+        "responsibility": "",
+        "runtime_environment": "",
+        "semantic_id": "component-reporting-consumers",
+        "trace": {
+          "source_key": "components_and_services",
+          "source_round": 7
+        }
+      }
+    ],
+    "interface_ids": [
+      "interface-1",
+      "interface-2"
+    ],
+    "interface_objects": [
+      {
+        "change_metadata": {
+          "change_source": "round_7",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "69a03a26d6ed27f2",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "informative",
+        "description": "System Inventory Web App calls System Inventory API",
+        "id": "interface-1",
+        "interaction_verb": "calls",
+        "model_layer": "design",
+        "protocol": "",
+        "semantic_id": "interface-1",
+        "source_component_id": "component-system-inventory-web-app",
+        "source_component_name": "System Inventory Web App",
+        "target_component_id": "component-system-inventory-api",
+        "target_component_name": "System Inventory API",
+        "trace": {
+          "source_key": "interfaces_and_integrations",
+          "source_round": 7
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_7",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "44e4a4a42d3319ec",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "informative",
+        "description": "System Inventory API sends Reporting Consumers",
+        "id": "interface-2",
+        "interaction_verb": "sends",
+        "model_layer": "design",
+        "protocol": "",
+        "semantic_id": "interface-2",
+        "source_component_id": "component-system-inventory-api",
+        "source_component_name": "System Inventory API",
+        "target_component_id": "component-reporting-consumers",
+        "target_component_name": "Reporting Consumers",
+        "trace": {
+          "source_key": "interfaces_and_integrations",
+          "source_round": 7
+        }
+      }
+    ],
+    "runtime_boundary_ids": [
+      "runtime-boundary-1"
+    ],
+    "runtime_boundary_objects": [
+      {
+        "boundary_type": "runtime_separation",
+        "change_metadata": {
+          "change_source": "round_7",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "c7d34ba59a95bc4d",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "informative",
+        "deployment_nodes": [],
+        "description": "System Inventory API runs separately from the UI",
+        "id": "runtime-boundary-1",
+        "model_layer": "design",
+        "name": "Runtime Boundary 1",
+        "semantic_id": "runtime-boundary-1",
+        "trace": {
+          "source_key": "runtime_boundaries",
+          "source_round": 7
+        }
+      }
+    ]
+  },
+  "element_readiness": {
+    "by_family": {
+      "acceptance_constraints": [
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-requirement-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-requirement-2",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-requirement-3",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-requirement-4",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-requirement-5",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-requirement-6",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-requirement-7",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-requirement-8",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-success-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        }
+      ],
+      "ambiguities": [],
+      "domain_invariants": [
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "domain_invariants",
+          "id": "domain-invariant-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "domain_invariants",
+          "id": "domain-invariant-2",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "domain_invariants",
+          "id": "domain-invariant-3",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        }
+      ],
+      "forbidden_transitions": [],
+      "guard_conditions": [
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "guard_conditions",
+          "id": "guard-condition-1",
+          "missing_fields": [
+            "related_transition_ids"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "guard_conditions",
+          "id": "guard-condition-2",
+          "missing_fields": [
+            "related_transition_ids"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
+        }
+      ],
+      "requirements": [
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "functional-requirement-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "functional-requirement-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "non_functional-requirement-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "non_functional-requirement-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "non_functional-requirement-2",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "non_functional-requirement-3",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "non_functional-requirement-4",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "non_functional-requirement-5",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "non_functional-requirement-6",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "non_functional-requirement-7",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        }
+      ],
+      "scenarios": [],
+      "state_invariants": [
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "state_invariants",
+          "id": "state-invariant-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "state_invariants",
+          "id": "state-invariant-2",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "state_invariants",
+          "id": "state-invariant-3",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        }
+      ],
+      "state_transitions": [
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "state_transitions",
+          "id": "state-transition-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "state_transitions",
+          "id": "state-transition-2",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "state_transitions",
+          "id": "state-transition-3",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "state_transitions",
+          "id": "state-transition-4",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        }
+      ],
+      "use_case_steps": [],
+      "use_cases": [
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_cases",
+          "id": "register-a-system",
+          "missing_fields": [
+            "main_success_scenario"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_cases",
+          "id": "edit-metadata",
+          "missing_fields": [
+            "main_success_scenario"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_cases",
+          "id": "compare-overlapping-systems",
+          "missing_fields": [
+            "main_success_scenario"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_cases",
+          "id": "track-lifecycle-state",
+          "missing_fields": [
+            "main_success_scenario"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_cases",
+          "id": "review-risks",
+          "missing_fields": [
+            "main_success_scenario"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_cases",
+          "id": "see-costs",
+          "missing_fields": [
+            "main_success_scenario"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_cases",
+          "id": "approve-deprecation",
+          "missing_fields": [
+            "main_success_scenario"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_cases",
+          "id": "report-portfolio-gaps",
+          "missing_fields": [
+            "main_success_scenario"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
+        }
+      ]
+    },
+    "summary": {
+      "blocked_normative_ids": [
+        "register-a-system",
+        "edit-metadata",
+        "compare-overlapping-systems",
+        "track-lifecycle-state",
+        "review-risks",
+        "see-costs",
+        "approve-deprecation",
+        "report-portfolio-gaps",
+        "guard-condition-1",
+        "guard-condition-2"
+      ],
+      "informative_ids": [],
+      "partial_normative_ids": [],
+      "ready_normative_ids": [
+        "functional-requirement-1",
+        "functional-requirement-1",
+        "non_functional-requirement-1",
+        "non_functional-requirement-1",
+        "non_functional-requirement-2",
+        "non_functional-requirement-3",
+        "non_functional-requirement-4",
+        "non_functional-requirement-5",
+        "non_functional-requirement-6",
+        "non_functional-requirement-7",
+        "acceptance-constraint-requirement-1",
+        "acceptance-constraint-requirement-2",
+        "acceptance-constraint-requirement-3",
+        "acceptance-constraint-requirement-4",
+        "acceptance-constraint-requirement-5",
+        "acceptance-constraint-requirement-6",
+        "acceptance-constraint-requirement-7",
+        "acceptance-constraint-requirement-8",
+        "acceptance-constraint-success-1",
+        "state-transition-1",
+        "state-transition-2",
+        "state-transition-3",
+        "state-transition-4",
+        "domain-invariant-1",
+        "domain-invariant-2",
+        "domain-invariant-3",
+        "state-invariant-1",
+        "state-invariant-2",
+        "state-invariant-3"
+      ]
+    }
+  },
+  "future_placeholders": {
+    "formal_specification": [],
+    "uml": []
+  },
+  "interaction_view": {
+    "message_ids": [
+      "interaction-message-1",
+      "interaction-message-2"
+    ],
+    "message_objects": [
+      {
+        "change_metadata": {
+          "change_source": "derived_interaction_view",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "53cc90b2f2a8e8e9",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "description": "System Inventory Web App calls System Inventory API",
+        "id": "interaction-message-1",
+        "interaction_verb": "calls",
+        "model_layer": "design",
+        "semantic_id": "interaction-message-1",
+        "source_id": "component-system-inventory-web-app",
+        "source_name": "System Inventory Web App",
+        "target_id": "component-system-inventory-api",
+        "target_name": "System Inventory API",
+        "trace": {
+          "source_key": "interfaces_and_integrations",
+          "source_round": 7
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_interaction_view",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "99af7d4c88ac8b72",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "description": "System Inventory API sends Reporting Consumers",
+        "id": "interaction-message-2",
+        "interaction_verb": "sends",
+        "model_layer": "design",
+        "semantic_id": "interaction-message-2",
+        "source_id": "component-system-inventory-api",
+        "source_name": "System Inventory API",
+        "target_id": "component-reporting-consumers",
+        "target_name": "Reporting Consumers",
+        "trace": {
+          "source_key": "interfaces_and_integrations",
+          "source_round": 7
+        }
+      }
+    ],
+    "realization_ids": [
+      "interaction-realization-1",
+      "interaction-realization-2",
+      "interaction-realization-3",
+      "interaction-realization-4",
+      "interaction-realization-5",
+      "interaction-realization-6",
+      "interaction-realization-7",
+      "interaction-realization-8"
+    ],
+    "realization_objects": [
+      {
+        "change_metadata": {
+          "change_source": "derived_interaction_view",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "d072c2560757e2d9",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "id": "interaction-realization-1",
+        "model_layer": "analysis",
+        "participant_ids": [],
+        "participant_names": [],
+        "semantic_id": "interaction-realization-1",
+        "step_objects": [],
+        "steps": [],
+        "trace": {
+          "source_key": "use_cases",
+          "source_round": 3
+        },
+        "use_case_id": "register-a-system",
+        "use_case_name": "Register a system"
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_interaction_view",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "40cd1e2a53575d83",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "id": "interaction-realization-2",
+        "model_layer": "analysis",
+        "participant_ids": [],
+        "participant_names": [],
+        "semantic_id": "interaction-realization-2",
+        "step_objects": [],
+        "steps": [],
+        "trace": {
+          "source_key": "use_cases",
+          "source_round": 3
+        },
+        "use_case_id": "edit-metadata",
+        "use_case_name": "edit metadata"
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_interaction_view",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "c86ec221438a6616",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "id": "interaction-realization-3",
+        "model_layer": "analysis",
+        "participant_ids": [],
+        "participant_names": [],
+        "semantic_id": "interaction-realization-3",
+        "step_objects": [],
+        "steps": [],
+        "trace": {
+          "source_key": "use_cases",
+          "source_round": 3
+        },
+        "use_case_id": "compare-overlapping-systems",
+        "use_case_name": "compare overlapping systems"
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_interaction_view",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "ee0830f3794bd18d",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "id": "interaction-realization-4",
+        "model_layer": "analysis",
+        "participant_ids": [],
+        "participant_names": [],
+        "semantic_id": "interaction-realization-4",
+        "step_objects": [],
+        "steps": [],
+        "trace": {
+          "source_key": "use_cases",
+          "source_round": 3
+        },
+        "use_case_id": "track-lifecycle-state",
+        "use_case_name": "track lifecycle state"
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_interaction_view",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "20691c1c22171f6d",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "id": "interaction-realization-5",
+        "model_layer": "analysis",
+        "participant_ids": [],
+        "participant_names": [],
+        "semantic_id": "interaction-realization-5",
+        "step_objects": [],
+        "steps": [],
+        "trace": {
+          "source_key": "use_cases",
+          "source_round": 3
+        },
+        "use_case_id": "review-risks",
+        "use_case_name": "review risks"
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_interaction_view",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "1df7247cb3f8591e",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "id": "interaction-realization-6",
+        "model_layer": "analysis",
+        "participant_ids": [],
+        "participant_names": [],
+        "semantic_id": "interaction-realization-6",
+        "step_objects": [],
+        "steps": [],
+        "trace": {
+          "source_key": "use_cases",
+          "source_round": 3
+        },
+        "use_case_id": "see-costs",
+        "use_case_name": "see costs"
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_interaction_view",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "4a3d424b2f344fbb",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "id": "interaction-realization-7",
+        "model_layer": "analysis",
+        "participant_ids": [],
+        "participant_names": [],
+        "semantic_id": "interaction-realization-7",
+        "step_objects": [],
+        "steps": [],
+        "trace": {
+          "source_key": "use_cases",
+          "source_round": 3
+        },
+        "use_case_id": "approve-deprecation",
+        "use_case_name": "approve deprecation"
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_interaction_view",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "ded44714c4ff2465",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "id": "interaction-realization-8",
+        "model_layer": "analysis",
+        "participant_ids": [],
+        "participant_names": [],
+        "semantic_id": "interaction-realization-8",
+        "step_objects": [],
+        "steps": [],
+        "trace": {
+          "source_key": "use_cases",
+          "source_round": 3
+        },
+        "use_case_id": "report-portfolio-gaps",
+        "use_case_name": "report portfolio gaps"
+      }
+    ]
+  },
+  "logical_view": {
+    "business_rule_objects": [
+      {
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "39d0fe629127c7ed",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "id": "business-rule-1",
+        "model_layer": "analysis",
+        "name": "Rule 1",
+        "rule_text": "A System must have a business owner before it becomes Active.",
+        "scope": "A System",
+        "semantic_id": "business-rule-1",
+        "trace": {
+          "source_key": "business_rules",
+          "source_round": 5
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "68c0c8b8aeec81ca",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "id": "business-rule-2",
+        "model_layer": "analysis",
+        "name": "Rule 2",
+        "rule_text": "A System lifecycle state change requires approval for deprecation.",
+        "scope": "A System lifecycle state change",
+        "semantic_id": "business-rule-2",
+        "trace": {
+          "source_key": "business_rules",
+          "source_round": 5
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "79c6a2ee0ae3e1ec",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "id": "business-rule-3",
+        "model_layer": "analysis",
+        "name": "Rule 3",
+        "rule_text": "A System must record vendor and contract dates.",
+        "scope": "A System",
+        "semantic_id": "business-rule-3",
+        "trace": {
+          "source_key": "business_rules",
+          "source_round": 5
+        }
+      }
+    ],
+    "business_rules": [
+      "A System must have a business owner before it becomes Active.",
+      "A System lifecycle state change requires approval for deprecation.",
+      "A System must record vendor and contract dates."
+    ],
+    "domain_entities": [
+      "System",
+      "Risk Assessment",
+      "Cost Record",
+      "Capability",
+      "Contract",
+      "Integration"
+    ],
+    "domain_entity_objects": [
+      {
+        "attributes": [],
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "1577db3f693c63c0",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "",
+        "entity_type": "domain_entity",
+        "id": "entity-system",
+        "model_layer": "analysis",
+        "name": "System",
+        "responsibilities": [],
+        "semantic_id": "entity-system",
+        "trace": {
+          "source_key": "domain_entities",
+          "source_round": 5
+        }
+      },
+      {
+        "attributes": [],
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "a57ef4a16cb94f26",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "",
+        "entity_type": "domain_entity",
+        "id": "entity-risk-assessment",
+        "model_layer": "analysis",
+        "name": "Risk Assessment",
+        "responsibilities": [],
+        "semantic_id": "entity-risk-assessment",
+        "trace": {
+          "source_key": "domain_entities",
+          "source_round": 5
+        }
+      },
+      {
+        "attributes": [],
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "1c046a800433e10b",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "",
+        "entity_type": "domain_entity",
+        "id": "entity-cost-record",
+        "model_layer": "analysis",
+        "name": "Cost Record",
+        "responsibilities": [],
+        "semantic_id": "entity-cost-record",
+        "trace": {
+          "source_key": "domain_entities",
+          "source_round": 5
+        }
+      },
+      {
+        "attributes": [],
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "09258b7496344799",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "",
+        "entity_type": "domain_entity",
+        "id": "entity-capability",
+        "model_layer": "analysis",
+        "name": "Capability",
+        "responsibilities": [],
+        "semantic_id": "entity-capability",
+        "trace": {
+          "source_key": "domain_entities",
+          "source_round": 5
+        }
+      },
+      {
+        "attributes": [],
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "d5474b4336ad506b",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "",
+        "entity_type": "domain_entity",
+        "id": "entity-contract",
+        "model_layer": "analysis",
+        "name": "Contract",
+        "responsibilities": [],
+        "semantic_id": "entity-contract",
+        "trace": {
+          "source_key": "domain_entities",
+          "source_round": 5
+        }
+      },
+      {
+        "attributes": [],
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "eb58d30f221513d9",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "",
+        "entity_type": "domain_entity",
+        "id": "entity-integration",
+        "model_layer": "analysis",
+        "name": "Integration",
+        "responsibilities": [],
+        "semantic_id": "entity-integration",
+        "trace": {
+          "source_key": "domain_entities",
+          "source_round": 5
+        }
+      }
+    ],
+    "domain_invariant_objects": [
+      {
+        "change_metadata": {
+          "change_source": "derived_domain_invariants",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "a0838e2d92556587",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "A System must have a business owner before it becomes Active.",
+        "id": "domain-invariant-1",
+        "model_layer": "analysis",
+        "name": "Rule 1",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "domain_invariants",
+          "id": "domain-invariant-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "scope_entity_ids": [
+          "entity-system"
+        ],
+        "semantic_id": "domain-invariant-1",
+        "source_business_rule_id": "business-rule-1",
+        "trace": {
+          "source_key": "business_rules",
+          "source_round": 5
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_domain_invariants",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "0faa9d909ed4effe",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "A System lifecycle state change requires approval for deprecation.",
+        "id": "domain-invariant-2",
+        "model_layer": "analysis",
+        "name": "Rule 2",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "domain_invariants",
+          "id": "domain-invariant-2",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "scope_entity_ids": [
+          "entity-system"
+        ],
+        "semantic_id": "domain-invariant-2",
+        "source_business_rule_id": "business-rule-2",
+        "trace": {
+          "source_key": "business_rules",
+          "source_round": 5
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_domain_invariants",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "ae58a8512d9d5819",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "A System must record vendor and contract dates.",
+        "id": "domain-invariant-3",
+        "model_layer": "analysis",
+        "name": "Rule 3",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "domain_invariants",
+          "id": "domain-invariant-3",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "scope_entity_ids": [
+          "entity-system",
+          "entity-contract"
+        ],
+        "semantic_id": "domain-invariant-3",
+        "source_business_rule_id": "business-rule-3",
+        "trace": {
+          "source_key": "business_rules",
+          "source_round": 5
+        }
+      }
+    ],
+    "domain_invariants": [
+      "A System must have a business owner before it becomes Active.",
+      "A System lifecycle state change requires approval for deprecation.",
+      "A System must record vendor and contract dates."
+    ],
+    "relationship_objects": [
+      {
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "00b251588522b7b6",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "A System has one Business Owner",
+        "id": "relationship-1",
+        "model_layer": "analysis",
+        "relationship_type": "",
+        "semantic_id": "relationship-1",
+        "source_entity_id": "",
+        "source_multiplicity": "",
+        "source_name": "",
+        "source_role_name": "",
+        "target_entity_id": "",
+        "target_multiplicity": "",
+        "target_name": "",
+        "target_role_name": "",
+        "trace": {
+          "source_key": "relationships",
+          "source_round": 5
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "360538e5dcd99cae",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "A System has one Technical Owner",
+        "id": "relationship-2",
+        "model_layer": "analysis",
+        "relationship_type": "",
+        "semantic_id": "relationship-2",
+        "source_entity_id": "",
+        "source_multiplicity": "",
+        "source_name": "",
+        "source_role_name": "",
+        "target_entity_id": "",
+        "target_multiplicity": "",
+        "target_name": "",
+        "target_role_name": "",
+        "trace": {
+          "source_key": "relationships",
+          "source_round": 5
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "934f71080e23519e",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "A System has many Integrations",
+        "id": "relationship-3",
+        "model_layer": "analysis",
+        "relationship_type": "has_many",
+        "semantic_id": "relationship-3",
+        "source_entity_id": "entity-system",
+        "source_multiplicity": "1",
+        "source_name": "A System",
+        "source_role_name": "integrations",
+        "target_entity_id": "entity-integration",
+        "target_multiplicity": "*",
+        "target_name": "Integrations",
+        "target_role_name": "a_system",
+        "trace": {
+          "source_key": "relationships",
+          "source_round": 5
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "ab39194c2a6358f7",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "A System has many Capabilities",
+        "id": "relationship-4",
+        "model_layer": "analysis",
+        "relationship_type": "has_many",
+        "semantic_id": "relationship-4",
+        "source_entity_id": "entity-system",
+        "source_multiplicity": "1",
+        "source_name": "A System",
+        "source_role_name": "capabilities",
+        "target_entity_id": "",
+        "target_multiplicity": "*",
+        "target_name": "Capabilities",
+        "target_role_name": "a_system",
+        "trace": {
+          "source_key": "relationships",
+          "source_round": 5
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "805991d9f16d4aa5",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "A System has one Contract",
+        "id": "relationship-5",
+        "model_layer": "analysis",
+        "relationship_type": "",
+        "semantic_id": "relationship-5",
+        "source_entity_id": "",
+        "source_multiplicity": "",
+        "source_name": "",
+        "source_role_name": "",
+        "target_entity_id": "",
+        "target_multiplicity": "",
+        "target_name": "",
+        "target_role_name": "",
+        "trace": {
+          "source_key": "relationships",
+          "source_round": 5
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "fa8309800cc5f504",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "A System has many Risk Assessments",
+        "id": "relationship-6",
+        "model_layer": "analysis",
+        "relationship_type": "has_many",
+        "semantic_id": "relationship-6",
+        "source_entity_id": "entity-system",
+        "source_multiplicity": "1",
+        "source_name": "A System",
+        "source_role_name": "risk_assessments",
+        "target_entity_id": "entity-risk-assessment",
+        "target_multiplicity": "*",
+        "target_name": "Risk Assessments",
+        "target_role_name": "a_system",
+        "trace": {
+          "source_key": "relationships",
+          "source_round": 5
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "ec019fec6642681e",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "A System has many Cost Records",
+        "id": "relationship-7",
+        "model_layer": "analysis",
+        "relationship_type": "has_many",
+        "semantic_id": "relationship-7",
+        "source_entity_id": "entity-system",
+        "source_multiplicity": "1",
+        "source_name": "A System",
+        "source_role_name": "cost_records",
+        "target_entity_id": "entity-cost-record",
+        "target_multiplicity": "*",
+        "target_name": "Cost Records",
+        "target_role_name": "a_system",
+        "trace": {
+          "source_key": "relationships",
+          "source_round": 5
+        }
+      }
+    ],
+    "relationships": [
+      "A System has one Business Owner",
+      "A System has one Technical Owner",
+      "A System has many Integrations",
+      "A System has many Capabilities",
+      "A System has one Contract",
+      "A System has many Risk Assessments",
+      "A System has many Cost Records"
+    ]
+  },
+  "metadata_fields": [
+    "System name",
+    "description",
+    "vendor",
+    "deployment type",
+    "business owner",
+    "technical owner",
+    "data classification",
+    "hosting model",
+    "integrations",
+    "capabilities supported",
+    "user population",
+    "geography",
+    "contract dates"
+  ],
+  "model_metadata": {
+    "change_metadata": {
+      "change_source": "normalize_replay_to_model",
+      "last_changed_at": "",
+      "regenerated_from_version": "",
+      "semantic_hash": "2f3ec68a35e9678e",
+      "semantic_version": 1,
+      "supersedes": []
+    },
+    "schema_version": 1,
+    "semantic_id": "rupify-model"
+  },
+  "open_questions": [],
+  "process_view": {
+    "forbidden_transition_objects": [],
+    "forbidden_transitions": [],
+    "guard_condition_objects": [
+      {
+        "change_metadata": {
+          "change_source": "derived_guard_conditions",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "065fe600e6dfe1f2",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "condition_text": "Deprecation approval requires enterprise architect review",
+        "content_semantics": "normative",
+        "description": "Deprecation approval requires enterprise architect review",
+        "id": "guard-condition-1",
+        "model_layer": "analysis",
+        "name": "Deprecation approval",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "guard_conditions",
+          "id": "guard-condition-1",
+          "missing_fields": [
+            "related_transition_ids"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
+        },
+        "related_transition_ids": [],
+        "semantic_id": "guard-condition-1",
+        "source_trigger_id": "trigger-1",
+        "state_entity_ids": [],
+        "trace": {
+          "source_key": "triggers_and_approvals",
+          "source_round": 6
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_guard_conditions",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "bed0aa2ab2818dc4",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "condition_text": "Contract expiry triggers lifecycle review",
+        "content_semantics": "normative",
+        "description": "Contract expiry triggers lifecycle review",
+        "id": "guard-condition-2",
+        "model_layer": "analysis",
+        "name": "Contract expiry",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "guard_conditions",
+          "id": "guard-condition-2",
+          "missing_fields": [
+            "related_transition_ids"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
+        },
+        "related_transition_ids": [],
+        "semantic_id": "guard-condition-2",
+        "source_trigger_id": "trigger-2",
+        "state_entity_ids": [],
+        "trace": {
+          "source_key": "triggers_and_approvals",
+          "source_round": 6
+        }
+      }
+    ],
+    "guard_conditions": [
+      "Deprecation approval requires enterprise architect review",
+      "Contract expiry triggers lifecycle review"
+    ],
+    "state_entities": [
+      "System"
+    ],
+    "state_entity_objects": [
+      {
+        "change_metadata": {
+          "change_source": "round_6",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "87ced495451bbf64",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "",
+        "entity_type": "stateful_entity",
+        "id": "state-entity-system",
+        "model_layer": "analysis",
+        "name": "System",
+        "semantic_id": "state-entity-system",
+        "states": [
+          "Proposed",
+          "Active",
+          "Retiring",
+          "Retired",
+          "Deprecated"
+        ],
+        "trace": {
+          "source_key": "state_entities",
+          "source_round": 6
+        }
+      }
+    ],
+    "state_invariant_objects": [
+      {
+        "change_metadata": {
+          "change_source": "derived_state_invariants",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "e99d374908167c66",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "A System must have a business owner before it becomes Active.",
+        "id": "state-invariant-1",
+        "model_layer": "analysis",
+        "name": "Rule 1",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "state_invariants",
+          "id": "state-invariant-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "state-invariant-1",
+        "source_business_rule_id": "business-rule-1",
+        "state_entity_ids": [
+          "state-entity-system"
+        ],
+        "trace": {
+          "source_key": "business_rules",
+          "source_round": 5
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_state_invariants",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "d3f0734ba4f5d238",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "A System lifecycle state change requires approval for deprecation.",
+        "id": "state-invariant-2",
+        "model_layer": "analysis",
+        "name": "Rule 2",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "state_invariants",
+          "id": "state-invariant-2",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "state-invariant-2",
+        "source_business_rule_id": "business-rule-2",
+        "state_entity_ids": [
+          "state-entity-system"
+        ],
+        "trace": {
+          "source_key": "business_rules",
+          "source_round": 5
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_state_invariants",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "86c22df4bc630d1b",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "A System must record vendor and contract dates.",
+        "id": "state-invariant-3",
+        "model_layer": "analysis",
+        "name": "Rule 3",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "state_invariants",
+          "id": "state-invariant-3",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "state-invariant-3",
+        "source_business_rule_id": "business-rule-3",
+        "state_entity_ids": [
+          "state-entity-system"
+        ],
+        "trace": {
+          "source_key": "business_rules",
+          "source_round": 5
+        }
+      }
+    ],
+    "state_invariants": [
+      "A System must have a business owner before it becomes Active.",
+      "A System lifecycle state change requires approval for deprecation.",
+      "A System must record vendor and contract dates."
+    ],
+    "state_transition_objects": [
+      {
+        "change_metadata": {
+          "change_source": "round_6",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "79c9acbe984baf73",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint": "",
+        "content_semantics": "normative",
+        "description": "System: Proposed -> Active -> Retiring -> Retired",
+        "from_state": "Proposed",
+        "id": "state-transition-1",
+        "is_exception_flow": false,
+        "is_terminal_transition": false,
+        "model_layer": "analysis",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "state_transitions",
+          "id": "state-transition-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "state-transition-1",
+        "state_entity_id": "state-entity-system",
+        "state_entity_name": "System",
+        "to_state": "Active",
+        "trace": {
+          "source_key": "states_and_transitions",
+          "source_round": 6
+        },
+        "trigger": ""
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_6",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "105b7f94b43109c5",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint": "",
+        "content_semantics": "normative",
+        "description": "System: Proposed -> Active -> Retiring -> Retired",
+        "from_state": "Active",
+        "id": "state-transition-2",
+        "is_exception_flow": false,
+        "is_terminal_transition": false,
+        "model_layer": "analysis",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "state_transitions",
+          "id": "state-transition-2",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "state-transition-2",
+        "state_entity_id": "state-entity-system",
+        "state_entity_name": "System",
+        "to_state": "Retiring",
+        "trace": {
+          "source_key": "states_and_transitions",
+          "source_round": 6
+        },
+        "trigger": ""
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_6",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "3f1c2199aa90c5fa",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint": "",
+        "content_semantics": "normative",
+        "description": "System: Proposed -> Active -> Retiring -> Retired",
+        "from_state": "Retiring",
+        "id": "state-transition-3",
+        "is_exception_flow": false,
+        "is_terminal_transition": false,
+        "model_layer": "analysis",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "state_transitions",
+          "id": "state-transition-3",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "state-transition-3",
+        "state_entity_id": "state-entity-system",
+        "state_entity_name": "System",
+        "to_state": "Retired",
+        "trace": {
+          "source_key": "states_and_transitions",
+          "source_round": 6
+        },
+        "trigger": ""
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_6",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "e6ebcb7b94af23fb",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint": "",
+        "content_semantics": "normative",
+        "description": "System: Active -> Deprecated",
+        "from_state": "Active",
+        "id": "state-transition-4",
+        "is_exception_flow": false,
+        "is_terminal_transition": false,
+        "model_layer": "analysis",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "state_transitions",
+          "id": "state-transition-4",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "state-transition-4",
+        "state_entity_id": "state-entity-system",
+        "state_entity_name": "System",
+        "to_state": "Deprecated",
+        "trace": {
+          "source_key": "states_and_transitions",
+          "source_round": 6
+        },
+        "trigger": ""
+      }
+    ],
+    "states_and_transitions": [
+      "System: Proposed -> Active -> Retiring -> Retired",
+      "System: Proposed -> Active -> Retiring -> Retired",
+      "System: Proposed -> Active -> Retiring -> Retired",
+      "System: Active -> Deprecated"
+    ],
+    "trigger_objects": [
+      {
+        "approval_required": true,
+        "change_metadata": {
+          "change_source": "round_6",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "abe96f51c19ab7b3",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint_type": "approval",
+        "content_semantics": "normative",
+        "description": "Deprecation approval requires enterprise architect review",
+        "event_name": "Deprecation approval",
+        "exceptional_behavior": false,
+        "id": "trigger-1",
+        "model_layer": "analysis",
+        "outcome": "enterprise architect review",
+        "semantic_id": "trigger-1",
+        "trace": {
+          "source_key": "triggers_and_approvals",
+          "source_round": 6
+        }
+      },
+      {
+        "approval_required": false,
+        "change_metadata": {
+          "change_source": "round_6",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "42de2ee3bbe7dfa8",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint_type": "event",
+        "content_semantics": "normative",
+        "description": "Contract expiry triggers lifecycle review",
+        "event_name": "Contract expiry",
+        "exceptional_behavior": false,
+        "id": "trigger-2",
+        "model_layer": "analysis",
+        "outcome": "lifecycle review",
+        "semantic_id": "trigger-2",
+        "trace": {
+          "source_key": "triggers_and_approvals",
+          "source_round": 6
+        }
+      }
+    ],
+    "triggers_and_approvals": [
+      "Deprecation approval requires enterprise architect review",
+      "Contract expiry triggers lifecycle review"
+    ]
+  },
+  "project": {
+    "domain": "Unspecified",
+    "name": "A system to manage inventory of IT Systems themselves.",
+    "problem_statement": "We have many IT Systems and some overlap, some are free, some are expensive, all are slightly different.",
+    "system_scope": "All IT systems"
+  },
+  "requirements": {
+    "acceptance_constraint_objects": [
+      {
+        "change_metadata": {
+          "change_source": "derived_acceptance_constraints",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "926a0e8b7f0d0604",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint_kind": "non_functional_requirement",
+        "content_semantics": "normative",
+        "description": "UI must be web based",
+        "id": "acceptance-constraint-requirement-1",
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "name": "Acceptance Constraint 1",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-requirement-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "acceptance-constraint-requirement-1",
+        "source_requirement_id": "non_functional-requirement-1",
+        "trace": {
+          "source_key": "constraints",
+          "source_round": 2
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_acceptance_constraints",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "ea270a270fd5ae0a",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint_kind": "non_functional_requirement",
+        "content_semantics": "normative",
+        "description": "SSO",
+        "id": "acceptance-constraint-requirement-2",
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "name": "Acceptance Constraint 2",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-requirement-2",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "acceptance-constraint-requirement-2",
+        "source_requirement_id": "non_functional-requirement-1",
+        "trace": {
+          "source_key": "non_functional_requirements",
+          "source_round": 4
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_acceptance_constraints",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "cc94e38b4882a356",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint_kind": "non_functional_requirement",
+        "content_semantics": "normative",
+        "description": "role-based access",
+        "id": "acceptance-constraint-requirement-3",
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "name": "Acceptance Constraint 3",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-requirement-3",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "acceptance-constraint-requirement-3",
+        "source_requirement_id": "non_functional-requirement-2",
+        "trace": {
+          "source_key": "non_functional_requirements",
+          "source_round": 4
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_acceptance_constraints",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "e3b5c94d9e1c0566",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint_kind": "non_functional_requirement",
+        "content_semantics": "normative",
+        "description": "audit trail",
+        "id": "acceptance-constraint-requirement-4",
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "name": "Acceptance Constraint 4",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-requirement-4",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "acceptance-constraint-requirement-4",
+        "source_requirement_id": "non_functional-requirement-3",
+        "trace": {
+          "source_key": "non_functional_requirements",
+          "source_round": 4
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_acceptance_constraints",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "9c5f49ef585cd8db",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint_kind": "non_functional_requirement",
+        "content_semantics": "normative",
+        "description": "search",
+        "id": "acceptance-constraint-requirement-5",
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "name": "Acceptance Constraint 5",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-requirement-5",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "acceptance-constraint-requirement-5",
+        "source_requirement_id": "non_functional-requirement-4",
+        "trace": {
+          "source_key": "non_functional_requirements",
+          "source_round": 4
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_acceptance_constraints",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "6e001e4c4833adf7",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint_kind": "non_functional_requirement",
+        "content_semantics": "normative",
+        "description": "filtering",
+        "id": "acceptance-constraint-requirement-6",
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "name": "Acceptance Constraint 6",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-requirement-6",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "acceptance-constraint-requirement-6",
+        "source_requirement_id": "non_functional-requirement-5",
+        "trace": {
+          "source_key": "non_functional_requirements",
+          "source_round": 4
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_acceptance_constraints",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "714fad84b7076d46",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint_kind": "non_functional_requirement",
+        "content_semantics": "normative",
+        "description": "performance (regular >1s for web page rendering)",
+        "id": "acceptance-constraint-requirement-7",
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "name": "Acceptance Constraint 7",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-requirement-7",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "acceptance-constraint-requirement-7",
+        "source_requirement_id": "non_functional-requirement-6",
+        "trace": {
+          "source_key": "non_functional_requirements",
+          "source_round": 4
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_acceptance_constraints",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "93c0bedbff37f4c7",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint_kind": "non_functional_requirement",
+        "content_semantics": "normative",
+        "description": "availability >=99%",
+        "id": "acceptance-constraint-requirement-8",
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "name": "Acceptance Constraint 8",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-requirement-8",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "acceptance-constraint-requirement-8",
+        "source_requirement_id": "non_functional-requirement-7",
+        "trace": {
+          "source_key": "non_functional_requirements",
+          "source_round": 4
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_acceptance_constraints",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "f58f7d91234137ac",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint_kind": "success_criterion",
+        "content_semantics": "normative",
+        "description": "Better planning of IT systems purchasing and life cycle",
+        "id": "acceptance-constraint-success-1",
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "name": "Success Criterion 1",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-success-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "acceptance-constraint-success-1",
+        "source_requirement_id": "",
+        "trace": {
+          "source_key": "success_criteria",
+          "source_round": 2
+        }
+      }
+    ],
+    "acceptance_constraints": [
+      "UI must be web based",
+      "SSO",
+      "role-based access",
+      "audit trail",
+      "search",
+      "filtering",
+      "performance (regular >1s for web page rendering)",
+      "availability >=99%",
+      "Better planning of IT systems purchasing and life cycle"
+    ],
+    "functional": [
+      "Yes business processes like stage gates and approval states must be supported",
+      "I think this will be the CMDB for IT Applications/systems - we need to be able to export data to various system for reporting."
+    ],
+    "functional_objects": [
+      {
+        "change_metadata": {
+          "change_source": "requirements",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "b817426cb7205235",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "fit_criterion": "",
+        "id": "functional-requirement-1",
+        "linked_step_ids": [],
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "quality_attribute": "",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "functional-requirement-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "requirement_kind": "functional",
+        "semantic_id": "functional-requirement-1",
+        "statement": "Yes business processes like stage gates and approval states must be supported",
+        "trace": {
+          "source_key": "workflow_scope",
+          "source_round": 4
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "requirements",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "139e2490d0d43a69",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "fit_criterion": "",
+        "id": "functional-requirement-1",
+        "linked_step_ids": [],
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "quality_attribute": "",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "functional-requirement-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "requirement_kind": "functional",
+        "semantic_id": "functional-requirement-1",
+        "statement": "I think this will be the CMDB for IT Applications/systems - we need to be able to export data to various system for reporting.",
+        "trace": {
+          "source_key": "integrations",
+          "source_round": 3
+        }
+      }
+    ],
+    "non_functional": [
+      "UI must be web based",
+      "SSO",
+      "role-based access",
+      "audit trail",
+      "search",
+      "filtering",
+      "performance (regular >1s for web page rendering)",
+      "availability >=99%"
+    ],
+    "non_functional_objects": [
+      {
+        "change_metadata": {
+          "change_source": "requirements",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "35140189626f3690",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "fit_criterion": "",
+        "id": "non_functional-requirement-1",
+        "linked_step_ids": [],
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "quality_attribute": "",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "non_functional-requirement-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "requirement_kind": "non_functional",
+        "semantic_id": "non_functional-requirement-1",
+        "statement": "UI must be web based",
+        "trace": {
+          "source_key": "constraints",
+          "source_round": 2
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "requirements",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "a8315094eda0a9ee",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "fit_criterion": "",
+        "id": "non_functional-requirement-1",
+        "linked_step_ids": [],
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "quality_attribute": "",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "non_functional-requirement-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "requirement_kind": "non_functional",
+        "semantic_id": "non_functional-requirement-1",
+        "statement": "SSO",
+        "trace": {
+          "source_key": "non_functional_requirements",
+          "source_round": 4
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "requirements",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "653fcfd7e5d0f72d",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "fit_criterion": "",
+        "id": "non_functional-requirement-2",
+        "linked_step_ids": [],
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "quality_attribute": "",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "non_functional-requirement-2",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "requirement_kind": "non_functional",
+        "semantic_id": "non_functional-requirement-2",
+        "statement": "role-based access",
+        "trace": {
+          "source_key": "non_functional_requirements",
+          "source_round": 4
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "requirements",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "1e1efba12799e966",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "fit_criterion": "",
+        "id": "non_functional-requirement-3",
+        "linked_step_ids": [],
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "quality_attribute": "",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "non_functional-requirement-3",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "requirement_kind": "non_functional",
+        "semantic_id": "non_functional-requirement-3",
+        "statement": "audit trail",
+        "trace": {
+          "source_key": "non_functional_requirements",
+          "source_round": 4
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "requirements",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "e4dde9ea3c5c65ff",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "fit_criterion": "",
+        "id": "non_functional-requirement-4",
+        "linked_step_ids": [],
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "quality_attribute": "",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "non_functional-requirement-4",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "requirement_kind": "non_functional",
+        "semantic_id": "non_functional-requirement-4",
+        "statement": "search",
+        "trace": {
+          "source_key": "non_functional_requirements",
+          "source_round": 4
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "requirements",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "2da660a4b12b3c4f",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "fit_criterion": "",
+        "id": "non_functional-requirement-5",
+        "linked_step_ids": [],
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "quality_attribute": "",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "non_functional-requirement-5",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "requirement_kind": "non_functional",
+        "semantic_id": "non_functional-requirement-5",
+        "statement": "filtering",
+        "trace": {
+          "source_key": "non_functional_requirements",
+          "source_round": 4
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "requirements",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "2425258393a5de78",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "fit_criterion": "",
+        "id": "non_functional-requirement-6",
+        "linked_step_ids": [],
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "quality_attribute": "",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "non_functional-requirement-6",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "requirement_kind": "non_functional",
+        "semantic_id": "non_functional-requirement-6",
+        "statement": "performance (regular >1s for web page rendering)",
+        "trace": {
+          "source_key": "non_functional_requirements",
+          "source_round": 4
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "requirements",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "a77d5256a7d4bfcb",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "fit_criterion": "",
+        "id": "non_functional-requirement-7",
+        "linked_step_ids": [],
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "quality_attribute": "",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "non_functional-requirement-7",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "requirement_kind": "non_functional",
+        "semantic_id": "non_functional-requirement-7",
+        "statement": "availability >=99%",
+        "trace": {
+          "source_key": "non_functional_requirements",
+          "source_round": 4
+        }
+      }
+    ]
+  },
+  "risks": [],
+  "scenarios": [],
+  "success_criteria": [
+    "Better planning of IT systems purchasing and life cycle"
+  ],
+  "traceability": {
+    "acceptance_constraint_to_requirement": [
+      {
+        "basis": "acceptance constraint is derived from canonical requirement",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "f499408c812a5b1f",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "acceptance-constraint-requirement-1",
+        "id": "trace-acceptance-constraint-requirement-1",
+        "link_type": "acceptance_constraint_to_requirement",
+        "semantic_id": "trace-acceptance-constraint-requirement-1",
+        "to_id": "non_functional-requirement-1"
+      },
+      {
+        "basis": "acceptance constraint is derived from canonical requirement",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "7f685b8d92b945df",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "acceptance-constraint-requirement-2",
+        "id": "trace-acceptance-constraint-requirement-2",
+        "link_type": "acceptance_constraint_to_requirement",
+        "semantic_id": "trace-acceptance-constraint-requirement-2",
+        "to_id": "non_functional-requirement-1"
+      },
+      {
+        "basis": "acceptance constraint is derived from canonical requirement",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "649c3fbca5601731",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "acceptance-constraint-requirement-3",
+        "id": "trace-acceptance-constraint-requirement-3",
+        "link_type": "acceptance_constraint_to_requirement",
+        "semantic_id": "trace-acceptance-constraint-requirement-3",
+        "to_id": "non_functional-requirement-2"
+      },
+      {
+        "basis": "acceptance constraint is derived from canonical requirement",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "91ac10d7368a9a9f",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "acceptance-constraint-requirement-4",
+        "id": "trace-acceptance-constraint-requirement-4",
+        "link_type": "acceptance_constraint_to_requirement",
+        "semantic_id": "trace-acceptance-constraint-requirement-4",
+        "to_id": "non_functional-requirement-3"
+      },
+      {
+        "basis": "acceptance constraint is derived from canonical requirement",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "a099510c537d1d22",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "acceptance-constraint-requirement-5",
+        "id": "trace-acceptance-constraint-requirement-5",
+        "link_type": "acceptance_constraint_to_requirement",
+        "semantic_id": "trace-acceptance-constraint-requirement-5",
+        "to_id": "non_functional-requirement-4"
+      },
+      {
+        "basis": "acceptance constraint is derived from canonical requirement",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "c37c99b080232b78",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "acceptance-constraint-requirement-6",
+        "id": "trace-acceptance-constraint-requirement-6",
+        "link_type": "acceptance_constraint_to_requirement",
+        "semantic_id": "trace-acceptance-constraint-requirement-6",
+        "to_id": "non_functional-requirement-5"
+      },
+      {
+        "basis": "acceptance constraint is derived from canonical requirement",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "c91c61b275d7fab9",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "acceptance-constraint-requirement-7",
+        "id": "trace-acceptance-constraint-requirement-7",
+        "link_type": "acceptance_constraint_to_requirement",
+        "semantic_id": "trace-acceptance-constraint-requirement-7",
+        "to_id": "non_functional-requirement-6"
+      },
+      {
+        "basis": "acceptance constraint is derived from canonical requirement",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "f1b8057e436d3a6c",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "acceptance-constraint-requirement-8",
+        "id": "trace-acceptance-constraint-requirement-8",
+        "link_type": "acceptance_constraint_to_requirement",
+        "semantic_id": "trace-acceptance-constraint-requirement-8",
+        "to_id": "non_functional-requirement-7"
+      }
+    ],
+    "ambiguity_to_element": [],
+    "analysis_to_design": [
+      {
+        "basis": "design component name references analysis object name",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "4bb19f288d292010",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "entity-system",
+        "id": "trace-analysis-design-1",
+        "link_type": "analysis_to_design",
+        "semantic_id": "trace-analysis-design-1",
+        "to_id": "component-system-inventory-web-app"
+      },
+      {
+        "basis": "design component name references analysis object name",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "6cde672c8271c7eb",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "entity-system",
+        "id": "trace-analysis-design-2",
+        "link_type": "analysis_to_design",
+        "semantic_id": "trace-analysis-design-2",
+        "to_id": "component-system-inventory-api"
+      },
+      {
+        "basis": "design component name references analysis object name",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "ad163be4082bd704",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "state-entity-system",
+        "id": "trace-analysis-design-3",
+        "link_type": "analysis_to_design",
+        "semantic_id": "trace-analysis-design-3",
+        "to_id": "component-system-inventory-web-app"
+      },
+      {
+        "basis": "design component name references analysis object name",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "fbb12644b7b75844",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "state-entity-system",
+        "id": "trace-analysis-design-4",
+        "link_type": "analysis_to_design",
+        "semantic_id": "trace-analysis-design-4",
+        "to_id": "component-system-inventory-api"
+      }
+    ],
+    "artifact_lineage": [
+      {
+        "artifact_section": "system-level use cases",
+        "basis": "canonical system-level use cases object renders into system-document.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "57eb8d9690d0fa91",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "register-a-system",
+        "id": "trace-artifact-system-document-system-level-use-cases-register-a-system",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-system-document-system-level-use-cases-register-a-system",
+        "to_artifact": "system-document.md"
+      },
+      {
+        "artifact_section": "system-level use cases",
+        "basis": "canonical system-level use cases object renders into system-document.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "b03a08f7eb0ce929",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "edit-metadata",
+        "id": "trace-artifact-system-document-system-level-use-cases-edit-metadata",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-system-document-system-level-use-cases-edit-metadata",
+        "to_artifact": "system-document.md"
+      },
+      {
+        "artifact_section": "system-level use cases",
+        "basis": "canonical system-level use cases object renders into system-document.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "70377adc9535beef",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "compare-overlapping-systems",
+        "id": "trace-artifact-system-document-system-level-use-cases-compare-overlapping-systems",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-system-document-system-level-use-cases-compare-overlapping-systems",
+        "to_artifact": "system-document.md"
+      },
+      {
+        "artifact_section": "system-level use cases",
+        "basis": "canonical system-level use cases object renders into system-document.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "a7b2e5a77d9c1982",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "track-lifecycle-state",
+        "id": "trace-artifact-system-document-system-level-use-cases-track-lifecycle-state",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-system-document-system-level-use-cases-track-lifecycle-state",
+        "to_artifact": "system-document.md"
+      },
+      {
+        "artifact_section": "system-level use cases",
+        "basis": "canonical system-level use cases object renders into system-document.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "8e9c907d80fbc3d2",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "review-risks",
+        "id": "trace-artifact-system-document-system-level-use-cases-review-risks",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-system-document-system-level-use-cases-review-risks",
+        "to_artifact": "system-document.md"
+      },
+      {
+        "artifact_section": "system-level use cases",
+        "basis": "canonical system-level use cases object renders into system-document.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "6ce17b1b8b27c10a",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "see-costs",
+        "id": "trace-artifact-system-document-system-level-use-cases-see-costs",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-system-document-system-level-use-cases-see-costs",
+        "to_artifact": "system-document.md"
+      },
+      {
+        "artifact_section": "system-level use cases",
+        "basis": "canonical system-level use cases object renders into system-document.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "da8c98fe1261eaea",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "approve-deprecation",
+        "id": "trace-artifact-system-document-system-level-use-cases-approve-deprecation",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-system-document-system-level-use-cases-approve-deprecation",
+        "to_artifact": "system-document.md"
+      },
+      {
+        "artifact_section": "system-level use cases",
+        "basis": "canonical system-level use cases object renders into system-document.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "914c00a38c1a598b",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "report-portfolio-gaps",
+        "id": "trace-artifact-system-document-system-level-use-cases-report-portfolio-gaps",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-system-document-system-level-use-cases-report-portfolio-gaps",
+        "to_artifact": "system-document.md"
+      },
+      {
+        "artifact_section": "architecture overview",
+        "basis": "canonical architecture overview object renders into system-document.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "f69c81a8f2400595",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "component-system-inventory-web-app",
+        "id": "trace-artifact-system-document-architecture-overview-component-system-inventory-web-app",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-system-document-architecture-overview-component-system-inventory-web-app",
+        "to_artifact": "system-document.md"
+      },
+      {
+        "artifact_section": "architecture overview",
+        "basis": "canonical architecture overview object renders into system-document.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "00e094380860061c",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "component-system-inventory-api",
+        "id": "trace-artifact-system-document-architecture-overview-component-system-inventory-api",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-system-document-architecture-overview-component-system-inventory-api",
+        "to_artifact": "system-document.md"
+      },
+      {
+        "artifact_section": "architecture overview",
+        "basis": "canonical architecture overview object renders into system-document.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "7d707f3fec7a9d2f",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "component-reporting-consumers",
+        "id": "trace-artifact-system-document-architecture-overview-component-reporting-consumers",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-system-document-architecture-overview-component-reporting-consumers",
+        "to_artifact": "system-document.md"
+      },
+      {
+        "artifact_section": "interfaces and integrations",
+        "basis": "canonical interfaces and integrations object renders into system-document.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "91eece8d26d5ed9b",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "interface-1",
+        "id": "trace-artifact-system-document-interfaces-and-integrations-interface-1",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-system-document-interfaces-and-integrations-interface-1",
+        "to_artifact": "system-document.md"
+      },
+      {
+        "artifact_section": "interfaces and integrations",
+        "basis": "canonical interfaces and integrations object renders into system-document.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "3f042eff6cee48d3",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "interface-2",
+        "id": "trace-artifact-system-document-interfaces-and-integrations-interface-2",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-system-document-interfaces-and-integrations-interface-2",
+        "to_artifact": "system-document.md"
+      },
+      {
+        "artifact_section": "runtime boundaries",
+        "basis": "canonical runtime boundaries object renders into system-document.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "fdf54dd2f5e1e22b",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "runtime-boundary-1",
+        "id": "trace-artifact-system-document-runtime-boundaries-runtime-boundary-1",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-system-document-runtime-boundaries-runtime-boundary-1",
+        "to_artifact": "system-document.md"
+      },
+      {
+        "artifact_section": "functional requirements",
+        "basis": "canonical functional requirements object renders into requirements-spec.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "fec25440bb6afe79",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "functional-requirement-1",
+        "id": "trace-artifact-requirements-spec-functional-requirements-functional-requirement-1",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-requirements-spec-functional-requirements-functional-requirement-1",
+        "to_artifact": "requirements-spec.md"
+      },
+      {
+        "artifact_section": "functional requirements",
+        "basis": "canonical functional requirements object renders into requirements-spec.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "fec25440bb6afe79",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "functional-requirement-1",
+        "id": "trace-artifact-requirements-spec-functional-requirements-functional-requirement-1",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-requirements-spec-functional-requirements-functional-requirement-1",
+        "to_artifact": "requirements-spec.md"
+      },
+      {
+        "artifact_section": "functional requirements",
+        "basis": "canonical functional requirements object renders into requirements-spec.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "366d3df1f215edf6",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "non_functional-requirement-1",
+        "id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-1",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-1",
+        "to_artifact": "requirements-spec.md"
+      },
+      {
+        "artifact_section": "functional requirements",
+        "basis": "canonical functional requirements object renders into requirements-spec.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "366d3df1f215edf6",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "non_functional-requirement-1",
+        "id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-1",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-1",
+        "to_artifact": "requirements-spec.md"
+      },
+      {
+        "artifact_section": "functional requirements",
+        "basis": "canonical functional requirements object renders into requirements-spec.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "553fc29268eb54af",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "non_functional-requirement-2",
+        "id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-2",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-2",
+        "to_artifact": "requirements-spec.md"
+      },
+      {
+        "artifact_section": "functional requirements",
+        "basis": "canonical functional requirements object renders into requirements-spec.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "45842652ab1a37ac",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "non_functional-requirement-3",
+        "id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-3",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-3",
+        "to_artifact": "requirements-spec.md"
+      },
+      {
+        "artifact_section": "functional requirements",
+        "basis": "canonical functional requirements object renders into requirements-spec.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "deffbd4b51a070ad",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "non_functional-requirement-4",
+        "id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-4",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-4",
+        "to_artifact": "requirements-spec.md"
+      },
+      {
+        "artifact_section": "functional requirements",
+        "basis": "canonical functional requirements object renders into requirements-spec.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "5d7714100200c16f",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "non_functional-requirement-5",
+        "id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-5",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-5",
+        "to_artifact": "requirements-spec.md"
+      },
+      {
+        "artifact_section": "functional requirements",
+        "basis": "canonical functional requirements object renders into requirements-spec.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "f3c17e6b06f0c694",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "non_functional-requirement-6",
+        "id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-6",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-6",
+        "to_artifact": "requirements-spec.md"
+      },
+      {
+        "artifact_section": "functional requirements",
+        "basis": "canonical functional requirements object renders into requirements-spec.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "515decfb51f1bc20",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "non_functional-requirement-7",
+        "id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-7",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-7",
+        "to_artifact": "requirements-spec.md"
+      },
+      {
+        "artifact_section": "acceptance constraints",
+        "basis": "canonical acceptance constraints object renders into requirements-spec.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "b9a087737158f727",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "acceptance-constraint-requirement-1",
+        "id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-1",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-1",
+        "to_artifact": "requirements-spec.md"
+      },
+      {
+        "artifact_section": "acceptance constraints",
+        "basis": "canonical acceptance constraints object renders into requirements-spec.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "b2270d7e957c58fa",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "acceptance-constraint-requirement-2",
+        "id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-2",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-2",
+        "to_artifact": "requirements-spec.md"
+      },
+      {
+        "artifact_section": "acceptance constraints",
+        "basis": "canonical acceptance constraints object renders into requirements-spec.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "8180562a372ad219",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "acceptance-constraint-requirement-3",
+        "id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-3",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-3",
+        "to_artifact": "requirements-spec.md"
+      },
+      {
+        "artifact_section": "acceptance constraints",
+        "basis": "canonical acceptance constraints object renders into requirements-spec.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "46ebf22f963fa28d",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "acceptance-constraint-requirement-4",
+        "id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-4",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-4",
+        "to_artifact": "requirements-spec.md"
+      },
+      {
+        "artifact_section": "acceptance constraints",
+        "basis": "canonical acceptance constraints object renders into requirements-spec.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "9434a1c4a8ceb824",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "acceptance-constraint-requirement-5",
+        "id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-5",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-5",
+        "to_artifact": "requirements-spec.md"
+      },
+      {
+        "artifact_section": "acceptance constraints",
+        "basis": "canonical acceptance constraints object renders into requirements-spec.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "d855358cded4ea44",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "acceptance-constraint-requirement-6",
+        "id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-6",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-6",
+        "to_artifact": "requirements-spec.md"
+      },
+      {
+        "artifact_section": "acceptance constraints",
+        "basis": "canonical acceptance constraints object renders into requirements-spec.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "ea6de4221e2055e8",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "acceptance-constraint-requirement-7",
+        "id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-7",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-7",
+        "to_artifact": "requirements-spec.md"
+      },
+      {
+        "artifact_section": "acceptance constraints",
+        "basis": "canonical acceptance constraints object renders into requirements-spec.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "6b96bb58a515b323",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "acceptance-constraint-requirement-8",
+        "id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-8",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-8",
+        "to_artifact": "requirements-spec.md"
+      },
+      {
+        "artifact_section": "acceptance constraints",
+        "basis": "canonical acceptance constraints object renders into requirements-spec.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "9a069ddc773b3326",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "acceptance-constraint-success-1",
+        "id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-success-1",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-success-1",
+        "to_artifact": "requirements-spec.md"
+      },
+      {
+        "artifact_section": "use cases",
+        "basis": "canonical use cases object renders into use-case-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "f1d60233868e7209",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "register-a-system",
+        "id": "trace-artifact-use-case-model-use-cases-register-a-system",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-use-case-model-use-cases-register-a-system",
+        "to_artifact": "use-case-model.md"
+      },
+      {
+        "artifact_section": "use cases",
+        "basis": "canonical use cases object renders into use-case-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "04de38aac3563833",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "edit-metadata",
+        "id": "trace-artifact-use-case-model-use-cases-edit-metadata",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-use-case-model-use-cases-edit-metadata",
+        "to_artifact": "use-case-model.md"
+      },
+      {
+        "artifact_section": "use cases",
+        "basis": "canonical use cases object renders into use-case-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "36db17fdd50fb1b0",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "compare-overlapping-systems",
+        "id": "trace-artifact-use-case-model-use-cases-compare-overlapping-systems",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-use-case-model-use-cases-compare-overlapping-systems",
+        "to_artifact": "use-case-model.md"
+      },
+      {
+        "artifact_section": "use cases",
+        "basis": "canonical use cases object renders into use-case-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "f3f7448e4959324c",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "track-lifecycle-state",
+        "id": "trace-artifact-use-case-model-use-cases-track-lifecycle-state",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-use-case-model-use-cases-track-lifecycle-state",
+        "to_artifact": "use-case-model.md"
+      },
+      {
+        "artifact_section": "use cases",
+        "basis": "canonical use cases object renders into use-case-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "081f034e4463efc3",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "review-risks",
+        "id": "trace-artifact-use-case-model-use-cases-review-risks",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-use-case-model-use-cases-review-risks",
+        "to_artifact": "use-case-model.md"
+      },
+      {
+        "artifact_section": "use cases",
+        "basis": "canonical use cases object renders into use-case-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "5add62a9f7896397",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "see-costs",
+        "id": "trace-artifact-use-case-model-use-cases-see-costs",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-use-case-model-use-cases-see-costs",
+        "to_artifact": "use-case-model.md"
+      },
+      {
+        "artifact_section": "use cases",
+        "basis": "canonical use cases object renders into use-case-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "4060af26dba9ac0d",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "approve-deprecation",
+        "id": "trace-artifact-use-case-model-use-cases-approve-deprecation",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-use-case-model-use-cases-approve-deprecation",
+        "to_artifact": "use-case-model.md"
+      },
+      {
+        "artifact_section": "use cases",
+        "basis": "canonical use cases object renders into use-case-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "fe2f43ca885c899d",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "report-portfolio-gaps",
+        "id": "trace-artifact-use-case-model-use-cases-report-portfolio-gaps",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-use-case-model-use-cases-report-portfolio-gaps",
+        "to_artifact": "use-case-model.md"
+      },
+      {
+        "artifact_section": "use-case documents",
+        "basis": "canonical use-case documents object renders into use-case-documents.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "1727802b3c9ffae2",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "register-a-system",
+        "id": "trace-artifact-use-case-documents-use-case-documents-register-a-system",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-use-case-documents-use-case-documents-register-a-system",
+        "to_artifact": "use-case-documents.md"
+      },
+      {
+        "artifact_section": "use-case documents",
+        "basis": "canonical use-case documents object renders into use-case-documents.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "d9d43f5b16d37400",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "edit-metadata",
+        "id": "trace-artifact-use-case-documents-use-case-documents-edit-metadata",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-use-case-documents-use-case-documents-edit-metadata",
+        "to_artifact": "use-case-documents.md"
+      },
+      {
+        "artifact_section": "use-case documents",
+        "basis": "canonical use-case documents object renders into use-case-documents.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "91f865980aa3f429",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "compare-overlapping-systems",
+        "id": "trace-artifact-use-case-documents-use-case-documents-compare-overlapping-systems",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-use-case-documents-use-case-documents-compare-overlapping-systems",
+        "to_artifact": "use-case-documents.md"
+      },
+      {
+        "artifact_section": "use-case documents",
+        "basis": "canonical use-case documents object renders into use-case-documents.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "97cad07ceb7a9d7a",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "track-lifecycle-state",
+        "id": "trace-artifact-use-case-documents-use-case-documents-track-lifecycle-state",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-use-case-documents-use-case-documents-track-lifecycle-state",
+        "to_artifact": "use-case-documents.md"
+      },
+      {
+        "artifact_section": "use-case documents",
+        "basis": "canonical use-case documents object renders into use-case-documents.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "e120797b94e90a85",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "review-risks",
+        "id": "trace-artifact-use-case-documents-use-case-documents-review-risks",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-use-case-documents-use-case-documents-review-risks",
+        "to_artifact": "use-case-documents.md"
+      },
+      {
+        "artifact_section": "use-case documents",
+        "basis": "canonical use-case documents object renders into use-case-documents.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "f0bb5d43cf2eb791",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "see-costs",
+        "id": "trace-artifact-use-case-documents-use-case-documents-see-costs",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-use-case-documents-use-case-documents-see-costs",
+        "to_artifact": "use-case-documents.md"
+      },
+      {
+        "artifact_section": "use-case documents",
+        "basis": "canonical use-case documents object renders into use-case-documents.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "d8181a547db101b5",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "approve-deprecation",
+        "id": "trace-artifact-use-case-documents-use-case-documents-approve-deprecation",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-use-case-documents-use-case-documents-approve-deprecation",
+        "to_artifact": "use-case-documents.md"
+      },
+      {
+        "artifact_section": "use-case documents",
+        "basis": "canonical use-case documents object renders into use-case-documents.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "c09fec63092a31b0",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "report-portfolio-gaps",
+        "id": "trace-artifact-use-case-documents-use-case-documents-report-portfolio-gaps",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-use-case-documents-use-case-documents-report-portfolio-gaps",
+        "to_artifact": "use-case-documents.md"
+      },
+      {
+        "artifact_section": "domain entities",
+        "basis": "canonical domain entities object renders into domain-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "887037ab9531f5ef",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "entity-system",
+        "id": "trace-artifact-domain-model-domain-entities-entity-system",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-domain-model-domain-entities-entity-system",
+        "to_artifact": "domain-model.md"
+      },
+      {
+        "artifact_section": "domain entities",
+        "basis": "canonical domain entities object renders into domain-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "62ef26eab7f16102",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "entity-risk-assessment",
+        "id": "trace-artifact-domain-model-domain-entities-entity-risk-assessment",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-domain-model-domain-entities-entity-risk-assessment",
+        "to_artifact": "domain-model.md"
+      },
+      {
+        "artifact_section": "domain entities",
+        "basis": "canonical domain entities object renders into domain-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "dbb9b5a0b9436260",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "entity-cost-record",
+        "id": "trace-artifact-domain-model-domain-entities-entity-cost-record",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-domain-model-domain-entities-entity-cost-record",
+        "to_artifact": "domain-model.md"
+      },
+      {
+        "artifact_section": "domain entities",
+        "basis": "canonical domain entities object renders into domain-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "789a2483947d840f",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "entity-capability",
+        "id": "trace-artifact-domain-model-domain-entities-entity-capability",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-domain-model-domain-entities-entity-capability",
+        "to_artifact": "domain-model.md"
+      },
+      {
+        "artifact_section": "domain entities",
+        "basis": "canonical domain entities object renders into domain-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "59f8ec7cc794e555",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "entity-contract",
+        "id": "trace-artifact-domain-model-domain-entities-entity-contract",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-domain-model-domain-entities-entity-contract",
+        "to_artifact": "domain-model.md"
+      },
+      {
+        "artifact_section": "domain entities",
+        "basis": "canonical domain entities object renders into domain-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "586636070ce25971",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "entity-integration",
+        "id": "trace-artifact-domain-model-domain-entities-entity-integration",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-domain-model-domain-entities-entity-integration",
+        "to_artifact": "domain-model.md"
+      },
+      {
+        "artifact_section": "relationships",
+        "basis": "canonical relationships object renders into domain-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "3f9d110e45e868b3",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "relationship-1",
+        "id": "trace-artifact-domain-model-relationships-relationship-1",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-domain-model-relationships-relationship-1",
+        "to_artifact": "domain-model.md"
+      },
+      {
+        "artifact_section": "relationships",
+        "basis": "canonical relationships object renders into domain-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "82d26cc72fe3d665",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "relationship-2",
+        "id": "trace-artifact-domain-model-relationships-relationship-2",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-domain-model-relationships-relationship-2",
+        "to_artifact": "domain-model.md"
+      },
+      {
+        "artifact_section": "relationships",
+        "basis": "canonical relationships object renders into domain-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "aed3828f4d7ff3e1",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "relationship-3",
+        "id": "trace-artifact-domain-model-relationships-relationship-3",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-domain-model-relationships-relationship-3",
+        "to_artifact": "domain-model.md"
+      },
+      {
+        "artifact_section": "relationships",
+        "basis": "canonical relationships object renders into domain-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "f87566d9edb20283",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "relationship-4",
+        "id": "trace-artifact-domain-model-relationships-relationship-4",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-domain-model-relationships-relationship-4",
+        "to_artifact": "domain-model.md"
+      },
+      {
+        "artifact_section": "relationships",
+        "basis": "canonical relationships object renders into domain-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "aa3eb4ffa7b6066e",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "relationship-5",
+        "id": "trace-artifact-domain-model-relationships-relationship-5",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-domain-model-relationships-relationship-5",
+        "to_artifact": "domain-model.md"
+      },
+      {
+        "artifact_section": "relationships",
+        "basis": "canonical relationships object renders into domain-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "7e39e463e9002a76",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "relationship-6",
+        "id": "trace-artifact-domain-model-relationships-relationship-6",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-domain-model-relationships-relationship-6",
+        "to_artifact": "domain-model.md"
+      },
+      {
+        "artifact_section": "relationships",
+        "basis": "canonical relationships object renders into domain-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "8fa95fb213bf3e7d",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "relationship-7",
+        "id": "trace-artifact-domain-model-relationships-relationship-7",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-domain-model-relationships-relationship-7",
+        "to_artifact": "domain-model.md"
+      },
+      {
+        "artifact_section": "business rules",
+        "basis": "canonical business rules object renders into domain-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "78dc7ea16d834a20",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "business-rule-1",
+        "id": "trace-artifact-domain-model-business-rules-business-rule-1",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-domain-model-business-rules-business-rule-1",
+        "to_artifact": "domain-model.md"
+      },
+      {
+        "artifact_section": "business rules",
+        "basis": "canonical business rules object renders into domain-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "e6182870d05b9f7a",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "business-rule-2",
+        "id": "trace-artifact-domain-model-business-rules-business-rule-2",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-domain-model-business-rules-business-rule-2",
+        "to_artifact": "domain-model.md"
+      },
+      {
+        "artifact_section": "business rules",
+        "basis": "canonical business rules object renders into domain-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "db08e5f8695442da",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "business-rule-3",
+        "id": "trace-artifact-domain-model-business-rules-business-rule-3",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-domain-model-business-rules-business-rule-3",
+        "to_artifact": "domain-model.md"
+      },
+      {
+        "artifact_section": "domain invariants",
+        "basis": "canonical domain invariants object renders into domain-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "a90aa119fd188cdf",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "domain-invariant-1",
+        "id": "trace-artifact-domain-model-domain-invariants-domain-invariant-1",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-domain-model-domain-invariants-domain-invariant-1",
+        "to_artifact": "domain-model.md"
+      },
+      {
+        "artifact_section": "domain invariants",
+        "basis": "canonical domain invariants object renders into domain-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "c954802ff4fd4b50",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "domain-invariant-2",
+        "id": "trace-artifact-domain-model-domain-invariants-domain-invariant-2",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-domain-model-domain-invariants-domain-invariant-2",
+        "to_artifact": "domain-model.md"
+      },
+      {
+        "artifact_section": "domain invariants",
+        "basis": "canonical domain invariants object renders into domain-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "122fe94f2ccfd8f9",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "domain-invariant-3",
+        "id": "trace-artifact-domain-model-domain-invariants-domain-invariant-3",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-domain-model-domain-invariants-domain-invariant-3",
+        "to_artifact": "domain-model.md"
+      },
+      {
+        "artifact_section": "use-case realizations",
+        "basis": "canonical use-case realizations object renders into interaction-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "c1b6823d2aeeb87a",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "interaction-realization-1",
+        "id": "trace-artifact-interaction-model-use-case-realizations-interaction-realization-1",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-interaction-model-use-case-realizations-interaction-realization-1",
+        "to_artifact": "interaction-model.md"
+      },
+      {
+        "artifact_section": "use-case realizations",
+        "basis": "canonical use-case realizations object renders into interaction-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "ff275c3ef6eda3ed",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "interaction-realization-2",
+        "id": "trace-artifact-interaction-model-use-case-realizations-interaction-realization-2",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-interaction-model-use-case-realizations-interaction-realization-2",
+        "to_artifact": "interaction-model.md"
+      },
+      {
+        "artifact_section": "use-case realizations",
+        "basis": "canonical use-case realizations object renders into interaction-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "7e4fb0b4c67991c7",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "interaction-realization-3",
+        "id": "trace-artifact-interaction-model-use-case-realizations-interaction-realization-3",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-interaction-model-use-case-realizations-interaction-realization-3",
+        "to_artifact": "interaction-model.md"
+      },
+      {
+        "artifact_section": "use-case realizations",
+        "basis": "canonical use-case realizations object renders into interaction-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "19f77e4577165002",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "interaction-realization-4",
+        "id": "trace-artifact-interaction-model-use-case-realizations-interaction-realization-4",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-interaction-model-use-case-realizations-interaction-realization-4",
+        "to_artifact": "interaction-model.md"
+      },
+      {
+        "artifact_section": "use-case realizations",
+        "basis": "canonical use-case realizations object renders into interaction-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "c9a030230c311202",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "interaction-realization-5",
+        "id": "trace-artifact-interaction-model-use-case-realizations-interaction-realization-5",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-interaction-model-use-case-realizations-interaction-realization-5",
+        "to_artifact": "interaction-model.md"
+      },
+      {
+        "artifact_section": "use-case realizations",
+        "basis": "canonical use-case realizations object renders into interaction-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "04f88acefe82b1c5",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "interaction-realization-6",
+        "id": "trace-artifact-interaction-model-use-case-realizations-interaction-realization-6",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-interaction-model-use-case-realizations-interaction-realization-6",
+        "to_artifact": "interaction-model.md"
+      },
+      {
+        "artifact_section": "use-case realizations",
+        "basis": "canonical use-case realizations object renders into interaction-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "e54d055255df10f0",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "interaction-realization-7",
+        "id": "trace-artifact-interaction-model-use-case-realizations-interaction-realization-7",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-interaction-model-use-case-realizations-interaction-realization-7",
+        "to_artifact": "interaction-model.md"
+      },
+      {
+        "artifact_section": "use-case realizations",
+        "basis": "canonical use-case realizations object renders into interaction-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "bf6e29c9d8c1ca38",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "interaction-realization-8",
+        "id": "trace-artifact-interaction-model-use-case-realizations-interaction-realization-8",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-interaction-model-use-case-realizations-interaction-realization-8",
+        "to_artifact": "interaction-model.md"
+      },
+      {
+        "artifact_section": "message flows",
+        "basis": "canonical message flows object renders into interaction-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "0b3a7106bfe418b7",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "interaction-message-1",
+        "id": "trace-artifact-interaction-model-message-flows-interaction-message-1",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-interaction-model-message-flows-interaction-message-1",
+        "to_artifact": "interaction-model.md"
+      },
+      {
+        "artifact_section": "message flows",
+        "basis": "canonical message flows object renders into interaction-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "7b943cc11b7a8f88",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "interaction-message-2",
+        "id": "trace-artifact-interaction-model-message-flows-interaction-message-2",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-interaction-model-message-flows-interaction-message-2",
+        "to_artifact": "interaction-model.md"
+      },
+      {
+        "artifact_section": "components",
+        "basis": "canonical components object renders into deployment-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "ec6a144b856a508f",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "component-system-inventory-web-app",
+        "id": "trace-artifact-deployment-model-components-component-system-inventory-web-app",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-deployment-model-components-component-system-inventory-web-app",
+        "to_artifact": "deployment-model.md"
+      },
+      {
+        "artifact_section": "components",
+        "basis": "canonical components object renders into deployment-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "a69efcf70a5d3768",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "component-system-inventory-api",
+        "id": "trace-artifact-deployment-model-components-component-system-inventory-api",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-deployment-model-components-component-system-inventory-api",
+        "to_artifact": "deployment-model.md"
+      },
+      {
+        "artifact_section": "components",
+        "basis": "canonical components object renders into deployment-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "ae76c9098925962d",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "component-reporting-consumers",
+        "id": "trace-artifact-deployment-model-components-component-reporting-consumers",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-deployment-model-components-component-reporting-consumers",
+        "to_artifact": "deployment-model.md"
+      },
+      {
+        "artifact_section": "interfaces and integrations",
+        "basis": "canonical interfaces and integrations object renders into deployment-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "4185f4411a623540",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "interface-1",
+        "id": "trace-artifact-deployment-model-interfaces-and-integrations-interface-1",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-deployment-model-interfaces-and-integrations-interface-1",
+        "to_artifact": "deployment-model.md"
+      },
+      {
+        "artifact_section": "interfaces and integrations",
+        "basis": "canonical interfaces and integrations object renders into deployment-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "a17ccea49d467835",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "interface-2",
+        "id": "trace-artifact-deployment-model-interfaces-and-integrations-interface-2",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-deployment-model-interfaces-and-integrations-interface-2",
+        "to_artifact": "deployment-model.md"
+      },
+      {
+        "artifact_section": "runtime boundaries",
+        "basis": "canonical runtime boundaries object renders into deployment-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "be72109b76fcb841",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "runtime-boundary-1",
+        "id": "trace-artifact-deployment-model-runtime-boundaries-runtime-boundary-1",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-deployment-model-runtime-boundaries-runtime-boundary-1",
+        "to_artifact": "deployment-model.md"
+      },
+      {
+        "artifact_section": "state entities",
+        "basis": "canonical state entities object renders into state-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "ec77547d2b28ffa3",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "state-entity-system",
+        "id": "trace-artifact-state-model-state-entities-state-entity-system",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-state-model-state-entities-state-entity-system",
+        "to_artifact": "state-model.md"
+      },
+      {
+        "artifact_section": "state transitions",
+        "basis": "canonical state transitions object renders into state-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "5e3bb5d335f535a0",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "state-transition-1",
+        "id": "trace-artifact-state-model-state-transitions-state-transition-1",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-state-model-state-transitions-state-transition-1",
+        "to_artifact": "state-model.md"
+      },
+      {
+        "artifact_section": "state transitions",
+        "basis": "canonical state transitions object renders into state-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "3c2aa5a1b7def9a0",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "state-transition-2",
+        "id": "trace-artifact-state-model-state-transitions-state-transition-2",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-state-model-state-transitions-state-transition-2",
+        "to_artifact": "state-model.md"
+      },
+      {
+        "artifact_section": "state transitions",
+        "basis": "canonical state transitions object renders into state-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "1af79bac5dae50d9",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "state-transition-3",
+        "id": "trace-artifact-state-model-state-transitions-state-transition-3",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-state-model-state-transitions-state-transition-3",
+        "to_artifact": "state-model.md"
+      },
+      {
+        "artifact_section": "state transitions",
+        "basis": "canonical state transitions object renders into state-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "facb3d54f01b3e57",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "state-transition-4",
+        "id": "trace-artifact-state-model-state-transitions-state-transition-4",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-state-model-state-transitions-state-transition-4",
+        "to_artifact": "state-model.md"
+      },
+      {
+        "artifact_section": "triggers and approvals",
+        "basis": "canonical triggers and approvals object renders into state-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "c82280ef83063a38",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "trigger-1",
+        "id": "trace-artifact-state-model-triggers-and-approvals-trigger-1",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-state-model-triggers-and-approvals-trigger-1",
+        "to_artifact": "state-model.md"
+      },
+      {
+        "artifact_section": "triggers and approvals",
+        "basis": "canonical triggers and approvals object renders into state-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "826c99d687ec2f69",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "trigger-2",
+        "id": "trace-artifact-state-model-triggers-and-approvals-trigger-2",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-state-model-triggers-and-approvals-trigger-2",
+        "to_artifact": "state-model.md"
+      },
+      {
+        "artifact_section": "state invariants",
+        "basis": "canonical state invariants object renders into state-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "0fc9afd4b2b4d208",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "state-invariant-1",
+        "id": "trace-artifact-state-model-state-invariants-state-invariant-1",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-state-model-state-invariants-state-invariant-1",
+        "to_artifact": "state-model.md"
+      },
+      {
+        "artifact_section": "state invariants",
+        "basis": "canonical state invariants object renders into state-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "7ca8114c140d58c2",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "state-invariant-2",
+        "id": "trace-artifact-state-model-state-invariants-state-invariant-2",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-state-model-state-invariants-state-invariant-2",
+        "to_artifact": "state-model.md"
+      },
+      {
+        "artifact_section": "state invariants",
+        "basis": "canonical state invariants object renders into state-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "4e3750dae2e4baa3",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "state-invariant-3",
+        "id": "trace-artifact-state-model-state-invariants-state-invariant-3",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-state-model-state-invariants-state-invariant-3",
+        "to_artifact": "state-model.md"
+      },
+      {
+        "artifact_section": "guard conditions",
+        "basis": "canonical guard conditions object renders into state-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "e6c1be629fc829cf",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "guard-condition-1",
+        "id": "trace-artifact-state-model-guard-conditions-guard-condition-1",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-state-model-guard-conditions-guard-condition-1",
+        "to_artifact": "state-model.md"
+      },
+      {
+        "artifact_section": "guard conditions",
+        "basis": "canonical guard conditions object renders into state-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "0135f82024c2d563",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "guard-condition-2",
+        "id": "trace-artifact-state-model-guard-conditions-guard-condition-2",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-state-model-guard-conditions-guard-condition-2",
+        "to_artifact": "state-model.md"
+      }
+    ],
+    "business_rule_to_transition": [
+      {
+        "basis": "business rule scope references state transition text",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "8330b21dc06c3215",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "business-rule-1",
+        "id": "trace-rule-transition-1",
+        "link_type": "business_rule_to_transition",
+        "semantic_id": "trace-rule-transition-1",
+        "to_id": "state-transition-1"
+      },
+      {
+        "basis": "business rule scope references state transition text",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "38ebf4886c4cbd8a",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "business-rule-1",
+        "id": "trace-rule-transition-2",
+        "link_type": "business_rule_to_transition",
+        "semantic_id": "trace-rule-transition-2",
+        "to_id": "state-transition-2"
+      },
+      {
+        "basis": "business rule scope references state transition text",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "2de406aa503c0e3c",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "business-rule-1",
+        "id": "trace-rule-transition-3",
+        "link_type": "business_rule_to_transition",
+        "semantic_id": "trace-rule-transition-3",
+        "to_id": "state-transition-3"
+      },
+      {
+        "basis": "business rule scope references state transition text",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "f37c64bb2964c748",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "business-rule-1",
+        "id": "trace-rule-transition-4",
+        "link_type": "business_rule_to_transition",
+        "semantic_id": "trace-rule-transition-4",
+        "to_id": "state-transition-4"
+      },
+      {
+        "basis": "business rule scope references state transition text",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "ff930d94cc08c88b",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "business-rule-3",
+        "id": "trace-rule-transition-5",
+        "link_type": "business_rule_to_transition",
+        "semantic_id": "trace-rule-transition-5",
+        "to_id": "state-transition-1"
+      },
+      {
+        "basis": "business rule scope references state transition text",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "f75fceaaa7c248ca",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "business-rule-3",
+        "id": "trace-rule-transition-6",
+        "link_type": "business_rule_to_transition",
+        "semantic_id": "trace-rule-transition-6",
+        "to_id": "state-transition-2"
+      },
+      {
+        "basis": "business rule scope references state transition text",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "a2b8426741530711",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "business-rule-3",
+        "id": "trace-rule-transition-7",
+        "link_type": "business_rule_to_transition",
+        "semantic_id": "trace-rule-transition-7",
+        "to_id": "state-transition-3"
+      },
+      {
+        "basis": "business rule scope references state transition text",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "1f50adb69526d9e9",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "business-rule-3",
+        "id": "trace-rule-transition-8",
+        "link_type": "business_rule_to_transition",
+        "semantic_id": "trace-rule-transition-8",
+        "to_id": "state-transition-4"
+      }
+    ],
+    "domain_invariant_to_entity": [
+      {
+        "basis": "domain invariant scope references domain entity",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "c23910b6713e30ea",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "domain-invariant-1",
+        "id": "trace-domain-invariant-entity-1",
+        "link_type": "domain_invariant_to_entity",
+        "semantic_id": "trace-domain-invariant-entity-1",
+        "to_id": "entity-system"
+      },
+      {
+        "basis": "domain invariant scope references domain entity",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "f9b0aeac127ec23a",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "domain-invariant-2",
+        "id": "trace-domain-invariant-entity-2",
+        "link_type": "domain_invariant_to_entity",
+        "semantic_id": "trace-domain-invariant-entity-2",
+        "to_id": "entity-system"
+      },
+      {
+        "basis": "domain invariant scope references domain entity",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "a077454bbc453b48",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "domain-invariant-3",
+        "id": "trace-domain-invariant-entity-3",
+        "link_type": "domain_invariant_to_entity",
+        "semantic_id": "trace-domain-invariant-entity-3",
+        "to_id": "entity-system"
+      },
+      {
+        "basis": "domain invariant scope references domain entity",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "7d1e630599a59661",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "domain-invariant-3",
+        "id": "trace-domain-invariant-entity-4",
+        "link_type": "domain_invariant_to_entity",
+        "semantic_id": "trace-domain-invariant-entity-4",
+        "to_id": "entity-contract"
+      }
+    ],
+    "forbidden_transition_to_transition": [],
+    "guard_to_transition": [],
+    "requirement_to_step": [],
+    "requirement_to_use_case": [],
+    "state_invariant_to_state": [
+      {
+        "basis": "state invariant scope references state entity",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "a7293ec5dae6d460",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "state-invariant-1",
+        "id": "trace-state-invariant-state-1",
+        "link_type": "state_invariant_to_state",
+        "semantic_id": "trace-state-invariant-state-1",
+        "to_id": "state-entity-system"
+      },
+      {
+        "basis": "state invariant scope references state entity",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "4a08ee79d9656d34",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "state-invariant-2",
+        "id": "trace-state-invariant-state-2",
+        "link_type": "state_invariant_to_state",
+        "semantic_id": "trace-state-invariant-state-2",
+        "to_id": "state-entity-system"
+      },
+      {
+        "basis": "state invariant scope references state entity",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "79abcaa321b80e68",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "state-invariant-3",
+        "id": "trace-state-invariant-state-3",
+        "link_type": "state_invariant_to_state",
+        "semantic_id": "trace-state-invariant-state-3",
+        "to_id": "state-entity-system"
+      }
+    ],
+    "step_to_interaction": [],
+    "step_to_transition": [],
+    "use_case_to_analysis": [
+      {
+        "basis": "use-case text references analysis object name",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "e3594e9f3a257337",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "register-a-system",
+        "id": "trace-uc-analysis-1",
+        "link_type": "use_case_to_analysis",
+        "semantic_id": "trace-uc-analysis-1",
+        "to_id": "entity-system"
+      },
+      {
+        "basis": "use-case text references analysis object name",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "2a59a5943a0158f5",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "register-a-system",
+        "id": "trace-uc-analysis-2",
+        "link_type": "use_case_to_analysis",
+        "semantic_id": "trace-uc-analysis-2",
+        "to_id": "state-entity-system"
+      },
+      {
+        "basis": "use-case text references analysis object name",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "d33c8769568faeb1",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "compare-overlapping-systems",
+        "id": "trace-uc-analysis-3",
+        "link_type": "use_case_to_analysis",
+        "semantic_id": "trace-uc-analysis-3",
+        "to_id": "entity-system"
+      },
+      {
+        "basis": "use-case text references analysis object name",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "7ea3d3efb49a9f45",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "compare-overlapping-systems",
+        "id": "trace-uc-analysis-4",
+        "link_type": "use_case_to_analysis",
+        "semantic_id": "trace-uc-analysis-4",
+        "to_id": "state-entity-system"
+      }
+    ]
+  },
+  "ucp": {
+    "environmental_factors": {
+      "application_experience": 3,
+      "difficult_programming_language": 2,
+      "familiar_with_process": 3,
+      "lead_analyst_capability": 4,
+      "motivation": 4,
+      "object_oriented_experience": 3,
+      "part_time_staff": 1,
+      "stable_requirements": 3
+    },
+    "productivity_hours_per_ucp": 20,
+    "technical_factors": {
+      "complex_internal_processing": 2,
+      "concurrency": 2,
+      "distributed_system": 3,
+      "easy_to_change": 4,
+      "easy_to_install": 2,
+      "easy_to_use": 4,
+      "end_user_efficiency": 4,
+      "portability": 2,
+      "response_time": 2,
+      "reusable_code": 3,
+      "special_security": 4,
+      "special_user_training": 1,
+      "third_party_access": 4
+    }
+  },
+  "use_cases": [
+    {
+      "change_metadata": {
+        "change_source": "round_3",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "d145a19075179f4d",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "complexity": "average",
+      "complexity_trace": {
+        "source_key": "use_case_complexity",
+        "source_round": 9
+      },
+      "content_semantics": "normative",
+      "extension_points": [],
+      "extensions": [],
+      "goal": "Register a system",
+      "id": "register-a-system",
+      "main_success_scenario": [],
+      "model_layer": "analysis",
+      "name": "Register a system",
+      "other_artifact_refs": [],
+      "other_requirement_ids": [],
+      "participating_analysis_object_ids": [
+        "entity-system",
+        "state-entity-system"
+      ],
+      "postconditions": [],
+      "preconditions": [],
+      "primary_actor": "Unspecified",
+      "primary_actor_id": "",
+      "priority": "",
+      "readiness": {
+        "blocking_ambiguity_ids": [],
+        "content_semantics": "normative",
+        "family": "use_cases",
+        "id": "register-a-system",
+        "missing_fields": [
+          "main_success_scenario"
+        ],
+        "normative_ready": false,
+        "status": "blocked"
+      },
+      "scenario_ids": [],
+      "semantic_id": "register-a-system",
+      "status": "",
+      "subordinate_use_case_ids": [],
+      "supporting_actor_ids": [],
+      "trace": {
+        "source_key": "use_cases",
+        "source_round": 3
+      },
+      "trigger": "",
+      "ui_notes": [],
+      "used_use_case_ids": []
+    },
+    {
+      "change_metadata": {
+        "change_source": "round_3",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "49b57b797dfb65d8",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "complexity": "simple",
+      "complexity_trace": {
+        "source_key": "use_case_complexity",
+        "source_round": 9
+      },
+      "content_semantics": "normative",
+      "extension_points": [],
+      "extensions": [],
+      "goal": "edit metadata",
+      "id": "edit-metadata",
+      "main_success_scenario": [],
+      "model_layer": "analysis",
+      "name": "edit metadata",
+      "other_artifact_refs": [],
+      "other_requirement_ids": [],
+      "participating_analysis_object_ids": [],
+      "postconditions": [],
+      "preconditions": [],
+      "primary_actor": "Unspecified",
+      "primary_actor_id": "",
+      "priority": "",
+      "readiness": {
+        "blocking_ambiguity_ids": [],
+        "content_semantics": "normative",
+        "family": "use_cases",
+        "id": "edit-metadata",
+        "missing_fields": [
+          "main_success_scenario"
+        ],
+        "normative_ready": false,
+        "status": "blocked"
+      },
+      "scenario_ids": [],
+      "semantic_id": "edit-metadata",
+      "status": "",
+      "subordinate_use_case_ids": [],
+      "supporting_actor_ids": [],
+      "trace": {
+        "source_key": "use_cases",
+        "source_round": 3
+      },
+      "trigger": "",
+      "ui_notes": [],
+      "used_use_case_ids": []
+    },
+    {
+      "change_metadata": {
+        "change_source": "round_3",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "97a5cb95cc045fb5",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "complexity": "average",
+      "complexity_trace": {
+        "source_key": "use_case_complexity",
+        "source_round": 9
+      },
+      "content_semantics": "normative",
+      "extension_points": [],
+      "extensions": [],
+      "goal": "compare overlapping systems",
+      "id": "compare-overlapping-systems",
+      "main_success_scenario": [],
+      "model_layer": "analysis",
+      "name": "compare overlapping systems",
+      "other_artifact_refs": [],
+      "other_requirement_ids": [],
+      "participating_analysis_object_ids": [
+        "entity-system",
+        "state-entity-system"
+      ],
+      "postconditions": [],
+      "preconditions": [],
+      "primary_actor": "Unspecified",
+      "primary_actor_id": "",
+      "priority": "",
+      "readiness": {
+        "blocking_ambiguity_ids": [],
+        "content_semantics": "normative",
+        "family": "use_cases",
+        "id": "compare-overlapping-systems",
+        "missing_fields": [
+          "main_success_scenario"
+        ],
+        "normative_ready": false,
+        "status": "blocked"
+      },
+      "scenario_ids": [],
+      "semantic_id": "compare-overlapping-systems",
+      "status": "",
+      "subordinate_use_case_ids": [],
+      "supporting_actor_ids": [],
+      "trace": {
+        "source_key": "use_cases",
+        "source_round": 3
+      },
+      "trigger": "",
+      "ui_notes": [],
+      "used_use_case_ids": []
+    },
+    {
+      "change_metadata": {
+        "change_source": "round_3",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "6077961c843c1a2e",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "complexity": "average",
+      "complexity_trace": {
+        "source_key": "use_case_complexity",
+        "source_round": 9
+      },
+      "content_semantics": "normative",
+      "extension_points": [],
+      "extensions": [],
+      "goal": "track lifecycle state",
+      "id": "track-lifecycle-state",
+      "main_success_scenario": [],
+      "model_layer": "analysis",
+      "name": "track lifecycle state",
+      "other_artifact_refs": [],
+      "other_requirement_ids": [],
+      "participating_analysis_object_ids": [],
+      "postconditions": [],
+      "preconditions": [],
+      "primary_actor": "Unspecified",
+      "primary_actor_id": "",
+      "priority": "",
+      "readiness": {
+        "blocking_ambiguity_ids": [],
+        "content_semantics": "normative",
+        "family": "use_cases",
+        "id": "track-lifecycle-state",
+        "missing_fields": [
+          "main_success_scenario"
+        ],
+        "normative_ready": false,
+        "status": "blocked"
+      },
+      "scenario_ids": [],
+      "semantic_id": "track-lifecycle-state",
+      "status": "",
+      "subordinate_use_case_ids": [],
+      "supporting_actor_ids": [],
+      "trace": {
+        "source_key": "use_cases",
+        "source_round": 3
+      },
+      "trigger": "",
+      "ui_notes": [],
+      "used_use_case_ids": []
+    },
+    {
+      "change_metadata": {
+        "change_source": "round_3",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "c5b1951eeada9174",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "complexity": "simple",
+      "complexity_trace": {
+        "source_key": "use_case_complexity",
+        "source_round": 9
+      },
+      "content_semantics": "normative",
+      "extension_points": [],
+      "extensions": [],
+      "goal": "review risks",
+      "id": "review-risks",
+      "main_success_scenario": [],
+      "model_layer": "analysis",
+      "name": "review risks",
+      "other_artifact_refs": [],
+      "other_requirement_ids": [],
+      "participating_analysis_object_ids": [],
+      "postconditions": [],
+      "preconditions": [],
+      "primary_actor": "Unspecified",
+      "primary_actor_id": "",
+      "priority": "",
+      "readiness": {
+        "blocking_ambiguity_ids": [],
+        "content_semantics": "normative",
+        "family": "use_cases",
+        "id": "review-risks",
+        "missing_fields": [
+          "main_success_scenario"
+        ],
+        "normative_ready": false,
+        "status": "blocked"
+      },
+      "scenario_ids": [],
+      "semantic_id": "review-risks",
+      "status": "",
+      "subordinate_use_case_ids": [],
+      "supporting_actor_ids": [],
+      "trace": {
+        "source_key": "use_cases",
+        "source_round": 3
+      },
+      "trigger": "",
+      "ui_notes": [],
+      "used_use_case_ids": []
+    },
+    {
+      "change_metadata": {
+        "change_source": "round_3",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "6373ef70fd6e12c5",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "complexity": "simple",
+      "complexity_trace": {
+        "source_key": "use_case_complexity",
+        "source_round": 9
+      },
+      "content_semantics": "normative",
+      "extension_points": [],
+      "extensions": [],
+      "goal": "see costs",
+      "id": "see-costs",
+      "main_success_scenario": [],
+      "model_layer": "analysis",
+      "name": "see costs",
+      "other_artifact_refs": [],
+      "other_requirement_ids": [],
+      "participating_analysis_object_ids": [],
+      "postconditions": [],
+      "preconditions": [],
+      "primary_actor": "Unspecified",
+      "primary_actor_id": "",
+      "priority": "",
+      "readiness": {
+        "blocking_ambiguity_ids": [],
+        "content_semantics": "normative",
+        "family": "use_cases",
+        "id": "see-costs",
+        "missing_fields": [
+          "main_success_scenario"
+        ],
+        "normative_ready": false,
+        "status": "blocked"
+      },
+      "scenario_ids": [],
+      "semantic_id": "see-costs",
+      "status": "",
+      "subordinate_use_case_ids": [],
+      "supporting_actor_ids": [],
+      "trace": {
+        "source_key": "use_cases",
+        "source_round": 3
+      },
+      "trigger": "",
+      "ui_notes": [],
+      "used_use_case_ids": []
+    },
+    {
+      "change_metadata": {
+        "change_source": "round_3",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "1bc75c3cb13f6dc9",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "complexity": "average",
+      "complexity_trace": {
+        "source_key": "use_case_complexity",
+        "source_round": 9
+      },
+      "content_semantics": "normative",
+      "extension_points": [],
+      "extensions": [],
+      "goal": "approve deprecation",
+      "id": "approve-deprecation",
+      "main_success_scenario": [],
+      "model_layer": "analysis",
+      "name": "approve deprecation",
+      "other_artifact_refs": [],
+      "other_requirement_ids": [],
+      "participating_analysis_object_ids": [],
+      "postconditions": [],
+      "preconditions": [],
+      "primary_actor": "Unspecified",
+      "primary_actor_id": "",
+      "priority": "",
+      "readiness": {
+        "blocking_ambiguity_ids": [],
+        "content_semantics": "normative",
+        "family": "use_cases",
+        "id": "approve-deprecation",
+        "missing_fields": [
+          "main_success_scenario"
+        ],
+        "normative_ready": false,
+        "status": "blocked"
+      },
+      "scenario_ids": [],
+      "semantic_id": "approve-deprecation",
+      "status": "",
+      "subordinate_use_case_ids": [],
+      "supporting_actor_ids": [],
+      "trace": {
+        "source_key": "use_cases",
+        "source_round": 3
+      },
+      "trigger": "",
+      "ui_notes": [],
+      "used_use_case_ids": []
+    },
+    {
+      "change_metadata": {
+        "change_source": "round_3",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "073a5935f13208c1",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "complexity": "average",
+      "complexity_trace": {
+        "source_key": "use_case_complexity",
+        "source_round": 9
+      },
+      "content_semantics": "normative",
+      "extension_points": [],
+      "extensions": [],
+      "goal": "report portfolio gaps",
+      "id": "report-portfolio-gaps",
+      "main_success_scenario": [],
+      "model_layer": "analysis",
+      "name": "report portfolio gaps",
+      "other_artifact_refs": [],
+      "other_requirement_ids": [],
+      "participating_analysis_object_ids": [],
+      "postconditions": [],
+      "preconditions": [],
+      "primary_actor": "Unspecified",
+      "primary_actor_id": "",
+      "priority": "",
+      "readiness": {
+        "blocking_ambiguity_ids": [],
+        "content_semantics": "normative",
+        "family": "use_cases",
+        "id": "report-portfolio-gaps",
+        "missing_fields": [
+          "main_success_scenario"
+        ],
+        "normative_ready": false,
+        "status": "blocked"
+      },
+      "scenario_ids": [],
+      "semantic_id": "report-portfolio-gaps",
+      "status": "",
+      "subordinate_use_case_ids": [],
+      "supporting_actor_ids": [],
+      "trace": {
+        "source_key": "use_cases",
+        "source_round": 3
+      },
+      "trigger": "",
+      "ui_notes": [],
+      "used_use_case_ids": []
+    }
+  ]
+}

--- a/tests/test_publication_bundle.py
+++ b/tests/test_publication_bundle.py
@@ -132,3 +132,37 @@ class PublicationBundleTests(unittest.TestCase):
             self.assertIn(str(archive_path), result.stdout)
             self.assertTrue((output_dir / "artifacts" / "formal" / "domain-model.md").exists())
             self.assertTrue(archive_path.exists())
+
+    def test_checked_in_cmdb_v2_bundle_includes_planning_export_and_manifest(self) -> None:
+        """The checked-in CMDB V2 bundle should preserve the Speckify handoff surface."""
+        repo_root = Path(__file__).resolve().parents[1]
+        example_dir = repo_root / "examples" / "it-systems-inventory-v2"
+
+        manifest_path = example_dir / "bundle-manifest.json"
+        planning_export_path = example_dir / "exports" / "speckify-planning-export.json"
+        readme_path = example_dir / "README.md"
+
+        self.assertTrue(manifest_path.exists())
+        self.assertTrue(planning_export_path.exists())
+        self.assertTrue((example_dir / "model" / "rupify-model.json").exists())
+        self.assertTrue(
+            (example_dir / "artifacts" / "formal" / "system-document.md").exists()
+        )
+        self.assertTrue(
+            (example_dir / "artifacts" / "mermaid" / "domain-model.mmd").exists()
+        )
+        self.assertIn("Speckify Handoff Surface", readme_path.read_text(encoding="utf-8"))
+
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        planning_export = json.loads(planning_export_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(
+            manifest["bundle_metadata"]["bundle_kind"],
+            "rupify_specification_publication_bundle",
+        )
+        self.assertEqual(
+            manifest["layout"]["planning_export"],
+            "exports/speckify-planning-export.json",
+        )
+        self.assertEqual(planning_export["export_metadata"]["export_kind"], "speckify_planning_export")
+        self.assertEqual(planning_export["summary"]["blocking_ambiguity_count"], 0)


### PR DESCRIPTION
## Summary
- add a checked-in V2 publication bundle for the existing CMDB / IT systems inventory interview fixture
- include the Speckify planning export, bundle manifest, and canonical model snapshot as the proven Rupify-side handoff surface
- document and test the CMDB V2 bundle so the export proof stays aligned with the current pipeline

Closes #84

## Scope Note
This PR proves the Rupify-side packaging and handoff boundary. Importing that package into Speckify remains Speckify work, not Rupify work.

## Verification
- uv run python -m unittest tests.test_publication_bundle tests.test_render
- uv run python -m unittest
