### PR TITLE
Fix Speckify planning export blockers

### DIFF
--- a/examples/it-systems-inventory-v2/README.md
+++ b/examples/it-systems-inventory-v2/README.md
@@ -18,7 +18,8 @@ uv run rupify-publish-bundle \
 
 ## Purpose
 
-This bundle is the concrete proof for the downstream Speckify integration path under issue `#84`.
+This bundle is the concrete proof for the downstream Speckify integration path under issue `#84`,
+with the import-cleanliness blockers from issue `#151` corrected upstream in Rupify.
 
 It demonstrates that the existing CMDB interview can now be carried all the way through:
 
@@ -48,10 +49,12 @@ The canonical model snapshot used to generate the bundle is:
 This V2 export currently shows:
 
 - a complete publication bundle with 17 files
-- 72 flattened planning elements
+- 82 flattened planning elements
 - 127 trace links
 - 29 ready normative elements
 - 0 blocking ambiguities
+- 0 unresolved trace references
+- 0 duplicate exported element IDs
 
 ## Known Limits In This Example
 

--- a/examples/it-systems-inventory-v2/artifacts/formal/requirements-spec.md
+++ b/examples/it-systems-inventory-v2/artifacts/formal/requirements-spec.md
@@ -37,13 +37,13 @@ We have many IT Systems and some overlap, some are free, some are expensive, all
 ## Acceptance Constraints
 
 - `acceptance-constraint-requirement-1` UI must be web based (semantics: normative; kind: non_functional_requirement; requirement: non_functional-requirement-1; readiness: ready; source: round 2 constraints)
-- `acceptance-constraint-requirement-2` SSO (semantics: normative; kind: non_functional_requirement; requirement: non_functional-requirement-1; readiness: ready; source: round 4 non_functional_requirements)
-- `acceptance-constraint-requirement-3` role-based access (semantics: normative; kind: non_functional_requirement; requirement: non_functional-requirement-2; readiness: ready; source: round 4 non_functional_requirements)
-- `acceptance-constraint-requirement-4` audit trail (semantics: normative; kind: non_functional_requirement; requirement: non_functional-requirement-3; readiness: ready; source: round 4 non_functional_requirements)
-- `acceptance-constraint-requirement-5` search (semantics: normative; kind: non_functional_requirement; requirement: non_functional-requirement-4; readiness: ready; source: round 4 non_functional_requirements)
-- `acceptance-constraint-requirement-6` filtering (semantics: normative; kind: non_functional_requirement; requirement: non_functional-requirement-5; readiness: ready; source: round 4 non_functional_requirements)
-- `acceptance-constraint-requirement-7` performance (regular >1s for web page rendering) (semantics: normative; kind: non_functional_requirement; requirement: non_functional-requirement-6; readiness: ready; source: round 4 non_functional_requirements)
-- `acceptance-constraint-requirement-8` availability >=99% (semantics: normative; kind: non_functional_requirement; requirement: non_functional-requirement-7; readiness: ready; source: round 4 non_functional_requirements)
+- `acceptance-constraint-requirement-2` SSO (semantics: normative; kind: non_functional_requirement; requirement: non_functional-requirement-2; readiness: ready; source: round 4 non_functional_requirements)
+- `acceptance-constraint-requirement-3` role-based access (semantics: normative; kind: non_functional_requirement; requirement: non_functional-requirement-3; readiness: ready; source: round 4 non_functional_requirements)
+- `acceptance-constraint-requirement-4` audit trail (semantics: normative; kind: non_functional_requirement; requirement: non_functional-requirement-4; readiness: ready; source: round 4 non_functional_requirements)
+- `acceptance-constraint-requirement-5` search (semantics: normative; kind: non_functional_requirement; requirement: non_functional-requirement-5; readiness: ready; source: round 4 non_functional_requirements)
+- `acceptance-constraint-requirement-6` filtering (semantics: normative; kind: non_functional_requirement; requirement: non_functional-requirement-6; readiness: ready; source: round 4 non_functional_requirements)
+- `acceptance-constraint-requirement-7` performance (regular >1s for web page rendering) (semantics: normative; kind: non_functional_requirement; requirement: non_functional-requirement-7; readiness: ready; source: round 4 non_functional_requirements)
+- `acceptance-constraint-requirement-8` availability >=99% (semantics: normative; kind: non_functional_requirement; requirement: non_functional-requirement-8; readiness: ready; source: round 4 non_functional_requirements)
 - `acceptance-constraint-success-1` Better planning of IT systems purchasing and life cycle (semantics: normative; kind: success_criterion; readiness: ready; source: round 2 success_criteria)
 
 

--- a/examples/it-systems-inventory-v2/bundle-manifest.json
+++ b/examples/it-systems-inventory-v2/bundle-manifest.json
@@ -15,7 +15,7 @@
       "change_source": "normalize_replay_to_model",
       "last_changed_at": "",
       "regenerated_from_version": "",
-      "semantic_hash": "2f3ec68a35e9678e",
+      "semantic_hash": "62d266a14515319f",
       "semantic_version": 1,
       "supersedes": []
     },

--- a/examples/it-systems-inventory-v2/exports/speckify-planning-export.json
+++ b/examples/it-systems-inventory-v2/exports/speckify-planning-export.json
@@ -30,14 +30,14 @@
     {
       "attributes": {
         "constraint_kind": "non_functional_requirement",
-        "source_requirement_id": "non_functional-requirement-1"
+        "source_requirement_id": "non_functional-requirement-2"
       },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_acceptance_constraints",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "ea270a270fd5ae0a",
+        "semantic_hash": "cc8fa5e4dd1589f3",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -56,14 +56,14 @@
     {
       "attributes": {
         "constraint_kind": "non_functional_requirement",
-        "source_requirement_id": "non_functional-requirement-2"
+        "source_requirement_id": "non_functional-requirement-3"
       },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_acceptance_constraints",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "cc94e38b4882a356",
+        "semantic_hash": "b9a15e23c0db7d29",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -82,14 +82,14 @@
     {
       "attributes": {
         "constraint_kind": "non_functional_requirement",
-        "source_requirement_id": "non_functional-requirement-3"
+        "source_requirement_id": "non_functional-requirement-4"
       },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_acceptance_constraints",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "e3b5c94d9e1c0566",
+        "semantic_hash": "c27d4311ee7676d4",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -108,14 +108,14 @@
     {
       "attributes": {
         "constraint_kind": "non_functional_requirement",
-        "source_requirement_id": "non_functional-requirement-4"
+        "source_requirement_id": "non_functional-requirement-5"
       },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_acceptance_constraints",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "9c5f49ef585cd8db",
+        "semantic_hash": "07c609485342104d",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -134,14 +134,14 @@
     {
       "attributes": {
         "constraint_kind": "non_functional_requirement",
-        "source_requirement_id": "non_functional-requirement-5"
+        "source_requirement_id": "non_functional-requirement-6"
       },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_acceptance_constraints",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "6e001e4c4833adf7",
+        "semantic_hash": "ed67c4ace2e59e49",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -160,14 +160,14 @@
     {
       "attributes": {
         "constraint_kind": "non_functional_requirement",
-        "source_requirement_id": "non_functional-requirement-6"
+        "source_requirement_id": "non_functional-requirement-7"
       },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_acceptance_constraints",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "714fad84b7076d46",
+        "semantic_hash": "195499f7e8219562",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -186,14 +186,14 @@
     {
       "attributes": {
         "constraint_kind": "non_functional_requirement",
-        "source_requirement_id": "non_functional-requirement-7"
+        "source_requirement_id": "non_functional-requirement-8"
       },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_acceptance_constraints",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "93c0bedbff37f4c7",
+        "semantic_hash": "b2827f52f6dc9af7",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -835,18 +835,18 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "139e2490d0d43a69",
+        "semantic_hash": "82d1c204f7e647cb",
         "semantic_version": 1,
         "supersedes": []
       },
       "content_semantics": "normative",
       "family": "functional_requirements",
-      "id": "functional-requirement-1",
+      "id": "functional-requirement-2",
       "missing_fields": [],
       "name": "",
       "normative_ready": true,
       "readiness_status": "ready",
-      "semantic_id": "functional-requirement-1",
+      "semantic_id": "functional-requirement-2",
       "source_key": "integrations",
       "source_round": 3,
       "text": "I think this will be the CMDB for IT Applications/systems - we need to be able to export data to various system for reporting."
@@ -904,6 +904,240 @@
       "source_key": "triggers_and_approvals",
       "source_round": 6,
       "text": "Contract expiry triggers lifecycle review"
+    },
+    {
+      "attributes": {
+        "interaction_verb": "calls"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_interaction_view",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "53cc90b2f2a8e8e9",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "",
+      "family": "interaction_messages",
+      "id": "interaction-message-1",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "interaction-message-1",
+      "source_key": "interfaces_and_integrations",
+      "source_round": 7,
+      "text": "System Inventory Web App calls System Inventory API"
+    },
+    {
+      "attributes": {
+        "interaction_verb": "sends"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_interaction_view",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "99af7d4c88ac8b72",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "",
+      "family": "interaction_messages",
+      "id": "interaction-message-2",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "interaction-message-2",
+      "source_key": "interfaces_and_integrations",
+      "source_round": 7,
+      "text": "System Inventory API sends Reporting Consumers"
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_interaction_view",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "d072c2560757e2d9",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "",
+      "family": "interaction_realizations",
+      "id": "interaction-realization-1",
+      "missing_fields": [],
+      "name": "Register a system",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "interaction-realization-1",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": ""
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_interaction_view",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "40cd1e2a53575d83",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "",
+      "family": "interaction_realizations",
+      "id": "interaction-realization-2",
+      "missing_fields": [],
+      "name": "edit metadata",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "interaction-realization-2",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": ""
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_interaction_view",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "c86ec221438a6616",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "",
+      "family": "interaction_realizations",
+      "id": "interaction-realization-3",
+      "missing_fields": [],
+      "name": "compare overlapping systems",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "interaction-realization-3",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": ""
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_interaction_view",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "ee0830f3794bd18d",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "",
+      "family": "interaction_realizations",
+      "id": "interaction-realization-4",
+      "missing_fields": [],
+      "name": "track lifecycle state",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "interaction-realization-4",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": ""
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_interaction_view",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "20691c1c22171f6d",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "",
+      "family": "interaction_realizations",
+      "id": "interaction-realization-5",
+      "missing_fields": [],
+      "name": "review risks",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "interaction-realization-5",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": ""
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_interaction_view",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "1df7247cb3f8591e",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "",
+      "family": "interaction_realizations",
+      "id": "interaction-realization-6",
+      "missing_fields": [],
+      "name": "see costs",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "interaction-realization-6",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": ""
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_interaction_view",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "4a3d424b2f344fbb",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "",
+      "family": "interaction_realizations",
+      "id": "interaction-realization-7",
+      "missing_fields": [],
+      "name": "approve deprecation",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "interaction-realization-7",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": ""
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_interaction_view",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "ded44714c4ff2465",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "",
+      "family": "interaction_realizations",
+      "id": "interaction-realization-8",
+      "missing_fields": [],
+      "name": "report portfolio gaps",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "interaction-realization-8",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": ""
     },
     {
       "attributes": {
@@ -993,32 +1227,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "a8315094eda0a9ee",
-        "semantic_version": 1,
-        "supersedes": []
-      },
-      "content_semantics": "normative",
-      "family": "non_functional_requirements",
-      "id": "non_functional-requirement-1",
-      "missing_fields": [],
-      "name": "",
-      "normative_ready": true,
-      "readiness_status": "ready",
-      "semantic_id": "non_functional-requirement-1",
-      "source_key": "non_functional_requirements",
-      "source_round": 4,
-      "text": "SSO"
-    },
-    {
-      "attributes": {
-        "requirement_kind": "non_functional"
-      },
-      "blocking_ambiguity_ids": [],
-      "change_metadata": {
-        "change_source": "requirements",
-        "last_changed_at": "",
-        "regenerated_from_version": "",
-        "semantic_hash": "653fcfd7e5d0f72d",
+        "semantic_hash": "2cfeeb6b1a5d6cf3",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -1032,7 +1241,7 @@
       "semantic_id": "non_functional-requirement-2",
       "source_key": "non_functional_requirements",
       "source_round": 4,
-      "text": "role-based access"
+      "text": "SSO"
     },
     {
       "attributes": {
@@ -1043,7 +1252,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "1e1efba12799e966",
+        "semantic_hash": "fea688a24e60eb26",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -1057,7 +1266,7 @@
       "semantic_id": "non_functional-requirement-3",
       "source_key": "non_functional_requirements",
       "source_round": 4,
-      "text": "audit trail"
+      "text": "role-based access"
     },
     {
       "attributes": {
@@ -1068,7 +1277,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "e4dde9ea3c5c65ff",
+        "semantic_hash": "06a6d153cde6db09",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -1082,7 +1291,7 @@
       "semantic_id": "non_functional-requirement-4",
       "source_key": "non_functional_requirements",
       "source_round": 4,
-      "text": "search"
+      "text": "audit trail"
     },
     {
       "attributes": {
@@ -1093,7 +1302,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "2da660a4b12b3c4f",
+        "semantic_hash": "a58c2dc37a3500ae",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -1107,7 +1316,7 @@
       "semantic_id": "non_functional-requirement-5",
       "source_key": "non_functional_requirements",
       "source_round": 4,
-      "text": "filtering"
+      "text": "search"
     },
     {
       "attributes": {
@@ -1118,7 +1327,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "2425258393a5de78",
+        "semantic_hash": "e0effb42b6bd2a5e",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -1132,7 +1341,7 @@
       "semantic_id": "non_functional-requirement-6",
       "source_key": "non_functional_requirements",
       "source_round": 4,
-      "text": "performance (regular >1s for web page rendering)"
+      "text": "filtering"
     },
     {
       "attributes": {
@@ -1143,7 +1352,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "a77d5256a7d4bfcb",
+        "semantic_hash": "f4298ae6bd42c9e4",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -1155,6 +1364,31 @@
       "normative_ready": true,
       "readiness_status": "ready",
       "semantic_id": "non_functional-requirement-7",
+      "source_key": "non_functional_requirements",
+      "source_round": 4,
+      "text": "performance (regular >1s for web page rendering)"
+    },
+    {
+      "attributes": {
+        "requirement_kind": "non_functional"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "requirements",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "7fbb857a1cf2c508",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "non_functional_requirements",
+      "id": "non_functional-requirement-8",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "non_functional-requirement-8",
       "source_key": "non_functional_requirements",
       "source_round": 4,
       "text": "availability >=99%"
@@ -1841,7 +2075,7 @@
       "change_source": "normalize_replay_to_model",
       "last_changed_at": "",
       "regenerated_from_version": "",
-      "semantic_hash": "2f3ec68a35e9678e",
+      "semantic_hash": "62d266a14515319f",
       "semantic_version": 1,
       "supersedes": []
     },
@@ -1877,14 +2111,14 @@
     {
       "attributes": {
         "constraint_kind": "non_functional_requirement",
-        "source_requirement_id": "non_functional-requirement-1"
+        "source_requirement_id": "non_functional-requirement-2"
       },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_acceptance_constraints",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "ea270a270fd5ae0a",
+        "semantic_hash": "cc8fa5e4dd1589f3",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -1903,14 +2137,14 @@
     {
       "attributes": {
         "constraint_kind": "non_functional_requirement",
-        "source_requirement_id": "non_functional-requirement-2"
+        "source_requirement_id": "non_functional-requirement-3"
       },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_acceptance_constraints",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "cc94e38b4882a356",
+        "semantic_hash": "b9a15e23c0db7d29",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -1929,14 +2163,14 @@
     {
       "attributes": {
         "constraint_kind": "non_functional_requirement",
-        "source_requirement_id": "non_functional-requirement-3"
+        "source_requirement_id": "non_functional-requirement-4"
       },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_acceptance_constraints",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "e3b5c94d9e1c0566",
+        "semantic_hash": "c27d4311ee7676d4",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -1955,14 +2189,14 @@
     {
       "attributes": {
         "constraint_kind": "non_functional_requirement",
-        "source_requirement_id": "non_functional-requirement-4"
+        "source_requirement_id": "non_functional-requirement-5"
       },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_acceptance_constraints",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "9c5f49ef585cd8db",
+        "semantic_hash": "07c609485342104d",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -1981,14 +2215,14 @@
     {
       "attributes": {
         "constraint_kind": "non_functional_requirement",
-        "source_requirement_id": "non_functional-requirement-5"
+        "source_requirement_id": "non_functional-requirement-6"
       },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_acceptance_constraints",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "6e001e4c4833adf7",
+        "semantic_hash": "ed67c4ace2e59e49",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -2007,14 +2241,14 @@
     {
       "attributes": {
         "constraint_kind": "non_functional_requirement",
-        "source_requirement_id": "non_functional-requirement-6"
+        "source_requirement_id": "non_functional-requirement-7"
       },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_acceptance_constraints",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "714fad84b7076d46",
+        "semantic_hash": "195499f7e8219562",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -2033,14 +2267,14 @@
     {
       "attributes": {
         "constraint_kind": "non_functional_requirement",
-        "source_requirement_id": "non_functional-requirement-7"
+        "source_requirement_id": "non_functional-requirement-8"
       },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_acceptance_constraints",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "93c0bedbff37f4c7",
+        "semantic_hash": "b2827f52f6dc9af7",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -2200,18 +2434,18 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "139e2490d0d43a69",
+        "semantic_hash": "82d1c204f7e647cb",
         "semantic_version": 1,
         "supersedes": []
       },
       "content_semantics": "normative",
       "family": "functional_requirements",
-      "id": "functional-requirement-1",
+      "id": "functional-requirement-2",
       "missing_fields": [],
       "name": "",
       "normative_ready": true,
       "readiness_status": "ready",
-      "semantic_id": "functional-requirement-1",
+      "semantic_id": "functional-requirement-2",
       "source_key": "integrations",
       "source_round": 3,
       "text": "I think this will be the CMDB for IT Applications/systems - we need to be able to export data to various system for reporting."
@@ -2250,32 +2484,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "a8315094eda0a9ee",
-        "semantic_version": 1,
-        "supersedes": []
-      },
-      "content_semantics": "normative",
-      "family": "non_functional_requirements",
-      "id": "non_functional-requirement-1",
-      "missing_fields": [],
-      "name": "",
-      "normative_ready": true,
-      "readiness_status": "ready",
-      "semantic_id": "non_functional-requirement-1",
-      "source_key": "non_functional_requirements",
-      "source_round": 4,
-      "text": "SSO"
-    },
-    {
-      "attributes": {
-        "requirement_kind": "non_functional"
-      },
-      "blocking_ambiguity_ids": [],
-      "change_metadata": {
-        "change_source": "requirements",
-        "last_changed_at": "",
-        "regenerated_from_version": "",
-        "semantic_hash": "653fcfd7e5d0f72d",
+        "semantic_hash": "2cfeeb6b1a5d6cf3",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -2289,7 +2498,7 @@
       "semantic_id": "non_functional-requirement-2",
       "source_key": "non_functional_requirements",
       "source_round": 4,
-      "text": "role-based access"
+      "text": "SSO"
     },
     {
       "attributes": {
@@ -2300,7 +2509,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "1e1efba12799e966",
+        "semantic_hash": "fea688a24e60eb26",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -2314,7 +2523,7 @@
       "semantic_id": "non_functional-requirement-3",
       "source_key": "non_functional_requirements",
       "source_round": 4,
-      "text": "audit trail"
+      "text": "role-based access"
     },
     {
       "attributes": {
@@ -2325,7 +2534,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "e4dde9ea3c5c65ff",
+        "semantic_hash": "06a6d153cde6db09",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -2339,7 +2548,7 @@
       "semantic_id": "non_functional-requirement-4",
       "source_key": "non_functional_requirements",
       "source_round": 4,
-      "text": "search"
+      "text": "audit trail"
     },
     {
       "attributes": {
@@ -2350,7 +2559,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "2da660a4b12b3c4f",
+        "semantic_hash": "a58c2dc37a3500ae",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -2364,7 +2573,7 @@
       "semantic_id": "non_functional-requirement-5",
       "source_key": "non_functional_requirements",
       "source_round": 4,
-      "text": "filtering"
+      "text": "search"
     },
     {
       "attributes": {
@@ -2375,7 +2584,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "2425258393a5de78",
+        "semantic_hash": "e0effb42b6bd2a5e",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -2389,7 +2598,7 @@
       "semantic_id": "non_functional-requirement-6",
       "source_key": "non_functional_requirements",
       "source_round": 4,
-      "text": "performance (regular >1s for web page rendering)"
+      "text": "filtering"
     },
     {
       "attributes": {
@@ -2400,7 +2609,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "a77d5256a7d4bfcb",
+        "semantic_hash": "f4298ae6bd42c9e4",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -2412,6 +2621,31 @@
       "normative_ready": true,
       "readiness_status": "ready",
       "semantic_id": "non_functional-requirement-7",
+      "source_key": "non_functional_requirements",
+      "source_round": 4,
+      "text": "performance (regular >1s for web page rendering)"
+    },
+    {
+      "attributes": {
+        "requirement_kind": "non_functional"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "requirements",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "7fbb857a1cf2c508",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "non_functional_requirements",
+      "id": "non_functional-requirement-8",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "non_functional-requirement-8",
       "source_key": "non_functional_requirements",
       "source_round": 4,
       "text": "availability >=99%"
@@ -2612,7 +2846,7 @@
   "summary": {
     "blocking_ambiguity_count": 0,
     "blocking_ambiguity_ids": [],
-    "element_count": 72,
+    "element_count": 82,
     "partial_or_blocked_normative_ids": [
       "business-rule-1",
       "business-rule-2",
@@ -2659,8 +2893,7 @@
       "domain-invariant-2",
       "domain-invariant-3",
       "functional-requirement-1",
-      "functional-requirement-1",
-      "non_functional-requirement-1",
+      "functional-requirement-2",
       "non_functional-requirement-1",
       "non_functional-requirement-2",
       "non_functional-requirement-3",
@@ -2668,6 +2901,7 @@
       "non_functional-requirement-5",
       "non_functional-requirement-6",
       "non_functional-requirement-7",
+      "non_functional-requirement-8",
       "state-invariant-1",
       "state-invariant-2",
       "state-invariant-3",
@@ -2705,7 +2939,7 @@
         "change_source": "derived_traceability",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "7f685b8d92b945df",
+        "semantic_hash": "2a8f30551fd123cf",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -2714,25 +2948,6 @@
       "id": "trace-acceptance-constraint-requirement-2",
       "link_type": "acceptance_constraint_to_requirement",
       "semantic_id": "trace-acceptance-constraint-requirement-2",
-      "to_artifact": "",
-      "to_id": "non_functional-requirement-1"
-    },
-    {
-      "artifact_section": "",
-      "basis": "acceptance constraint is derived from canonical requirement",
-      "change_metadata": {
-        "change_source": "derived_traceability",
-        "last_changed_at": "",
-        "regenerated_from_version": "",
-        "semantic_hash": "649c3fbca5601731",
-        "semantic_version": 1,
-        "supersedes": []
-      },
-      "family": "acceptance_constraint_to_requirement",
-      "from_id": "acceptance-constraint-requirement-3",
-      "id": "trace-acceptance-constraint-requirement-3",
-      "link_type": "acceptance_constraint_to_requirement",
-      "semantic_id": "trace-acceptance-constraint-requirement-3",
       "to_artifact": "",
       "to_id": "non_functional-requirement-2"
     },
@@ -2743,15 +2958,15 @@
         "change_source": "derived_traceability",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "91ac10d7368a9a9f",
+        "semantic_hash": "1042f169ffa0dfac",
         "semantic_version": 1,
         "supersedes": []
       },
       "family": "acceptance_constraint_to_requirement",
-      "from_id": "acceptance-constraint-requirement-4",
-      "id": "trace-acceptance-constraint-requirement-4",
+      "from_id": "acceptance-constraint-requirement-3",
+      "id": "trace-acceptance-constraint-requirement-3",
       "link_type": "acceptance_constraint_to_requirement",
-      "semantic_id": "trace-acceptance-constraint-requirement-4",
+      "semantic_id": "trace-acceptance-constraint-requirement-3",
       "to_artifact": "",
       "to_id": "non_functional-requirement-3"
     },
@@ -2762,15 +2977,15 @@
         "change_source": "derived_traceability",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "a099510c537d1d22",
+        "semantic_hash": "c159e8e6b122d0a5",
         "semantic_version": 1,
         "supersedes": []
       },
       "family": "acceptance_constraint_to_requirement",
-      "from_id": "acceptance-constraint-requirement-5",
-      "id": "trace-acceptance-constraint-requirement-5",
+      "from_id": "acceptance-constraint-requirement-4",
+      "id": "trace-acceptance-constraint-requirement-4",
       "link_type": "acceptance_constraint_to_requirement",
-      "semantic_id": "trace-acceptance-constraint-requirement-5",
+      "semantic_id": "trace-acceptance-constraint-requirement-4",
       "to_artifact": "",
       "to_id": "non_functional-requirement-4"
     },
@@ -2781,15 +2996,15 @@
         "change_source": "derived_traceability",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "c37c99b080232b78",
+        "semantic_hash": "7093ee6afe35b701",
         "semantic_version": 1,
         "supersedes": []
       },
       "family": "acceptance_constraint_to_requirement",
-      "from_id": "acceptance-constraint-requirement-6",
-      "id": "trace-acceptance-constraint-requirement-6",
+      "from_id": "acceptance-constraint-requirement-5",
+      "id": "trace-acceptance-constraint-requirement-5",
       "link_type": "acceptance_constraint_to_requirement",
-      "semantic_id": "trace-acceptance-constraint-requirement-6",
+      "semantic_id": "trace-acceptance-constraint-requirement-5",
       "to_artifact": "",
       "to_id": "non_functional-requirement-5"
     },
@@ -2800,15 +3015,15 @@
         "change_source": "derived_traceability",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "c91c61b275d7fab9",
+        "semantic_hash": "d21a0052e99e9f96",
         "semantic_version": 1,
         "supersedes": []
       },
       "family": "acceptance_constraint_to_requirement",
-      "from_id": "acceptance-constraint-requirement-7",
-      "id": "trace-acceptance-constraint-requirement-7",
+      "from_id": "acceptance-constraint-requirement-6",
+      "id": "trace-acceptance-constraint-requirement-6",
       "link_type": "acceptance_constraint_to_requirement",
-      "semantic_id": "trace-acceptance-constraint-requirement-7",
+      "semantic_id": "trace-acceptance-constraint-requirement-6",
       "to_artifact": "",
       "to_id": "non_functional-requirement-6"
     },
@@ -2819,7 +3034,26 @@
         "change_source": "derived_traceability",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "f1b8057e436d3a6c",
+        "semantic_hash": "925ad8c492270e3b",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "acceptance_constraint_to_requirement",
+      "from_id": "acceptance-constraint-requirement-7",
+      "id": "trace-acceptance-constraint-requirement-7",
+      "link_type": "acceptance_constraint_to_requirement",
+      "semantic_id": "trace-acceptance-constraint-requirement-7",
+      "to_artifact": "",
+      "to_id": "non_functional-requirement-7"
+    },
+    {
+      "artifact_section": "",
+      "basis": "acceptance constraint is derived from canonical requirement",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "43a452499469b490",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -2829,7 +3063,7 @@
       "link_type": "acceptance_constraint_to_requirement",
       "semantic_id": "trace-acceptance-constraint-requirement-8",
       "to_artifact": "",
-      "to_id": "non_functional-requirement-7"
+      "to_id": "non_functional-requirement-8"
     },
     {
       "artifact_section": "",
@@ -3769,34 +4003,15 @@
         "change_source": "derived_traceability",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "fec25440bb6afe79",
+        "semantic_hash": "49f0e4b5d57e2433",
         "semantic_version": 1,
         "supersedes": []
       },
       "family": "artifact_lineage",
-      "from_id": "functional-requirement-1",
-      "id": "trace-artifact-requirements-spec-functional-requirements-functional-requirement-1",
+      "from_id": "functional-requirement-2",
+      "id": "trace-artifact-requirements-spec-functional-requirements-functional-requirement-2",
       "link_type": "artifact_lineage",
-      "semantic_id": "trace-artifact-requirements-spec-functional-requirements-functional-requirement-1",
-      "to_artifact": "requirements-spec.md",
-      "to_id": ""
-    },
-    {
-      "artifact_section": "functional requirements",
-      "basis": "canonical functional requirements object renders into requirements-spec.md",
-      "change_metadata": {
-        "change_source": "derived_traceability",
-        "last_changed_at": "",
-        "regenerated_from_version": "",
-        "semantic_hash": "366d3df1f215edf6",
-        "semantic_version": 1,
-        "supersedes": []
-      },
-      "family": "artifact_lineage",
-      "from_id": "non_functional-requirement-1",
-      "id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-1",
-      "link_type": "artifact_lineage",
-      "semantic_id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-1",
+      "semantic_id": "trace-artifact-requirements-spec-functional-requirements-functional-requirement-2",
       "to_artifact": "requirements-spec.md",
       "to_id": ""
     },
@@ -3930,6 +4145,25 @@
       "id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-7",
       "link_type": "artifact_lineage",
       "semantic_id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-7",
+      "to_artifact": "requirements-spec.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "functional requirements",
+      "basis": "canonical functional requirements object renders into requirements-spec.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "995eb12674eaca8d",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "non_functional-requirement-8",
+      "id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-8",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-8",
       "to_artifact": "requirements-spec.md",
       "to_id": ""
     },

--- a/examples/it-systems-inventory-v2/model/rupify-model.json
+++ b/examples/it-systems-inventory-v2/model/rupify-model.json
@@ -276,7 +276,7 @@
           "change_source": "derived_acceptance_constraints",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "ea270a270fd5ae0a",
+          "semantic_hash": "cc8fa5e4dd1589f3",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -297,7 +297,7 @@
           "status": "ready"
         },
         "semantic_id": "acceptance-constraint-requirement-2",
-        "source_requirement_id": "non_functional-requirement-1",
+        "source_requirement_id": "non_functional-requirement-2",
         "trace": {
           "source_key": "non_functional_requirements",
           "source_round": 4
@@ -308,7 +308,7 @@
           "change_source": "derived_acceptance_constraints",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "cc94e38b4882a356",
+          "semantic_hash": "b9a15e23c0db7d29",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -329,7 +329,7 @@
           "status": "ready"
         },
         "semantic_id": "acceptance-constraint-requirement-3",
-        "source_requirement_id": "non_functional-requirement-2",
+        "source_requirement_id": "non_functional-requirement-3",
         "trace": {
           "source_key": "non_functional_requirements",
           "source_round": 4
@@ -340,7 +340,7 @@
           "change_source": "derived_acceptance_constraints",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "e3b5c94d9e1c0566",
+          "semantic_hash": "c27d4311ee7676d4",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -361,7 +361,7 @@
           "status": "ready"
         },
         "semantic_id": "acceptance-constraint-requirement-4",
-        "source_requirement_id": "non_functional-requirement-3",
+        "source_requirement_id": "non_functional-requirement-4",
         "trace": {
           "source_key": "non_functional_requirements",
           "source_round": 4
@@ -372,7 +372,7 @@
           "change_source": "derived_acceptance_constraints",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "9c5f49ef585cd8db",
+          "semantic_hash": "07c609485342104d",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -393,7 +393,7 @@
           "status": "ready"
         },
         "semantic_id": "acceptance-constraint-requirement-5",
-        "source_requirement_id": "non_functional-requirement-4",
+        "source_requirement_id": "non_functional-requirement-5",
         "trace": {
           "source_key": "non_functional_requirements",
           "source_round": 4
@@ -404,7 +404,7 @@
           "change_source": "derived_acceptance_constraints",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "6e001e4c4833adf7",
+          "semantic_hash": "ed67c4ace2e59e49",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -425,7 +425,7 @@
           "status": "ready"
         },
         "semantic_id": "acceptance-constraint-requirement-6",
-        "source_requirement_id": "non_functional-requirement-5",
+        "source_requirement_id": "non_functional-requirement-6",
         "trace": {
           "source_key": "non_functional_requirements",
           "source_round": 4
@@ -436,7 +436,7 @@
           "change_source": "derived_acceptance_constraints",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "714fad84b7076d46",
+          "semantic_hash": "195499f7e8219562",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -457,7 +457,7 @@
           "status": "ready"
         },
         "semantic_id": "acceptance-constraint-requirement-7",
-        "source_requirement_id": "non_functional-requirement-6",
+        "source_requirement_id": "non_functional-requirement-7",
         "trace": {
           "source_key": "non_functional_requirements",
           "source_round": 4
@@ -468,7 +468,7 @@
           "change_source": "derived_acceptance_constraints",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "93c0bedbff37f4c7",
+          "semantic_hash": "b2827f52f6dc9af7",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -489,7 +489,7 @@
           "status": "ready"
         },
         "semantic_id": "acceptance-constraint-requirement-8",
-        "source_requirement_id": "non_functional-requirement-7",
+        "source_requirement_id": "non_functional-requirement-8",
         "trace": {
           "source_key": "non_functional_requirements",
           "source_round": 4
@@ -1378,15 +1378,15 @@
     ],
     "requirement_ids": [
       "functional-requirement-1",
-      "functional-requirement-1",
-      "non_functional-requirement-1",
+      "functional-requirement-2",
       "non_functional-requirement-1",
       "non_functional-requirement-2",
       "non_functional-requirement-3",
       "non_functional-requirement-4",
       "non_functional-requirement-5",
       "non_functional-requirement-6",
-      "non_functional-requirement-7"
+      "non_functional-requirement-7",
+      "non_functional-requirement-8"
     ],
     "requirement_objects": [
       {
@@ -1427,13 +1427,13 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "139e2490d0d43a69",
+          "semantic_hash": "82d1c204f7e647cb",
           "semantic_version": 1,
           "supersedes": []
         },
         "content_semantics": "normative",
         "fit_criterion": "",
-        "id": "functional-requirement-1",
+        "id": "functional-requirement-2",
         "linked_step_ids": [],
         "linked_use_case_ids": [],
         "model_layer": "analysis",
@@ -1442,13 +1442,13 @@
           "blocking_ambiguity_ids": [],
           "content_semantics": "normative",
           "family": "requirements",
-          "id": "functional-requirement-1",
+          "id": "functional-requirement-2",
           "missing_fields": [],
           "normative_ready": true,
           "status": "ready"
         },
         "requirement_kind": "functional",
-        "semantic_id": "functional-requirement-1",
+        "semantic_id": "functional-requirement-2",
         "statement": "I think this will be the CMDB for IT Applications/systems - we need to be able to export data to various system for reporting.",
         "trace": {
           "source_key": "integrations",
@@ -1493,40 +1493,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "a8315094eda0a9ee",
-          "semantic_version": 1,
-          "supersedes": []
-        },
-        "content_semantics": "normative",
-        "fit_criterion": "",
-        "id": "non_functional-requirement-1",
-        "linked_step_ids": [],
-        "linked_use_case_ids": [],
-        "model_layer": "analysis",
-        "quality_attribute": "",
-        "readiness": {
-          "blocking_ambiguity_ids": [],
-          "content_semantics": "normative",
-          "family": "requirements",
-          "id": "non_functional-requirement-1",
-          "missing_fields": [],
-          "normative_ready": true,
-          "status": "ready"
-        },
-        "requirement_kind": "non_functional",
-        "semantic_id": "non_functional-requirement-1",
-        "statement": "SSO",
-        "trace": {
-          "source_key": "non_functional_requirements",
-          "source_round": 4
-        }
-      },
-      {
-        "change_metadata": {
-          "change_source": "requirements",
-          "last_changed_at": "",
-          "regenerated_from_version": "",
-          "semantic_hash": "653fcfd7e5d0f72d",
+          "semantic_hash": "2cfeeb6b1a5d6cf3",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -1548,7 +1515,7 @@
         },
         "requirement_kind": "non_functional",
         "semantic_id": "non_functional-requirement-2",
-        "statement": "role-based access",
+        "statement": "SSO",
         "trace": {
           "source_key": "non_functional_requirements",
           "source_round": 4
@@ -1559,7 +1526,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "1e1efba12799e966",
+          "semantic_hash": "fea688a24e60eb26",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -1581,7 +1548,7 @@
         },
         "requirement_kind": "non_functional",
         "semantic_id": "non_functional-requirement-3",
-        "statement": "audit trail",
+        "statement": "role-based access",
         "trace": {
           "source_key": "non_functional_requirements",
           "source_round": 4
@@ -1592,7 +1559,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "e4dde9ea3c5c65ff",
+          "semantic_hash": "06a6d153cde6db09",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -1614,7 +1581,7 @@
         },
         "requirement_kind": "non_functional",
         "semantic_id": "non_functional-requirement-4",
-        "statement": "search",
+        "statement": "audit trail",
         "trace": {
           "source_key": "non_functional_requirements",
           "source_round": 4
@@ -1625,7 +1592,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "2da660a4b12b3c4f",
+          "semantic_hash": "a58c2dc37a3500ae",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -1647,7 +1614,7 @@
         },
         "requirement_kind": "non_functional",
         "semantic_id": "non_functional-requirement-5",
-        "statement": "filtering",
+        "statement": "search",
         "trace": {
           "source_key": "non_functional_requirements",
           "source_round": 4
@@ -1658,7 +1625,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "2425258393a5de78",
+          "semantic_hash": "e0effb42b6bd2a5e",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -1680,7 +1647,7 @@
         },
         "requirement_kind": "non_functional",
         "semantic_id": "non_functional-requirement-6",
-        "statement": "performance (regular >1s for web page rendering)",
+        "statement": "filtering",
         "trace": {
           "source_key": "non_functional_requirements",
           "source_round": 4
@@ -1691,7 +1658,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "a77d5256a7d4bfcb",
+          "semantic_hash": "f4298ae6bd42c9e4",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -1713,6 +1680,39 @@
         },
         "requirement_kind": "non_functional",
         "semantic_id": "non_functional-requirement-7",
+        "statement": "performance (regular >1s for web page rendering)",
+        "trace": {
+          "source_key": "non_functional_requirements",
+          "source_round": 4
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "requirements",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "7fbb857a1cf2c508",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "fit_criterion": "",
+        "id": "non_functional-requirement-8",
+        "linked_step_ids": [],
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "quality_attribute": "",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "non_functional-requirement-8",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "requirement_kind": "non_functional",
+        "semantic_id": "non_functional-requirement-8",
         "statement": "availability >=99%",
         "trace": {
           "source_key": "non_functional_requirements",
@@ -2996,16 +2996,7 @@
           "blocking_ambiguity_ids": [],
           "content_semantics": "normative",
           "family": "requirements",
-          "id": "functional-requirement-1",
-          "missing_fields": [],
-          "normative_ready": true,
-          "status": "ready"
-        },
-        {
-          "blocking_ambiguity_ids": [],
-          "content_semantics": "normative",
-          "family": "requirements",
-          "id": "non_functional-requirement-1",
+          "id": "functional-requirement-2",
           "missing_fields": [],
           "normative_ready": true,
           "status": "ready"
@@ -3069,6 +3060,15 @@
           "content_semantics": "normative",
           "family": "requirements",
           "id": "non_functional-requirement-7",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "non_functional-requirement-8",
           "missing_fields": [],
           "normative_ready": true,
           "status": "ready"
@@ -3251,8 +3251,7 @@
       "partial_normative_ids": [],
       "ready_normative_ids": [
         "functional-requirement-1",
-        "functional-requirement-1",
-        "non_functional-requirement-1",
+        "functional-requirement-2",
         "non_functional-requirement-1",
         "non_functional-requirement-2",
         "non_functional-requirement-3",
@@ -3260,6 +3259,7 @@
         "non_functional-requirement-5",
         "non_functional-requirement-6",
         "non_functional-requirement-7",
+        "non_functional-requirement-8",
         "acceptance-constraint-requirement-1",
         "acceptance-constraint-requirement-2",
         "acceptance-constraint-requirement-3",
@@ -4090,7 +4090,7 @@
       "change_source": "normalize_replay_to_model",
       "last_changed_at": "",
       "regenerated_from_version": "",
-      "semantic_hash": "2f3ec68a35e9678e",
+      "semantic_hash": "62d266a14515319f",
       "semantic_version": 1,
       "supersedes": []
     },
@@ -4568,7 +4568,7 @@
           "change_source": "derived_acceptance_constraints",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "ea270a270fd5ae0a",
+          "semantic_hash": "cc8fa5e4dd1589f3",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -4589,7 +4589,7 @@
           "status": "ready"
         },
         "semantic_id": "acceptance-constraint-requirement-2",
-        "source_requirement_id": "non_functional-requirement-1",
+        "source_requirement_id": "non_functional-requirement-2",
         "trace": {
           "source_key": "non_functional_requirements",
           "source_round": 4
@@ -4600,7 +4600,7 @@
           "change_source": "derived_acceptance_constraints",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "cc94e38b4882a356",
+          "semantic_hash": "b9a15e23c0db7d29",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -4621,7 +4621,7 @@
           "status": "ready"
         },
         "semantic_id": "acceptance-constraint-requirement-3",
-        "source_requirement_id": "non_functional-requirement-2",
+        "source_requirement_id": "non_functional-requirement-3",
         "trace": {
           "source_key": "non_functional_requirements",
           "source_round": 4
@@ -4632,7 +4632,7 @@
           "change_source": "derived_acceptance_constraints",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "e3b5c94d9e1c0566",
+          "semantic_hash": "c27d4311ee7676d4",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -4653,7 +4653,7 @@
           "status": "ready"
         },
         "semantic_id": "acceptance-constraint-requirement-4",
-        "source_requirement_id": "non_functional-requirement-3",
+        "source_requirement_id": "non_functional-requirement-4",
         "trace": {
           "source_key": "non_functional_requirements",
           "source_round": 4
@@ -4664,7 +4664,7 @@
           "change_source": "derived_acceptance_constraints",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "9c5f49ef585cd8db",
+          "semantic_hash": "07c609485342104d",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -4685,7 +4685,7 @@
           "status": "ready"
         },
         "semantic_id": "acceptance-constraint-requirement-5",
-        "source_requirement_id": "non_functional-requirement-4",
+        "source_requirement_id": "non_functional-requirement-5",
         "trace": {
           "source_key": "non_functional_requirements",
           "source_round": 4
@@ -4696,7 +4696,7 @@
           "change_source": "derived_acceptance_constraints",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "6e001e4c4833adf7",
+          "semantic_hash": "ed67c4ace2e59e49",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -4717,7 +4717,7 @@
           "status": "ready"
         },
         "semantic_id": "acceptance-constraint-requirement-6",
-        "source_requirement_id": "non_functional-requirement-5",
+        "source_requirement_id": "non_functional-requirement-6",
         "trace": {
           "source_key": "non_functional_requirements",
           "source_round": 4
@@ -4728,7 +4728,7 @@
           "change_source": "derived_acceptance_constraints",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "714fad84b7076d46",
+          "semantic_hash": "195499f7e8219562",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -4749,7 +4749,7 @@
           "status": "ready"
         },
         "semantic_id": "acceptance-constraint-requirement-7",
-        "source_requirement_id": "non_functional-requirement-6",
+        "source_requirement_id": "non_functional-requirement-7",
         "trace": {
           "source_key": "non_functional_requirements",
           "source_round": 4
@@ -4760,7 +4760,7 @@
           "change_source": "derived_acceptance_constraints",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "93c0bedbff37f4c7",
+          "semantic_hash": "b2827f52f6dc9af7",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -4781,7 +4781,7 @@
           "status": "ready"
         },
         "semantic_id": "acceptance-constraint-requirement-8",
-        "source_requirement_id": "non_functional-requirement-7",
+        "source_requirement_id": "non_functional-requirement-8",
         "trace": {
           "source_key": "non_functional_requirements",
           "source_round": 4
@@ -4874,13 +4874,13 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "139e2490d0d43a69",
+          "semantic_hash": "82d1c204f7e647cb",
           "semantic_version": 1,
           "supersedes": []
         },
         "content_semantics": "normative",
         "fit_criterion": "",
-        "id": "functional-requirement-1",
+        "id": "functional-requirement-2",
         "linked_step_ids": [],
         "linked_use_case_ids": [],
         "model_layer": "analysis",
@@ -4889,13 +4889,13 @@
           "blocking_ambiguity_ids": [],
           "content_semantics": "normative",
           "family": "requirements",
-          "id": "functional-requirement-1",
+          "id": "functional-requirement-2",
           "missing_fields": [],
           "normative_ready": true,
           "status": "ready"
         },
         "requirement_kind": "functional",
-        "semantic_id": "functional-requirement-1",
+        "semantic_id": "functional-requirement-2",
         "statement": "I think this will be the CMDB for IT Applications/systems - we need to be able to export data to various system for reporting.",
         "trace": {
           "source_key": "integrations",
@@ -4952,40 +4952,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "a8315094eda0a9ee",
-          "semantic_version": 1,
-          "supersedes": []
-        },
-        "content_semantics": "normative",
-        "fit_criterion": "",
-        "id": "non_functional-requirement-1",
-        "linked_step_ids": [],
-        "linked_use_case_ids": [],
-        "model_layer": "analysis",
-        "quality_attribute": "",
-        "readiness": {
-          "blocking_ambiguity_ids": [],
-          "content_semantics": "normative",
-          "family": "requirements",
-          "id": "non_functional-requirement-1",
-          "missing_fields": [],
-          "normative_ready": true,
-          "status": "ready"
-        },
-        "requirement_kind": "non_functional",
-        "semantic_id": "non_functional-requirement-1",
-        "statement": "SSO",
-        "trace": {
-          "source_key": "non_functional_requirements",
-          "source_round": 4
-        }
-      },
-      {
-        "change_metadata": {
-          "change_source": "requirements",
-          "last_changed_at": "",
-          "regenerated_from_version": "",
-          "semantic_hash": "653fcfd7e5d0f72d",
+          "semantic_hash": "2cfeeb6b1a5d6cf3",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -5007,7 +4974,7 @@
         },
         "requirement_kind": "non_functional",
         "semantic_id": "non_functional-requirement-2",
-        "statement": "role-based access",
+        "statement": "SSO",
         "trace": {
           "source_key": "non_functional_requirements",
           "source_round": 4
@@ -5018,7 +4985,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "1e1efba12799e966",
+          "semantic_hash": "fea688a24e60eb26",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -5040,7 +5007,7 @@
         },
         "requirement_kind": "non_functional",
         "semantic_id": "non_functional-requirement-3",
-        "statement": "audit trail",
+        "statement": "role-based access",
         "trace": {
           "source_key": "non_functional_requirements",
           "source_round": 4
@@ -5051,7 +5018,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "e4dde9ea3c5c65ff",
+          "semantic_hash": "06a6d153cde6db09",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -5073,7 +5040,7 @@
         },
         "requirement_kind": "non_functional",
         "semantic_id": "non_functional-requirement-4",
-        "statement": "search",
+        "statement": "audit trail",
         "trace": {
           "source_key": "non_functional_requirements",
           "source_round": 4
@@ -5084,7 +5051,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "2da660a4b12b3c4f",
+          "semantic_hash": "a58c2dc37a3500ae",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -5106,7 +5073,7 @@
         },
         "requirement_kind": "non_functional",
         "semantic_id": "non_functional-requirement-5",
-        "statement": "filtering",
+        "statement": "search",
         "trace": {
           "source_key": "non_functional_requirements",
           "source_round": 4
@@ -5117,7 +5084,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "2425258393a5de78",
+          "semantic_hash": "e0effb42b6bd2a5e",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -5139,7 +5106,7 @@
         },
         "requirement_kind": "non_functional",
         "semantic_id": "non_functional-requirement-6",
-        "statement": "performance (regular >1s for web page rendering)",
+        "statement": "filtering",
         "trace": {
           "source_key": "non_functional_requirements",
           "source_round": 4
@@ -5150,7 +5117,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "a77d5256a7d4bfcb",
+          "semantic_hash": "f4298ae6bd42c9e4",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -5172,6 +5139,39 @@
         },
         "requirement_kind": "non_functional",
         "semantic_id": "non_functional-requirement-7",
+        "statement": "performance (regular >1s for web page rendering)",
+        "trace": {
+          "source_key": "non_functional_requirements",
+          "source_round": 4
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "requirements",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "7fbb857a1cf2c508",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "fit_criterion": "",
+        "id": "non_functional-requirement-8",
+        "linked_step_ids": [],
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "quality_attribute": "",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "non_functional-requirement-8",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "requirement_kind": "non_functional",
+        "semantic_id": "non_functional-requirement-8",
         "statement": "availability >=99%",
         "trace": {
           "source_key": "non_functional_requirements",
@@ -5209,7 +5209,7 @@
           "change_source": "derived_traceability",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "7f685b8d92b945df",
+          "semantic_hash": "2a8f30551fd123cf",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -5217,22 +5217,6 @@
         "id": "trace-acceptance-constraint-requirement-2",
         "link_type": "acceptance_constraint_to_requirement",
         "semantic_id": "trace-acceptance-constraint-requirement-2",
-        "to_id": "non_functional-requirement-1"
-      },
-      {
-        "basis": "acceptance constraint is derived from canonical requirement",
-        "change_metadata": {
-          "change_source": "derived_traceability",
-          "last_changed_at": "",
-          "regenerated_from_version": "",
-          "semantic_hash": "649c3fbca5601731",
-          "semantic_version": 1,
-          "supersedes": []
-        },
-        "from_id": "acceptance-constraint-requirement-3",
-        "id": "trace-acceptance-constraint-requirement-3",
-        "link_type": "acceptance_constraint_to_requirement",
-        "semantic_id": "trace-acceptance-constraint-requirement-3",
         "to_id": "non_functional-requirement-2"
       },
       {
@@ -5241,14 +5225,14 @@
           "change_source": "derived_traceability",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "91ac10d7368a9a9f",
+          "semantic_hash": "1042f169ffa0dfac",
           "semantic_version": 1,
           "supersedes": []
         },
-        "from_id": "acceptance-constraint-requirement-4",
-        "id": "trace-acceptance-constraint-requirement-4",
+        "from_id": "acceptance-constraint-requirement-3",
+        "id": "trace-acceptance-constraint-requirement-3",
         "link_type": "acceptance_constraint_to_requirement",
-        "semantic_id": "trace-acceptance-constraint-requirement-4",
+        "semantic_id": "trace-acceptance-constraint-requirement-3",
         "to_id": "non_functional-requirement-3"
       },
       {
@@ -5257,14 +5241,14 @@
           "change_source": "derived_traceability",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "a099510c537d1d22",
+          "semantic_hash": "c159e8e6b122d0a5",
           "semantic_version": 1,
           "supersedes": []
         },
-        "from_id": "acceptance-constraint-requirement-5",
-        "id": "trace-acceptance-constraint-requirement-5",
+        "from_id": "acceptance-constraint-requirement-4",
+        "id": "trace-acceptance-constraint-requirement-4",
         "link_type": "acceptance_constraint_to_requirement",
-        "semantic_id": "trace-acceptance-constraint-requirement-5",
+        "semantic_id": "trace-acceptance-constraint-requirement-4",
         "to_id": "non_functional-requirement-4"
       },
       {
@@ -5273,14 +5257,14 @@
           "change_source": "derived_traceability",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "c37c99b080232b78",
+          "semantic_hash": "7093ee6afe35b701",
           "semantic_version": 1,
           "supersedes": []
         },
-        "from_id": "acceptance-constraint-requirement-6",
-        "id": "trace-acceptance-constraint-requirement-6",
+        "from_id": "acceptance-constraint-requirement-5",
+        "id": "trace-acceptance-constraint-requirement-5",
         "link_type": "acceptance_constraint_to_requirement",
-        "semantic_id": "trace-acceptance-constraint-requirement-6",
+        "semantic_id": "trace-acceptance-constraint-requirement-5",
         "to_id": "non_functional-requirement-5"
       },
       {
@@ -5289,14 +5273,14 @@
           "change_source": "derived_traceability",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "c91c61b275d7fab9",
+          "semantic_hash": "d21a0052e99e9f96",
           "semantic_version": 1,
           "supersedes": []
         },
-        "from_id": "acceptance-constraint-requirement-7",
-        "id": "trace-acceptance-constraint-requirement-7",
+        "from_id": "acceptance-constraint-requirement-6",
+        "id": "trace-acceptance-constraint-requirement-6",
         "link_type": "acceptance_constraint_to_requirement",
-        "semantic_id": "trace-acceptance-constraint-requirement-7",
+        "semantic_id": "trace-acceptance-constraint-requirement-6",
         "to_id": "non_functional-requirement-6"
       },
       {
@@ -5305,7 +5289,23 @@
           "change_source": "derived_traceability",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "f1b8057e436d3a6c",
+          "semantic_hash": "925ad8c492270e3b",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "acceptance-constraint-requirement-7",
+        "id": "trace-acceptance-constraint-requirement-7",
+        "link_type": "acceptance_constraint_to_requirement",
+        "semantic_id": "trace-acceptance-constraint-requirement-7",
+        "to_id": "non_functional-requirement-7"
+      },
+      {
+        "basis": "acceptance constraint is derived from canonical requirement",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "43a452499469b490",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -5313,7 +5313,7 @@
         "id": "trace-acceptance-constraint-requirement-8",
         "link_type": "acceptance_constraint_to_requirement",
         "semantic_id": "trace-acceptance-constraint-requirement-8",
-        "to_id": "non_functional-requirement-7"
+        "to_id": "non_functional-requirement-8"
       }
     ],
     "ambiguity_to_element": [],
@@ -5646,31 +5646,14 @@
           "change_source": "derived_traceability",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "fec25440bb6afe79",
+          "semantic_hash": "49f0e4b5d57e2433",
           "semantic_version": 1,
           "supersedes": []
         },
-        "from_id": "functional-requirement-1",
-        "id": "trace-artifact-requirements-spec-functional-requirements-functional-requirement-1",
+        "from_id": "functional-requirement-2",
+        "id": "trace-artifact-requirements-spec-functional-requirements-functional-requirement-2",
         "link_type": "artifact_lineage",
-        "semantic_id": "trace-artifact-requirements-spec-functional-requirements-functional-requirement-1",
-        "to_artifact": "requirements-spec.md"
-      },
-      {
-        "artifact_section": "functional requirements",
-        "basis": "canonical functional requirements object renders into requirements-spec.md",
-        "change_metadata": {
-          "change_source": "derived_traceability",
-          "last_changed_at": "",
-          "regenerated_from_version": "",
-          "semantic_hash": "366d3df1f215edf6",
-          "semantic_version": 1,
-          "supersedes": []
-        },
-        "from_id": "non_functional-requirement-1",
-        "id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-1",
-        "link_type": "artifact_lineage",
-        "semantic_id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-1",
+        "semantic_id": "trace-artifact-requirements-spec-functional-requirements-functional-requirement-2",
         "to_artifact": "requirements-spec.md"
       },
       {
@@ -5790,6 +5773,23 @@
         "id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-7",
         "link_type": "artifact_lineage",
         "semantic_id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-7",
+        "to_artifact": "requirements-spec.md"
+      },
+      {
+        "artifact_section": "functional requirements",
+        "basis": "canonical functional requirements object renders into requirements-spec.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "995eb12674eaca8d",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "non_functional-requirement-8",
+        "id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-8",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-8",
         "to_artifact": "requirements-spec.md"
       },
       {

--- a/src/rupify_tools/discovery.py
+++ b/src/rupify_tools/discovery.py
@@ -675,6 +675,15 @@ def _normalize_requirement_objects(
     return objects
 
 
+def _reindex_requirement_objects(
+    items: list[dict[str, Any]],
+    requirement_kind: str,
+) -> None:
+    """Assign stable sequential requirement ids across one combined requirement family."""
+    for index, item in enumerate(items, 1):
+        item["id"] = f"{requirement_kind}-requirement-{index}"
+
+
 def _split_structured_parts(item: str) -> list[str]:
     """Split a pipe-delimited structured answer into trimmed parts."""
     return [part.strip() for part in item.split("|") if part.strip()]
@@ -1891,6 +1900,7 @@ def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
                 "integrations",
             )
         )
+    _reindex_requirement_objects(functional_requirement_objects, "functional")
 
     non_functional_requirement_objects = []
     if constraints:
@@ -1910,6 +1920,7 @@ def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
                 "non_functional_requirements",
             )
         )
+    _reindex_requirement_objects(non_functional_requirement_objects, "non_functional")
     risk_objects = _with_trace(
         _normalize_risks(_ensure_list(round_12.get("risks"))),
         12,

--- a/src/rupify_tools/planning_export.py
+++ b/src/rupify_tools/planning_export.py
@@ -28,6 +28,8 @@ ELEMENT_FAMILY_SPECS: tuple[tuple[str, tuple[str, ...]], ...] = (
     ("components", ("architecture_view", "component_objects")),
     ("interfaces", ("architecture_view", "interface_objects")),
     ("runtime_boundaries", ("architecture_view", "runtime_boundary_objects")),
+    ("interaction_realizations", ("interaction_view", "realization_objects")),
+    ("interaction_messages", ("interaction_view", "message_objects")),
 )
 
 

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -234,6 +234,47 @@ class DiscoveryTests(unittest.TestCase):
             model["design_view"]["component_objects"],
         )
 
+    def test_normalize_replay_to_model_reindexes_combined_requirement_batches(self) -> None:
+        """Requirement ids should remain unique when multiple rounds contribute the same family."""
+        replay = replay_session(
+            [
+                {
+                    "round": 2,
+                    "responses": [
+                        {"key": "constraints", "answer": ["Web based"]},
+                    ],
+                },
+                {
+                    "round": 3,
+                    "responses": [
+                        {"key": "integrations", "answer": "Export data to reporting systems"},
+                    ],
+                },
+                {
+                    "round": 4,
+                    "responses": [
+                        {"key": "workflow_scope", "answer": "Support approvals"},
+                        {"key": "non_functional_requirements", "answer": ["SSO", "Audit trail"]},
+                    ],
+                },
+            ]
+        )
+
+        model = normalize_replay_to_model(replay)
+
+        self.assertEqual(
+            [item["id"] for item in model["requirements"]["functional_objects"]],
+            ["functional-requirement-1", "functional-requirement-2"],
+        )
+        self.assertEqual(
+            [item["id"] for item in model["requirements"]["non_functional_objects"]],
+            [
+                "non_functional-requirement-1",
+                "non_functional-requirement-2",
+                "non_functional-requirement-3",
+            ],
+        )
+
     def test_normalize_replay_to_model_keeps_empty_sections_explicit(self) -> None:
         """Missing optional view rounds should still produce stable empty sections."""
         replay = replay_session(

--- a/tests/test_planning_export.py
+++ b/tests/test_planning_export.py
@@ -138,6 +138,42 @@ class PlanningExportTests(unittest.TestCase):
             "interface_objects": [],
             "runtime_boundary_objects": [],
         }
+        model["interaction_view"] = {
+            "realization_objects": [
+                {
+                    "id": "interaction-realization-1",
+                    "semantic_id": "interaction-realization-1",
+                    "use_case_name": "Redeem Reward",
+                    "steps": ["Customer selects reward."],
+                    "content_semantics": "informative",
+                    "readiness": {
+                        "status": "ready",
+                        "normative_ready": False,
+                        "missing_fields": [],
+                        "blocking_ambiguity_ids": [],
+                    },
+                    "change_metadata": {"semantic_hash": "realhash"},
+                    "trace": {"source_round": 3, "source_key": "use_cases"},
+                }
+            ],
+            "message_objects": [
+                {
+                    "id": "interaction-message-1",
+                    "semantic_id": "interaction-message-1",
+                    "description": "Member App calls Rewards API",
+                    "content_semantics": "informative",
+                    "readiness": {
+                        "status": "ready",
+                        "normative_ready": False,
+                        "missing_fields": [],
+                        "blocking_ambiguity_ids": [],
+                    },
+                    "change_metadata": {"semantic_hash": "messagehash"},
+                    "trace": {"source_round": 7, "source_key": "interfaces_and_integrations"},
+                    "interaction_verb": "calls",
+                }
+            ],
+        }
         model["traceability"] = {
             "requirement_to_use_case": [
                 {
@@ -161,6 +197,18 @@ class PlanningExportTests(unittest.TestCase):
                     "change_metadata": {"semantic_hash": "ambtracehash"},
                 }
             ],
+            "artifact_lineage": [
+                {
+                    "id": "trace-artifact-interaction-message-1",
+                    "semantic_id": "trace-artifact-interaction-message-1",
+                    "from_id": "interaction-message-1",
+                    "to_artifact": "interaction-model.md",
+                    "artifact_section": "message flows",
+                    "link_type": "artifact_lineage",
+                    "basis": "canonical message flow renders into interaction-model.md",
+                    "change_metadata": {"semantic_hash": "artifacthash"},
+                }
+            ],
         }
 
         export = build_planning_export(model)
@@ -180,9 +228,17 @@ class PlanningExportTests(unittest.TestCase):
         self.assertIn("acceptance-constraint-1", export["summary"]["partial_or_blocked_normative_ids"])
         self.assertTrue(any(item["family"] == "use_cases" for item in export["ready_normative_elements"]))
         self.assertTrue(any(link["family"] == "ambiguity_to_element" for link in export["trace_links"]))
+        self.assertTrue(any(item["family"] == "interaction_messages" for item in export["elements"]))
         self.assertEqual(
             next(item for item in export["elements"] if item["id"] == "acceptance-constraint-1")["attributes"]["linked_use_case_ids"],
             ["uc-redeem"],
+        )
+        self.assertTrue(
+            any(
+                link["id"] == "trace-artifact-interaction-message-1"
+                and link["from_id"] == "interaction-message-1"
+                for link in export["trace_links"]
+            )
         )
 
     def test_cli_writes_planning_export_json(self) -> None:
@@ -255,6 +311,30 @@ class PlanningExportTests(unittest.TestCase):
             self.assertEqual(payload["export_metadata"]["export_kind"], "speckify_planning_export")
             self.assertEqual(payload["summary"]["element_count"], 0)
             self.assertIn(str(output_path), completed.stdout)
+
+    def test_checked_in_cmdb_v2_export_has_unique_ids_and_resolved_trace_references(self) -> None:
+        """The checked-in CMDB V2 export should be clean for strict Speckify import."""
+        repo_root = Path(__file__).resolve().parents[1]
+        export_path = (
+            repo_root
+            / "examples"
+            / "it-systems-inventory-v2"
+            / "exports"
+            / "speckify-planning-export.json"
+        )
+        payload = json.loads(export_path.read_text(encoding="utf-8"))
+
+        element_ids = [item["id"] for item in payload["elements"]]
+        self.assertEqual(len(element_ids), len(set(element_ids)))
+
+        element_id_set = set(element_ids)
+        unresolved = []
+        for link in payload["trace_links"]:
+            if link.get("from_id") and link["from_id"] not in element_id_set:
+                unresolved.append(("from", link["id"], link["from_id"]))
+            if link.get("to_id") and link["to_id"] not in element_id_set:
+                unresolved.append(("to", link["id"], link["to_id"]))
+        self.assertEqual(unresolved, [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- fix duplicate requirement ids in the canonical CMDB model by reindexing combined requirement batches
- include interaction realizations and messages in the Speckify planning export so artifact-lineage links resolve inside exported elements
- regenerate the checked-in CMDB V2 handoff bundle and add regressions for unique ids and resolved trace references

Closes #151

## Verification
- uv run python -m unittest tests.test_discovery tests.test_planning_export tests.test_publication_bundle
- uv run python -m unittest
