### PR TITLE
Add loyalty platform V2 bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ improving Rupify:
 - [Example Model](examples/it-systems-inventory/rupify-model.yaml)
 - [Example Feedback](examples/it-systems-inventory/rupify-feedback.md)
 - [V2 Publication Bundle](examples/it-systems-inventory-v2/README.md)
+- [Loyalty Platform V2 Bundle](examples/loyalty-platform-v2/README.md)
 
 ## Current Limitations
 

--- a/examples/loyalty-platform-v2/README.md
+++ b/examples/loyalty-platform-v2/README.md
@@ -1,46 +1,61 @@
 # Loyalty Platform V2 Bundle
 
-This directory is the V2 checked-in publication bundle for the legacy loyalty-platform example at
-[examples/loyalty-platform/specops-model.json](/Volumes/Data/GitHub/Peterbb148/rupify/examples/loyalty-platform/specops-model.json).
+This directory is the V2 checked-in publication bundle for the loyalty-platform interview fixture at
+[tests/fixtures/loyalty_platform_session.json](/Volumes/Data/GitHub/Peterbb148/rupify/tests/fixtures/loyalty_platform_session.json).
 
-It was generated from the current publication pipeline:
+It was generated from the current interview and publication pipeline:
 
 ```bash
+uv run rupify-interview-to-formal \
+  --input tests/fixtures/loyalty_platform_session.json \
+  --output-dir /tmp/rupify-loyalty-v2-formal \
+  --write-model /tmp/rupify-loyalty-v2-formal/rupify-model.json
+
 uv run rupify-publish-bundle \
-  --model examples/loyalty-platform/specops-model.json \
+  --model /tmp/rupify-loyalty-v2-formal/rupify-model.json \
   --output-dir /tmp/rupify-loyalty-v2-bundle
 ```
 
 ## Purpose
 
-This bundle gives the loyalty example the same current publication layout as the rest of Rupify:
+This bundle gives the loyalty example the same current replay-based V2 treatment as the CMDB case:
 
+- interview replay into the canonical model
 - formal Markdown artifacts
 - Mermaid publication artifacts
 - UCP output
 - bundle manifest
-- a checked-in planning export path
+- Speckify planning export
+
+## Speckify Handoff Surface
+
+The primary downstream contract for Speckify is:
+
+- [exports/speckify-planning-export.json](/Volumes/Data/GitHub/Peterbb148/rupify/examples/loyalty-platform-v2/exports/speckify-planning-export.json)
+
+The root publication index for the full handoff bundle is:
+
+- [bundle-manifest.json](/Volumes/Data/GitHub/Peterbb148/rupify/examples/loyalty-platform-v2/bundle-manifest.json)
+
+The canonical model snapshot used to generate the bundle is:
+
+- [model/rupify-model.json](/Volumes/Data/GitHub/Peterbb148/rupify/examples/loyalty-platform-v2/model/rupify-model.json)
 
 ## Current Result
 
-This V2 bundle currently shows:
+This V2 export currently shows:
 
 - a complete publication bundle with 17 generated files
-- a valid bundle manifest at
-  [bundle-manifest.json](/Volumes/Data/GitHub/Peterbb148/rupify/examples/loyalty-platform-v2/bundle-manifest.json)
-- a canonical model snapshot at
-  [model/rupify-model.json](/Volumes/Data/GitHub/Peterbb148/rupify/examples/loyalty-platform-v2/model/rupify-model.json)
-- a Speckify export path at
-  [exports/speckify-planning-export.json](/Volumes/Data/GitHub/Peterbb148/rupify/examples/loyalty-platform-v2/exports/speckify-planning-export.json)
+- 108 flattened planning elements
+- 144 trace links
+- 62 ready normative elements
+- 0 blocking ambiguities
+- 0 duplicate exported element IDs
+- 0 unresolved trace references
 
-## Important Limitation
+## Notes
 
-Unlike the CMDB V2 bundle, this loyalty-platform example still starts from an older `specops-model`
-shape rather than a newer replay-normalized Rupify model.
-
-That means the checked-in planning export is currently structurally valid but empty:
-
-- `element_count = 0`
-- `trace_link_count = 0`
-
-So this bundle is a publication-layout refresh, not yet a full Speckify handoff proof.
+- this fixture was reconstructed from the legacy loyalty example so that the product can now be
+  exercised through the current interview/replay pipeline
+- the replay-generated UCP estimate is now [artifacts/ucp/ucp-estimate.md](/Volumes/Data/GitHub/Peterbb148/rupify/examples/loyalty-platform-v2/artifacts/ucp/ucp-estimate.md)
+  rather than being inherited directly from the old checked-in model

--- a/examples/loyalty-platform-v2/README.md
+++ b/examples/loyalty-platform-v2/README.md
@@ -1,0 +1,46 @@
+# Loyalty Platform V2 Bundle
+
+This directory is the V2 checked-in publication bundle for the legacy loyalty-platform example at
+[examples/loyalty-platform/specops-model.json](/Volumes/Data/GitHub/Peterbb148/rupify/examples/loyalty-platform/specops-model.json).
+
+It was generated from the current publication pipeline:
+
+```bash
+uv run rupify-publish-bundle \
+  --model examples/loyalty-platform/specops-model.json \
+  --output-dir /tmp/rupify-loyalty-v2-bundle
+```
+
+## Purpose
+
+This bundle gives the loyalty example the same current publication layout as the rest of Rupify:
+
+- formal Markdown artifacts
+- Mermaid publication artifacts
+- UCP output
+- bundle manifest
+- a checked-in planning export path
+
+## Current Result
+
+This V2 bundle currently shows:
+
+- a complete publication bundle with 17 generated files
+- a valid bundle manifest at
+  [bundle-manifest.json](/Volumes/Data/GitHub/Peterbb148/rupify/examples/loyalty-platform-v2/bundle-manifest.json)
+- a canonical model snapshot at
+  [model/rupify-model.json](/Volumes/Data/GitHub/Peterbb148/rupify/examples/loyalty-platform-v2/model/rupify-model.json)
+- a Speckify export path at
+  [exports/speckify-planning-export.json](/Volumes/Data/GitHub/Peterbb148/rupify/examples/loyalty-platform-v2/exports/speckify-planning-export.json)
+
+## Important Limitation
+
+Unlike the CMDB V2 bundle, this loyalty-platform example still starts from an older `specops-model`
+shape rather than a newer replay-normalized Rupify model.
+
+That means the checked-in planning export is currently structurally valid but empty:
+
+- `element_count = 0`
+- `trace_link_count = 0`
+
+So this bundle is a publication-layout refresh, not yet a full Speckify handoff proof.

--- a/examples/loyalty-platform-v2/artifacts/formal/deployment-model.md
+++ b/examples/loyalty-platform-v2/artifacts/formal/deployment-model.md
@@ -3,12 +3,46 @@
 ## Project
 
 - Name: Loyalty Platform
-- Domain: Retail
+- Domain: Unspecified
 
 ## Scope
 
 A member loyalty platform for enrollment, rewards browsing, redemption, and operational reporting.
 
+## Components
+
+- `component-member-app` Member App [source: round 7 components_and_services]
+- `component-loyalty-api` Loyalty API [source: round 7 components_and_services]
+- `component-operations-console` Operations Console [source: round 7 components_and_services]
+- `component-analytics-service` Analytics Service [source: round 7 components_and_services]
+- `component-payment-gateway-adapter` Payment Gateway Adapter [source: round 7 components_and_services]
 
 
+## Interfaces and Integrations
+
+- `interface-1` Member App calls Loyalty API [source: round 7 interfaces_and_integrations]
+- `interface-2` Operations Console calls Loyalty API [source: round 7 interfaces_and_integrations]
+- `interface-3` Loyalty API calls Payment Gateway Adapter [source: round 7 interfaces_and_integrations]
+- `interface-4` Loyalty API sends Analytics Service [source: round 7 interfaces_and_integrations]
+
+
+## Runtime Boundaries
+
+- `runtime-boundary-1` Member-facing apps and operations console run separately from the core API [source: round 7 runtime_boundaries]
+- `runtime-boundary-2` Payment Gateway Adapter crosses an external boundary [source: round 7 runtime_boundaries]
+
+
+## Artifact Lineage
+
+- `trace-artifact-deployment-model-components-component-member-app` component-member-app -> deployment-model.md#components (canonical components object renders into deployment-model.md)
+- `trace-artifact-deployment-model-components-component-loyalty-api` component-loyalty-api -> deployment-model.md#components (canonical components object renders into deployment-model.md)
+- `trace-artifact-deployment-model-components-component-operations-console` component-operations-console -> deployment-model.md#components (canonical components object renders into deployment-model.md)
+- `trace-artifact-deployment-model-components-component-analytics-service` component-analytics-service -> deployment-model.md#components (canonical components object renders into deployment-model.md)
+- `trace-artifact-deployment-model-components-component-payment-gateway-adapter` component-payment-gateway-adapter -> deployment-model.md#components (canonical components object renders into deployment-model.md)
+- `trace-artifact-deployment-model-interfaces-and-integrations-interface-1` interface-1 -> deployment-model.md#interfaces and integrations (canonical interfaces and integrations object renders into deployment-model.md)
+- `trace-artifact-deployment-model-interfaces-and-integrations-interface-2` interface-2 -> deployment-model.md#interfaces and integrations (canonical interfaces and integrations object renders into deployment-model.md)
+- `trace-artifact-deployment-model-interfaces-and-integrations-interface-3` interface-3 -> deployment-model.md#interfaces and integrations (canonical interfaces and integrations object renders into deployment-model.md)
+- `trace-artifact-deployment-model-interfaces-and-integrations-interface-4` interface-4 -> deployment-model.md#interfaces and integrations (canonical interfaces and integrations object renders into deployment-model.md)
+- `trace-artifact-deployment-model-runtime-boundaries-runtime-boundary-1` runtime-boundary-1 -> deployment-model.md#runtime boundaries (canonical runtime boundaries object renders into deployment-model.md)
+- `trace-artifact-deployment-model-runtime-boundaries-runtime-boundary-2` runtime-boundary-2 -> deployment-model.md#runtime boundaries (canonical runtime boundaries object renders into deployment-model.md)
 

--- a/examples/loyalty-platform-v2/artifacts/formal/deployment-model.md
+++ b/examples/loyalty-platform-v2/artifacts/formal/deployment-model.md
@@ -1,0 +1,14 @@
+# Deployment Model
+
+## Project
+
+- Name: Loyalty Platform
+- Domain: Retail
+
+## Scope
+
+A member loyalty platform for enrollment, rewards browsing, redemption, and operational reporting.
+
+
+
+

--- a/examples/loyalty-platform-v2/artifacts/formal/domain-model.md
+++ b/examples/loyalty-platform-v2/artifacts/formal/domain-model.md
@@ -1,0 +1,18 @@
+# Domain Model
+
+## Project
+
+- Name: Loyalty Platform
+- Domain: Retail
+
+## Scope
+
+A member loyalty platform for enrollment, rewards browsing, redemption, and operational reporting.
+
+
+
+
+
+
+
+

--- a/examples/loyalty-platform-v2/artifacts/formal/domain-model.md
+++ b/examples/loyalty-platform-v2/artifacts/formal/domain-model.md
@@ -3,16 +3,86 @@
 ## Project
 
 - Name: Loyalty Platform
-- Domain: Retail
+- Domain: Unspecified
 
 ## Scope
 
 A member loyalty platform for enrollment, rewards browsing, redemption, and operational reporting.
 
+## Domain Entities
+
+- `entity-member` Member [source: round 5 domain_entities]
+- `entity-reward` Reward [source: round 5 domain_entities]
+- `entity-reward-catalog-entry` Reward Catalog Entry [source: round 5 domain_entities]
+- `entity-campaign` Campaign [source: round 5 domain_entities]
+- `entity-redemption` Redemption [source: round 5 domain_entities]
+- `entity-payment-confirmation` Payment Confirmation [source: round 5 domain_entities]
+- `entity-analytics-report` Analytics Report [source: round 5 domain_entities]
+
+
+## Relationships
+
+- `relationship-1` A Member has many Redemptions (multiplicity: 1 -> *; roles: redemptions / a_member) [source: round 5 relationships]
+- `relationship-2` A Reward Catalog Entry has one Reward [source: round 5 relationships]
+- `relationship-3` A Campaign has many Reward Catalog Entries (multiplicity: 1 -> *; roles: reward_catalog_entries / a_campaign) [source: round 5 relationships]
+- `relationship-4` A Redemption has one Payment Confirmation [source: round 5 relationships]
+- `relationship-5` An Analytics Report has many Redemptions (multiplicity: 1 -> *; roles: redemptions / an_analytics_report) [source: round 5 relationships]
+
+
+## Business Rules
+
+- `business-rule-1` A Redemption must not be fulfilled unless reward eligibility and available points are confirmed. [source: round 5 business_rules]
+- `business-rule-2` A Reward Catalog Entry must be validated before it becomes Published. [source: round 5 business_rules]
+- `business-rule-3` A Member must provide the required details and consents before enrollment completes. [source: round 5 business_rules]
+
+
+## Domain Invariants
+
+- `domain-invariant-1` A Redemption must not be fulfilled unless reward eligibility and available points are confirmed. (semantics: normative; business rule: business-rule-1; scope: entity-reward, entity-redemption; readiness: ready; source: round 5 business_rules)
+- `domain-invariant-2` A Reward Catalog Entry must be validated before it becomes Published. (semantics: normative; business rule: business-rule-2; scope: entity-reward, entity-reward-catalog-entry; readiness: ready; source: round 5 business_rules)
+- `domain-invariant-3` A Member must provide the required details and consents before enrollment completes. (semantics: normative; business rule: business-rule-3; scope: entity-member; readiness: ready; source: round 5 business_rules)
+
+
+## Use-Case To Domain Traceability
+
+- `trace-uc-analysis-1` enroll-member -> entity-member (use-case text references analysis object name)
+- `trace-uc-analysis-2` browse-rewards -> entity-reward (use-case text references analysis object name)
+- `trace-uc-analysis-3` redeem-reward -> entity-member (use-case text references analysis object name)
+- `trace-uc-analysis-4` redeem-reward -> entity-reward (use-case text references analysis object name)
+- `trace-uc-analysis-5` redeem-reward -> entity-redemption (use-case text references analysis object name)
+- `trace-uc-analysis-7` manage-reward-catalog -> entity-reward (use-case text references analysis object name)
+- `trace-uc-analysis-8` review-redemption-analytics -> entity-campaign (use-case text references analysis object name)
+- `trace-uc-analysis-9` review-redemption-analytics -> entity-redemption (use-case text references analysis object name)
+
+
+## Domain Invariant To Entity Traceability
+
+- `trace-domain-invariant-entity-1` domain-invariant-1 -> entity-reward (domain invariant scope references domain entity)
+- `trace-domain-invariant-entity-2` domain-invariant-1 -> entity-redemption (domain invariant scope references domain entity)
+- `trace-domain-invariant-entity-3` domain-invariant-2 -> entity-reward (domain invariant scope references domain entity)
+- `trace-domain-invariant-entity-4` domain-invariant-2 -> entity-reward-catalog-entry (domain invariant scope references domain entity)
+- `trace-domain-invariant-entity-5` domain-invariant-3 -> entity-member (domain invariant scope references domain entity)
 
 
 
+## Artifact Lineage
 
-
-
+- `trace-artifact-domain-model-domain-entities-entity-member` entity-member -> domain-model.md#domain entities (canonical domain entities object renders into domain-model.md)
+- `trace-artifact-domain-model-domain-entities-entity-reward` entity-reward -> domain-model.md#domain entities (canonical domain entities object renders into domain-model.md)
+- `trace-artifact-domain-model-domain-entities-entity-reward-catalog-entry` entity-reward-catalog-entry -> domain-model.md#domain entities (canonical domain entities object renders into domain-model.md)
+- `trace-artifact-domain-model-domain-entities-entity-campaign` entity-campaign -> domain-model.md#domain entities (canonical domain entities object renders into domain-model.md)
+- `trace-artifact-domain-model-domain-entities-entity-redemption` entity-redemption -> domain-model.md#domain entities (canonical domain entities object renders into domain-model.md)
+- `trace-artifact-domain-model-domain-entities-entity-payment-confirmation` entity-payment-confirmation -> domain-model.md#domain entities (canonical domain entities object renders into domain-model.md)
+- `trace-artifact-domain-model-domain-entities-entity-analytics-report` entity-analytics-report -> domain-model.md#domain entities (canonical domain entities object renders into domain-model.md)
+- `trace-artifact-domain-model-relationships-relationship-1` relationship-1 -> domain-model.md#relationships (canonical relationships object renders into domain-model.md)
+- `trace-artifact-domain-model-relationships-relationship-2` relationship-2 -> domain-model.md#relationships (canonical relationships object renders into domain-model.md)
+- `trace-artifact-domain-model-relationships-relationship-3` relationship-3 -> domain-model.md#relationships (canonical relationships object renders into domain-model.md)
+- `trace-artifact-domain-model-relationships-relationship-4` relationship-4 -> domain-model.md#relationships (canonical relationships object renders into domain-model.md)
+- `trace-artifact-domain-model-relationships-relationship-5` relationship-5 -> domain-model.md#relationships (canonical relationships object renders into domain-model.md)
+- `trace-artifact-domain-model-business-rules-business-rule-1` business-rule-1 -> domain-model.md#business rules (canonical business rules object renders into domain-model.md)
+- `trace-artifact-domain-model-business-rules-business-rule-2` business-rule-2 -> domain-model.md#business rules (canonical business rules object renders into domain-model.md)
+- `trace-artifact-domain-model-business-rules-business-rule-3` business-rule-3 -> domain-model.md#business rules (canonical business rules object renders into domain-model.md)
+- `trace-artifact-domain-model-domain-invariants-domain-invariant-1` domain-invariant-1 -> domain-model.md#domain invariants (canonical domain invariants object renders into domain-model.md)
+- `trace-artifact-domain-model-domain-invariants-domain-invariant-2` domain-invariant-2 -> domain-model.md#domain invariants (canonical domain invariants object renders into domain-model.md)
+- `trace-artifact-domain-model-domain-invariants-domain-invariant-3` domain-invariant-3 -> domain-model.md#domain invariants (canonical domain invariants object renders into domain-model.md)
 

--- a/examples/loyalty-platform-v2/artifacts/formal/interaction-model.md
+++ b/examples/loyalty-platform-v2/artifacts/formal/interaction-model.md
@@ -1,0 +1,19 @@
+# Interaction Model
+
+## Project
+
+- Name: Loyalty Platform
+- Domain: Retail
+
+## Scope
+
+A member loyalty platform for enrollment, rewards browsing, redemption, and operational reporting.
+
+## Use-Case Realizations
+
+No interaction realizations documented.
+
+## Message Flows
+
+- None
+

--- a/examples/loyalty-platform-v2/artifacts/formal/interaction-model.md
+++ b/examples/loyalty-platform-v2/artifacts/formal/interaction-model.md
@@ -3,7 +3,7 @@
 ## Project
 
 - Name: Loyalty Platform
-- Domain: Retail
+- Domain: Unspecified
 
 ## Scope
 
@@ -11,9 +11,92 @@ A member loyalty platform for enrollment, rewards browsing, redemption, and oper
 
 ## Use-Case Realizations
 
-No interaction realizations documented.
+### Enroll Member
+
+- Realization ID: `interaction-realization-1`
+- Use case ID: `enroll-member`
+- Participants: Unspecified
+
+#### Steps
+
+1. Customer opens the loyalty enrollment flow.
+2. Customer provides the required details and consents.
+3. System validates the submission and creates the member account.
+
+- Source: round 3 use_cases
+
+### Browse Rewards
+
+- Realization ID: `interaction-realization-2`
+- Use case ID: `browse-rewards`
+- Participants: Unspecified
+
+#### Steps
+
+1. Customer opens the rewards catalog.
+2. System displays available rewards and points balance.
+3. Customer filters or sorts the catalog.
+
+- Source: round 3 use_cases
+
+### Redeem Reward
+
+- Realization ID: `interaction-realization-3`
+- Use case ID: `redeem-reward`
+- Participants: Unspecified
+
+#### Steps
+
+1. Customer selects a reward.
+2. System validates reward eligibility and available points.
+3. System reserves the reward and updates the member balance.
+4. System confirms redemption to the customer.
+
+- Source: round 3 use_cases
+
+### Manage Reward Catalog
+
+- Realization ID: `interaction-realization-4`
+- Use case ID: `manage-reward-catalog`
+- Participants: Unspecified
+
+#### Steps
+
+1. Operations Manager opens catalog administration.
+2. Operations Manager updates reward configuration.
+3. System validates and publishes the change.
+
+- Source: round 3 use_cases
+
+### Review Redemption Analytics
+
+- Realization ID: `interaction-realization-5`
+- Use case ID: `review-redemption-analytics`
+- Participants: Unspecified
+
+#### Steps
+
+1. Operations Manager opens the analytics dashboard.
+2. System shows redemption and campaign metrics.
+
+- Source: round 3 use_cases
 
 ## Message Flows
 
-- None
+- `interaction-message-1` Member App -> Loyalty API (calls): Member App calls Loyalty API [source: round 7 interfaces_and_integrations]
+- `interaction-message-2` Operations Console -> Loyalty API (calls): Operations Console calls Loyalty API [source: round 7 interfaces_and_integrations]
+- `interaction-message-3` Loyalty API -> Payment Gateway Adapter (calls): Loyalty API calls Payment Gateway Adapter [source: round 7 interfaces_and_integrations]
+- `interaction-message-4` Loyalty API -> Analytics Service (sends): Loyalty API sends Analytics Service [source: round 7 interfaces_and_integrations]
+
+## Artifact Lineage
+
+- `trace-artifact-interaction-model-use-case-realizations-interaction-realization-1` interaction-realization-1 -> interaction-model.md#use-case realizations (canonical use-case realizations object renders into interaction-model.md)
+- `trace-artifact-interaction-model-use-case-realizations-interaction-realization-2` interaction-realization-2 -> interaction-model.md#use-case realizations (canonical use-case realizations object renders into interaction-model.md)
+- `trace-artifact-interaction-model-use-case-realizations-interaction-realization-3` interaction-realization-3 -> interaction-model.md#use-case realizations (canonical use-case realizations object renders into interaction-model.md)
+- `trace-artifact-interaction-model-use-case-realizations-interaction-realization-4` interaction-realization-4 -> interaction-model.md#use-case realizations (canonical use-case realizations object renders into interaction-model.md)
+- `trace-artifact-interaction-model-use-case-realizations-interaction-realization-5` interaction-realization-5 -> interaction-model.md#use-case realizations (canonical use-case realizations object renders into interaction-model.md)
+- `trace-artifact-interaction-model-message-flows-interaction-message-1` interaction-message-1 -> interaction-model.md#message flows (canonical message flows object renders into interaction-model.md)
+- `trace-artifact-interaction-model-message-flows-interaction-message-2` interaction-message-2 -> interaction-model.md#message flows (canonical message flows object renders into interaction-model.md)
+- `trace-artifact-interaction-model-message-flows-interaction-message-3` interaction-message-3 -> interaction-model.md#message flows (canonical message flows object renders into interaction-model.md)
+- `trace-artifact-interaction-model-message-flows-interaction-message-4` interaction-message-4 -> interaction-model.md#message flows (canonical message flows object renders into interaction-model.md)
 

--- a/examples/loyalty-platform-v2/artifacts/formal/requirements-spec.md
+++ b/examples/loyalty-platform-v2/artifacts/formal/requirements-spec.md
@@ -3,7 +3,7 @@
 ## Project
 
 - Name: Loyalty Platform
-- Domain: Retail
+- Domain: Unspecified
 - Scope: A member loyalty platform for enrollment, rewards browsing, redemption, and operational reporting.
 
 ## Problem Statement
@@ -24,38 +24,133 @@ Legacy loyalty operations are fragmented across channels and teams, causing inco
 
 ## Functional Requirements
 
-- The system must allow customers to enroll in the loyalty program digitally.
-- The system must show point balance and available rewards to eligible members.
-- The system must allow members to redeem rewards when eligibility conditions are satisfied.
 - The system must allow operations managers to maintain reward catalog entries and campaign rules.
-- The system must provide reporting on redemptions and campaign performance.
+- The platform must integrate with payment confirmation and downstream reporting sources.
 
 ## Non-Functional Requirements
 
 - The system must protect member and reward transactions with appropriate security controls.
 - The member-facing experience must remain usable on common digital channels.
 - The platform must support integrations with external systems such as payment confirmation and reporting sources.
+- The system must allow customers to enroll in the loyalty program digitally.
+- The system must show point balance and available rewards to eligible members.
+- The system must allow members to redeem rewards when eligibility conditions are satisfied.
+- The system must provide reporting on redemptions and campaign performance.
+
+## Acceptance Constraints
+
+- `acceptance-constraint-requirement-1` The system must protect member and reward transactions with appropriate security controls. (semantics: normative; kind: non_functional_requirement; requirement: non_functional-requirement-1; readiness: ready; source: round 2 constraints)
+- `acceptance-constraint-requirement-2` The member-facing experience must remain usable on common digital channels. (semantics: normative; kind: non_functional_requirement; requirement: non_functional-requirement-2; readiness: ready; source: round 2 constraints)
+- `acceptance-constraint-requirement-3` The platform must support integrations with external systems such as payment confirmation and reporting sources. (semantics: normative; kind: non_functional_requirement; requirement: non_functional-requirement-3; readiness: ready; source: round 2 constraints)
+- `acceptance-constraint-requirement-4` The system must allow customers to enroll in the loyalty program digitally. (semantics: normative; kind: non_functional_requirement; requirement: non_functional-requirement-4; readiness: ready; source: round 4 non_functional_requirements)
+- `acceptance-constraint-requirement-5` The system must show point balance and available rewards to eligible members. (semantics: normative; kind: non_functional_requirement; requirement: non_functional-requirement-5; readiness: ready; source: round 4 non_functional_requirements)
+- `acceptance-constraint-requirement-6` The system must allow members to redeem rewards when eligibility conditions are satisfied. (semantics: normative; kind: non_functional_requirement; requirement: non_functional-requirement-6; readiness: ready; source: round 4 non_functional_requirements)
+- `acceptance-constraint-requirement-7` The system must provide reporting on redemptions and campaign performance. (semantics: normative; kind: non_functional_requirement; requirement: non_functional-requirement-7; readiness: ready; source: round 4 non_functional_requirements)
+- `acceptance-constraint-success-1` Members can enroll and redeem rewards through one coherent digital journey. (semantics: normative; kind: success_criterion; readiness: ready; source: round 2 success_criteria)
+- `acceptance-constraint-success-2` Operations managers can update the reward catalog without engineering support for routine changes. (semantics: normative; kind: success_criterion; readiness: ready; source: round 2 success_criteria)
+- `acceptance-constraint-success-3` The business can review redemption and campaign performance in one reporting workflow. (semantics: normative; kind: success_criterion; readiness: ready; source: round 2 success_criteria)
 
 
+## Logical View
+
+- `entity-member` Member [source: round 5 domain_entities]
+- `entity-reward` Reward [source: round 5 domain_entities]
+- `entity-reward-catalog-entry` Reward Catalog Entry [source: round 5 domain_entities]
+- `entity-campaign` Campaign [source: round 5 domain_entities]
+- `entity-redemption` Redemption [source: round 5 domain_entities]
+- `entity-payment-confirmation` Payment Confirmation [source: round 5 domain_entities]
+- `entity-analytics-report` Analytics Report [source: round 5 domain_entities]
 
 
+## Relationships
+
+- `relationship-1` A Member has many Redemptions [source: round 5 relationships]
+- `relationship-2` A Reward Catalog Entry has one Reward [source: round 5 relationships]
+- `relationship-3` A Campaign has many Reward Catalog Entries [source: round 5 relationships]
+- `relationship-4` A Redemption has one Payment Confirmation [source: round 5 relationships]
+- `relationship-5` An Analytics Report has many Redemptions [source: round 5 relationships]
 
 
+## Business Rules
+
+- `business-rule-1` A Redemption must not be fulfilled unless reward eligibility and available points are confirmed. [source: round 5 business_rules]
+- `business-rule-2` A Reward Catalog Entry must be validated before it becomes Published. [source: round 5 business_rules]
+- `business-rule-3` A Member must provide the required details and consents before enrollment completes. [source: round 5 business_rules]
 
 
+## Process View
+
+- `state-entity-redemption` Redemption {states: Requested, Validated, Fulfilled, Rejected} [source: round 6 state_entities]
+- `state-entity-reward-catalog-entry` Reward Catalog Entry {states: Draft, Published, Retired} [source: round 6 state_entities]
 
 
+## States and Transitions
+
+- `state-transition-1` Redemption: Requested -> Validated -> Fulfilled [source: round 6 states_and_transitions]
+- `state-transition-2` Redemption: Requested -> Validated -> Fulfilled [source: round 6 states_and_transitions]
+- `state-transition-3` Redemption: Requested -> Rejected [source: round 6 states_and_transitions]
+- `state-transition-4` Reward Catalog Entry: Draft -> Published -> Retired [source: round 6 states_and_transitions]
+- `state-transition-5` Reward Catalog Entry: Draft -> Published -> Retired [source: round 6 states_and_transitions]
 
 
+## Triggers and Approvals
+
+- `trigger-1` Payment confirmation triggers redemption fulfillment [source: round 6 triggers_and_approvals]
+- `trigger-2` Catalog validation approval is required before a reward becomes Published [source: round 6 triggers_and_approvals]
+
+
+## Architecture View
+
+- `component-member-app` Member App [source: round 7 components_and_services]
+- `component-loyalty-api` Loyalty API [source: round 7 components_and_services]
+- `component-operations-console` Operations Console [source: round 7 components_and_services]
+- `component-analytics-service` Analytics Service [source: round 7 components_and_services]
+- `component-payment-gateway-adapter` Payment Gateway Adapter [source: round 7 components_and_services]
+
+
+## Interfaces and Integrations
+
+- `interface-1` Member App calls Loyalty API [source: round 7 interfaces_and_integrations]
+- `interface-2` Operations Console calls Loyalty API [source: round 7 interfaces_and_integrations]
+- `interface-3` Loyalty API calls Payment Gateway Adapter [source: round 7 interfaces_and_integrations]
+- `interface-4` Loyalty API sends Analytics Service [source: round 7 interfaces_and_integrations]
+
+
+## Runtime Boundaries
+
+- `runtime-boundary-1` Member-facing apps and operations console run separately from the core API [source: round 7 runtime_boundaries]
+- `runtime-boundary-2` Payment Gateway Adapter crosses an external boundary [source: round 7 runtime_boundaries]
+
+
+## Requirement To Use-Case Traceability
+
+- `trace-req-uc-1` non_functional-requirement-6 -> redeem-reward (requirement statement references use-case name)
+
+
+## Use-Case To Analysis Traceability
+
+- `trace-uc-analysis-1` enroll-member -> entity-member (use-case text references analysis object name)
+- `trace-uc-analysis-2` browse-rewards -> entity-reward (use-case text references analysis object name)
+- `trace-uc-analysis-3` redeem-reward -> entity-member (use-case text references analysis object name)
+- `trace-uc-analysis-4` redeem-reward -> entity-reward (use-case text references analysis object name)
+- `trace-uc-analysis-5` redeem-reward -> entity-redemption (use-case text references analysis object name)
+- `trace-uc-analysis-6` redeem-reward -> state-entity-redemption (use-case text references analysis object name)
+- `trace-uc-analysis-7` manage-reward-catalog -> entity-reward (use-case text references analysis object name)
+- `trace-uc-analysis-8` review-redemption-analytics -> entity-campaign (use-case text references analysis object name)
+- `trace-uc-analysis-9` review-redemption-analytics -> entity-redemption (use-case text references analysis object name)
+- `trace-uc-analysis-10` review-redemption-analytics -> state-entity-redemption (use-case text references analysis object name)
+
+
+## Analysis To Design Traceability
+
+- `trace-analysis-design-1` entity-member -> component-member-app (design component name references analysis object name)
 
 
 
 ## Assumptions
 
-- The first delivery increment focuses on a single market and one loyalty program configuration.
-- A single product team delivers the first release.
+- None
 
 ## Open Questions
 
-- Should partner merchants be modeled as separate actors in V1?
-- What reporting latency is acceptable for operational analytics?
+- None

--- a/examples/loyalty-platform-v2/artifacts/formal/requirements-spec.md
+++ b/examples/loyalty-platform-v2/artifacts/formal/requirements-spec.md
@@ -1,0 +1,61 @@
+# Requirements Specification
+
+## Project
+
+- Name: Loyalty Platform
+- Domain: Retail
+- Scope: A member loyalty platform for enrollment, rewards browsing, redemption, and operational reporting.
+
+## Problem Statement
+
+Legacy loyalty operations are fragmented across channels and teams, causing inconsistent member experience and slow campaign execution.
+
+## Business Goals
+
+- Increase repeat customer engagement through a unified loyalty experience.
+- Reduce the operational time required to launch or adjust reward campaigns.
+- Create a reliable source of truth for loyalty performance reporting.
+
+## Success Criteria
+
+- Members can enroll and redeem rewards through one coherent digital journey.
+- Operations managers can update the reward catalog without engineering support for routine changes.
+- The business can review redemption and campaign performance in one reporting workflow.
+
+## Functional Requirements
+
+- The system must allow customers to enroll in the loyalty program digitally.
+- The system must show point balance and available rewards to eligible members.
+- The system must allow members to redeem rewards when eligibility conditions are satisfied.
+- The system must allow operations managers to maintain reward catalog entries and campaign rules.
+- The system must provide reporting on redemptions and campaign performance.
+
+## Non-Functional Requirements
+
+- The system must protect member and reward transactions with appropriate security controls.
+- The member-facing experience must remain usable on common digital channels.
+- The platform must support integrations with external systems such as payment confirmation and reporting sources.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+## Assumptions
+
+- The first delivery increment focuses on a single market and one loyalty program configuration.
+- A single product team delivers the first release.
+
+## Open Questions
+
+- Should partner merchants be modeled as separate actors in V1?
+- What reporting latency is acceptable for operational analytics?

--- a/examples/loyalty-platform-v2/artifacts/formal/scenario-documents.md
+++ b/examples/loyalty-platform-v2/artifacts/formal/scenario-documents.md
@@ -1,0 +1,3 @@
+# Scenario Documents
+
+No scenarios documented.

--- a/examples/loyalty-platform-v2/artifacts/formal/scenario-documents.md
+++ b/examples/loyalty-platform-v2/artifacts/formal/scenario-documents.md
@@ -1,3 +1,258 @@
 # Scenario Documents
 
-No scenarios documented.
+## Reward Inventory Exhausted
+
+- ID: `scenario-reward-inventory-exhausted`
+- Parent Use Case: Redeem Reward
+- Priority: high
+- Status: open
+- Content Semantics: normative
+- Readiness: ready
+- Source: round 13 scenarios
+
+### Brief Description
+
+Redemption fails because no reward inventory remains.
+
+### Flow of Events
+
+1. Customer selects a reward.
+2. System checks reward availability.
+3. System reports that inventory is exhausted.
+
+### Activity Notes
+
+- None
+
+### Sequence Notes
+
+- None
+
+### Interaction Realizations
+
+#### Redeem Reward
+
+- Participants: Unspecified
+
+##### Realization Steps
+
+1. Customer selects a reward.
+2. System validates reward eligibility and available points.
+3. System reserves the reward and updates the member balance.
+4. System confirms redemption to the customer.
+
+
+### Participating Analysis Objects
+
+- None
+
+### Linked Requirements
+
+- None
+
+### Other Artifacts
+
+- None
+
+
+## Scenario Supporting Traceability
+
+- `trace-uc-analysis-3` redeem-reward -> entity-member (use-case text references analysis object name)
+- `trace-uc-analysis-4` redeem-reward -> entity-reward (use-case text references analysis object name)
+- `trace-uc-analysis-5` redeem-reward -> entity-redemption (use-case text references analysis object name)
+- `trace-uc-analysis-6` redeem-reward -> state-entity-redemption (use-case text references analysis object name)
+
+
+
+## Missing Payment Confirmation
+
+- ID: `scenario-missing-payment-confirmation`
+- Parent Use Case: Redeem Reward
+- Priority: medium
+- Status: open
+- Content Semantics: normative
+- Readiness: ready
+- Source: round 13 scenarios
+
+### Brief Description
+
+Redemption pauses until dependent payment confirmation arrives.
+
+### Flow of Events
+
+1. Customer selects a reward.
+2. System requests payment confirmation.
+3. System blocks fulfillment until confirmation arrives.
+
+### Activity Notes
+
+- None
+
+### Sequence Notes
+
+- None
+
+### Interaction Realizations
+
+#### Redeem Reward
+
+- Participants: Unspecified
+
+##### Realization Steps
+
+1. Customer selects a reward.
+2. System validates reward eligibility and available points.
+3. System reserves the reward and updates the member balance.
+4. System confirms redemption to the customer.
+
+
+### Participating Analysis Objects
+
+- None
+
+### Linked Requirements
+
+- None
+
+### Other Artifacts
+
+- None
+
+
+## Scenario Supporting Traceability
+
+- `trace-uc-analysis-3` redeem-reward -> entity-member (use-case text references analysis object name)
+- `trace-uc-analysis-4` redeem-reward -> entity-reward (use-case text references analysis object name)
+- `trace-uc-analysis-5` redeem-reward -> entity-redemption (use-case text references analysis object name)
+- `trace-uc-analysis-6` redeem-reward -> state-entity-redemption (use-case text references analysis object name)
+
+
+
+## Invalid Catalog Change
+
+- ID: `scenario-invalid-catalog-change`
+- Parent Use Case: Manage Reward Catalog
+- Priority: medium
+- Status: open
+- Content Semantics: normative
+- Readiness: ready
+- Source: round 13 scenarios
+
+### Brief Description
+
+Publication is rejected because the new reward configuration would break an active offer.
+
+### Flow of Events
+
+1. Operations Manager updates reward configuration.
+2. System validates the change.
+3. System rejects the invalid change.
+
+### Activity Notes
+
+- None
+
+### Sequence Notes
+
+- None
+
+### Interaction Realizations
+
+#### Manage Reward Catalog
+
+- Participants: Unspecified
+
+##### Realization Steps
+
+1. Operations Manager opens catalog administration.
+2. Operations Manager updates reward configuration.
+3. System validates and publishes the change.
+
+
+### Participating Analysis Objects
+
+- None
+
+### Linked Requirements
+
+- None
+
+### Other Artifacts
+
+- None
+
+
+## Scenario Supporting Traceability
+
+- `trace-uc-analysis-7` manage-reward-catalog -> entity-reward (use-case text references analysis object name)
+
+
+
+## Reporting Delay
+
+- ID: `scenario-reporting-delay`
+- Parent Use Case: Review Redemption Analytics
+- Priority: low
+- Status: open
+- Content Semantics: normative
+- Readiness: ready
+- Source: round 13 scenarios
+
+### Brief Description
+
+Analytics view is partial because a reporting source is delayed.
+
+### Flow of Events
+
+1. Operations Manager opens the analytics dashboard.
+2. System detects delayed reporting data.
+3. System shows a partial-data warning.
+
+### Activity Notes
+
+- None
+
+### Sequence Notes
+
+- None
+
+### Interaction Realizations
+
+#### Review Redemption Analytics
+
+- Participants: Unspecified
+
+##### Realization Steps
+
+1. Operations Manager opens the analytics dashboard.
+2. System shows redemption and campaign metrics.
+
+
+### Participating Analysis Objects
+
+- None
+
+### Linked Requirements
+
+- None
+
+### Other Artifacts
+
+- None
+
+
+## Scenario Supporting Traceability
+
+- `trace-uc-analysis-8` review-redemption-analytics -> entity-campaign (use-case text references analysis object name)
+- `trace-uc-analysis-9` review-redemption-analytics -> entity-redemption (use-case text references analysis object name)
+- `trace-uc-analysis-10` review-redemption-analytics -> state-entity-redemption (use-case text references analysis object name)
+
+
+
+## Artifact Lineage
+
+- `trace-artifact-scenario-documents-scenario-documents-scenario-reward-inventory-exhausted` scenario-reward-inventory-exhausted -> scenario-documents.md#scenario documents (canonical scenario documents object renders into scenario-documents.md)
+- `trace-artifact-scenario-documents-scenario-documents-scenario-missing-payment-confirmation` scenario-missing-payment-confirmation -> scenario-documents.md#scenario documents (canonical scenario documents object renders into scenario-documents.md)
+- `trace-artifact-scenario-documents-scenario-documents-scenario-invalid-catalog-change` scenario-invalid-catalog-change -> scenario-documents.md#scenario documents (canonical scenario documents object renders into scenario-documents.md)
+- `trace-artifact-scenario-documents-scenario-documents-scenario-reporting-delay` scenario-reporting-delay -> scenario-documents.md#scenario documents (canonical scenario documents object renders into scenario-documents.md)
+

--- a/examples/loyalty-platform-v2/artifacts/formal/state-model.md
+++ b/examples/loyalty-platform-v2/artifacts/formal/state-model.md
@@ -1,0 +1,23 @@
+# State Model
+
+## Project
+
+- Name: Loyalty Platform
+- Domain: Retail
+
+## Scope
+
+A member loyalty platform for enrollment, rewards browsing, redemption, and operational reporting.
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/examples/loyalty-platform-v2/artifacts/formal/state-model.md
+++ b/examples/loyalty-platform-v2/artifacts/formal/state-model.md
@@ -3,21 +3,92 @@
 ## Project
 
 - Name: Loyalty Platform
-- Domain: Retail
+- Domain: Unspecified
 
 ## Scope
 
 A member loyalty platform for enrollment, rewards browsing, redemption, and operational reporting.
 
+## State Entities
+
+- `state-entity-redemption` Redemption {states: Requested, Validated, Fulfilled, Rejected} [source: round 6 state_entities]
+- `state-entity-reward-catalog-entry` Reward Catalog Entry {states: Draft, Published, Retired} [source: round 6 state_entities]
+
+
+## State Transitions
+
+- `state-transition-1` Requested -> Validated (entity: Redemption) [source: round 6 states_and_transitions]
+- `state-transition-2` Validated -> Fulfilled (entity: Redemption; terminal transition) [source: round 6 states_and_transitions]
+- `state-transition-3` Requested -> Rejected (entity: Redemption; exception flow; terminal transition) [source: round 6 states_and_transitions]
+- `state-transition-4` Draft -> Published (entity: Reward Catalog Entry) [source: round 6 states_and_transitions]
+- `state-transition-5` Published -> Retired (entity: Reward Catalog Entry) [source: round 6 states_and_transitions]
+
+
+## Triggers and Approvals
+
+- `trigger-1` Payment confirmation triggers redemption fulfillment (event: Payment confirmation; type: event) [source: round 6 triggers_and_approvals]
+- `trigger-2` Catalog validation approval is required before a reward becomes Published (type: approval; approval required) [source: round 6 triggers_and_approvals]
+
+
+## State Invariants
+
+- `state-invariant-1` A Redemption must not be fulfilled unless reward eligibility and available points are confirmed. (semantics: normative; business rule: business-rule-1; states: state-entity-redemption; readiness: ready; source: round 5 business_rules)
+- `state-invariant-2` A Reward Catalog Entry must be validated before it becomes Published. (semantics: normative; business rule: business-rule-2; states: state-entity-reward-catalog-entry; readiness: ready; source: round 5 business_rules)
+
+
+## Guard Conditions
+
+- `guard-condition-1` Payment confirmation triggers redemption fulfillment (semantics: normative; trigger: trigger-1; states: state-entity-redemption; readiness: blocked; source: round 6 triggers_and_approvals)
+- `guard-condition-2` Catalog validation approval is required before a reward becomes Published (semantics: normative; trigger: trigger-2; transitions: state-transition-1, state-transition-2, state-transition-3, state-transition-4, state-transition-5; readiness: ready; source: round 6 triggers_and_approvals)
+
+
+## Forbidden Transitions
+
+- `forbidden-transition-1` A Redemption must not be fulfilled unless reward eligibility and available points are confirmed. (semantics: normative; business rule: business-rule-1; readiness: ready; source: round 5 business_rules)
+
+
+## Use-Case To State Traceability
+
+- `trace-uc-analysis-6` redeem-reward -> state-entity-redemption (use-case text references analysis object name)
+- `trace-uc-analysis-10` review-redemption-analytics -> state-entity-redemption (use-case text references analysis object name)
+
+
+## State Invariant To State Traceability
+
+- `trace-state-invariant-state-1` state-invariant-1 -> state-entity-redemption (state invariant scope references state entity)
+- `trace-state-invariant-state-2` state-invariant-2 -> state-entity-reward-catalog-entry (state invariant scope references state entity)
+
+
+## Guard To Transition Traceability
+
+- `trace-guard-transition-1` guard-condition-2 -> state-transition-1 (guard condition text references state transition)
+- `trace-guard-transition-2` guard-condition-2 -> state-transition-2 (guard condition text references state transition)
+- `trace-guard-transition-3` guard-condition-2 -> state-transition-3 (guard condition text references state transition)
+- `trace-guard-transition-4` guard-condition-2 -> state-transition-4 (guard condition text references state transition)
+- `trace-guard-transition-5` guard-condition-2 -> state-transition-5 (guard condition text references state transition)
 
 
 
+## State To Design Traceability
+
+- `trace-analysis-design-1` entity-member -> component-member-app (design component name references analysis object name)
 
 
 
+## Artifact Lineage
 
-
-
-
-
+- `trace-artifact-state-model-state-entities-state-entity-redemption` state-entity-redemption -> state-model.md#state entities (canonical state entities object renders into state-model.md)
+- `trace-artifact-state-model-state-entities-state-entity-reward-catalog-entry` state-entity-reward-catalog-entry -> state-model.md#state entities (canonical state entities object renders into state-model.md)
+- `trace-artifact-state-model-state-transitions-state-transition-1` state-transition-1 -> state-model.md#state transitions (canonical state transitions object renders into state-model.md)
+- `trace-artifact-state-model-state-transitions-state-transition-2` state-transition-2 -> state-model.md#state transitions (canonical state transitions object renders into state-model.md)
+- `trace-artifact-state-model-state-transitions-state-transition-3` state-transition-3 -> state-model.md#state transitions (canonical state transitions object renders into state-model.md)
+- `trace-artifact-state-model-state-transitions-state-transition-4` state-transition-4 -> state-model.md#state transitions (canonical state transitions object renders into state-model.md)
+- `trace-artifact-state-model-state-transitions-state-transition-5` state-transition-5 -> state-model.md#state transitions (canonical state transitions object renders into state-model.md)
+- `trace-artifact-state-model-triggers-and-approvals-trigger-1` trigger-1 -> state-model.md#triggers and approvals (canonical triggers and approvals object renders into state-model.md)
+- `trace-artifact-state-model-triggers-and-approvals-trigger-2` trigger-2 -> state-model.md#triggers and approvals (canonical triggers and approvals object renders into state-model.md)
+- `trace-artifact-state-model-state-invariants-state-invariant-1` state-invariant-1 -> state-model.md#state invariants (canonical state invariants object renders into state-model.md)
+- `trace-artifact-state-model-state-invariants-state-invariant-2` state-invariant-2 -> state-model.md#state invariants (canonical state invariants object renders into state-model.md)
+- `trace-artifact-state-model-guard-conditions-guard-condition-1` guard-condition-1 -> state-model.md#guard conditions (canonical guard conditions object renders into state-model.md)
+- `trace-artifact-state-model-guard-conditions-guard-condition-2` guard-condition-2 -> state-model.md#guard conditions (canonical guard conditions object renders into state-model.md)
+- `trace-artifact-state-model-forbidden-transitions-forbidden-transition-1` forbidden-transition-1 -> state-model.md#forbidden transitions (canonical forbidden transitions object renders into state-model.md)
 

--- a/examples/loyalty-platform-v2/artifacts/formal/system-document.md
+++ b/examples/loyalty-platform-v2/artifacts/formal/system-document.md
@@ -12,15 +12,17 @@ A member loyalty platform for enrollment, rewards browsing, redemption, and oper
 
 ## Risk Factors
 
-- None
+- `risk-payment-confirmation-dependency` Payment confirmation dependency (priority: high; status: open) Mitigation: add retry and reconciliation flow. [source: round 12 risks]
+- `risk-reward-configuration-errors` Reward configuration errors (priority: medium; status: open) Mitigation: validate publish flow and guard rules. [source: round 12 risks]
+- `risk-reporting-latency` Reporting latency (priority: medium; status: open) Mitigation: monitor analytics pipeline freshness. [source: round 12 risks]
 
 ## System-Level Use Cases
 
-- `uc-enroll` Enroll Member (actor: Customer): Join the loyalty program and activate an account.
-- `uc-browse` Browse Rewards (actor: Customer): View eligible rewards and current point balance.
-- `uc-redeem` Redeem Reward (actor: Customer): Redeem a selected reward against available loyalty points.
-- `uc-catalog` Manage Reward Catalog (actor: Operations Manager): Create or update reward catalog entries and campaign details.
-- `uc-analytics` Review Redemption Analytics (actor: Operations Manager): Inspect reward redemption and campaign performance.
+- `enroll-member` Enroll Member (actor: Unspecified; priority: high; status: confirmed): Enroll Member
+- `browse-rewards` Browse Rewards (actor: Unspecified; priority: high; status: confirmed): Browse Rewards
+- `redeem-reward` Redeem Reward (actor: Unspecified; priority: high; status: confirmed): Redeem Reward
+- `manage-reward-catalog` Manage Reward Catalog (actor: Unspecified; priority: medium; status: confirmed): Manage Reward Catalog
+- `review-redemption-analytics` Review Redemption Analytics (actor: Unspecified; priority: medium; status: confirmed): Review Redemption Analytics
 
 ## System-Level Diagram References
 
@@ -28,9 +30,55 @@ A member loyalty platform for enrollment, rewards browsing, redemption, and oper
 - `deployment-model.md` for the detailed architecture and runtime view
 
 
+## Architecture Overview
 
+- `component-member-app` Member App [source: round 7 components_and_services]
+- `component-loyalty-api` Loyalty API [source: round 7 components_and_services]
+- `component-operations-console` Operations Console [source: round 7 components_and_services]
+- `component-analytics-service` Analytics Service [source: round 7 components_and_services]
+- `component-payment-gateway-adapter` Payment Gateway Adapter [source: round 7 components_and_services]
+
+
+## Interfaces and Integrations
+
+- `interface-1` Member App calls Loyalty API [source: round 7 interfaces_and_integrations]
+- `interface-2` Operations Console calls Loyalty API [source: round 7 interfaces_and_integrations]
+- `interface-3` Loyalty API calls Payment Gateway Adapter [source: round 7 interfaces_and_integrations]
+- `interface-4` Loyalty API sends Analytics Service [source: round 7 interfaces_and_integrations]
+
+
+## Runtime Boundaries
+
+- `runtime-boundary-1` Member-facing apps and operations console run separately from the core API [source: round 7 runtime_boundaries]
+- `runtime-boundary-2` Payment Gateway Adapter crosses an external boundary [source: round 7 runtime_boundaries]
 
 ## Subsystem Descriptions
 
-- None
+- `component-member-app` Member App [source: round 7 components_and_services]
+- `component-loyalty-api` Loyalty API [source: round 7 components_and_services]
+- `component-operations-console` Operations Console [source: round 7 components_and_services]
+- `component-analytics-service` Analytics Service [source: round 7 components_and_services]
+- `component-payment-gateway-adapter` Payment Gateway Adapter [source: round 7 components_and_services]
+
+## Artifact Lineage
+
+- `trace-artifact-system-document-risk-factors-risk-payment-confirmation-dependency` risk-payment-confirmation-dependency -> system-document.md#risk factors (canonical risk factors object renders into system-document.md)
+- `trace-artifact-system-document-risk-factors-risk-reward-configuration-errors` risk-reward-configuration-errors -> system-document.md#risk factors (canonical risk factors object renders into system-document.md)
+- `trace-artifact-system-document-risk-factors-risk-reporting-latency` risk-reporting-latency -> system-document.md#risk factors (canonical risk factors object renders into system-document.md)
+- `trace-artifact-system-document-system-level-use-cases-enroll-member` enroll-member -> system-document.md#system-level use cases (canonical system-level use cases object renders into system-document.md)
+- `trace-artifact-system-document-system-level-use-cases-browse-rewards` browse-rewards -> system-document.md#system-level use cases (canonical system-level use cases object renders into system-document.md)
+- `trace-artifact-system-document-system-level-use-cases-redeem-reward` redeem-reward -> system-document.md#system-level use cases (canonical system-level use cases object renders into system-document.md)
+- `trace-artifact-system-document-system-level-use-cases-manage-reward-catalog` manage-reward-catalog -> system-document.md#system-level use cases (canonical system-level use cases object renders into system-document.md)
+- `trace-artifact-system-document-system-level-use-cases-review-redemption-analytics` review-redemption-analytics -> system-document.md#system-level use cases (canonical system-level use cases object renders into system-document.md)
+- `trace-artifact-system-document-architecture-overview-component-member-app` component-member-app -> system-document.md#architecture overview (canonical architecture overview object renders into system-document.md)
+- `trace-artifact-system-document-architecture-overview-component-loyalty-api` component-loyalty-api -> system-document.md#architecture overview (canonical architecture overview object renders into system-document.md)
+- `trace-artifact-system-document-architecture-overview-component-operations-console` component-operations-console -> system-document.md#architecture overview (canonical architecture overview object renders into system-document.md)
+- `trace-artifact-system-document-architecture-overview-component-analytics-service` component-analytics-service -> system-document.md#architecture overview (canonical architecture overview object renders into system-document.md)
+- `trace-artifact-system-document-architecture-overview-component-payment-gateway-adapter` component-payment-gateway-adapter -> system-document.md#architecture overview (canonical architecture overview object renders into system-document.md)
+- `trace-artifact-system-document-interfaces-and-integrations-interface-1` interface-1 -> system-document.md#interfaces and integrations (canonical interfaces and integrations object renders into system-document.md)
+- `trace-artifact-system-document-interfaces-and-integrations-interface-2` interface-2 -> system-document.md#interfaces and integrations (canonical interfaces and integrations object renders into system-document.md)
+- `trace-artifact-system-document-interfaces-and-integrations-interface-3` interface-3 -> system-document.md#interfaces and integrations (canonical interfaces and integrations object renders into system-document.md)
+- `trace-artifact-system-document-interfaces-and-integrations-interface-4` interface-4 -> system-document.md#interfaces and integrations (canonical interfaces and integrations object renders into system-document.md)
+- `trace-artifact-system-document-runtime-boundaries-runtime-boundary-1` runtime-boundary-1 -> system-document.md#runtime boundaries (canonical runtime boundaries object renders into system-document.md)
+- `trace-artifact-system-document-runtime-boundaries-runtime-boundary-2` runtime-boundary-2 -> system-document.md#runtime boundaries (canonical runtime boundaries object renders into system-document.md)
 

--- a/examples/loyalty-platform-v2/artifacts/formal/system-document.md
+++ b/examples/loyalty-platform-v2/artifacts/formal/system-document.md
@@ -1,0 +1,36 @@
+# System / Subsystem Document
+
+## System Name
+
+Loyalty Platform
+
+## Brief Description
+
+Legacy loyalty operations are fragmented across channels and teams, causing inconsistent member experience and slow campaign execution.
+
+A member loyalty platform for enrollment, rewards browsing, redemption, and operational reporting.
+
+## Risk Factors
+
+- None
+
+## System-Level Use Cases
+
+- `uc-enroll` Enroll Member (actor: Customer): Join the loyalty program and activate an account.
+- `uc-browse` Browse Rewards (actor: Customer): View eligible rewards and current point balance.
+- `uc-redeem` Redeem Reward (actor: Customer): Redeem a selected reward against available loyalty points.
+- `uc-catalog` Manage Reward Catalog (actor: Operations Manager): Create or update reward catalog entries and campaign details.
+- `uc-analytics` Review Redemption Analytics (actor: Operations Manager): Inspect reward redemption and campaign performance.
+
+## System-Level Diagram References
+
+- `use-case-model.md` for the detailed system-level use-case view
+- `deployment-model.md` for the detailed architecture and runtime view
+
+
+
+
+## Subsystem Descriptions
+
+- None
+

--- a/examples/loyalty-platform-v2/artifacts/formal/use-case-documents.md
+++ b/examples/loyalty-platform-v2/artifacts/formal/use-case-documents.md
@@ -1,0 +1,379 @@
+# Use-Case Documents
+
+## Enroll Member
+
+- ID: `uc-enroll`
+- Primary Actor: Customer
+- Supporting Actors: None
+- Priority: Unspecified
+- Status: Unspecified
+- Content Semantics: Unspecified
+- Readiness: unspecified
+- Complexity: simple
+- Goal: Join the loyalty program and activate an account.
+- Trigger: Unspecified
+- Source: round n/a 
+
+### Brief Description
+
+Join the loyalty program and activate an account.
+
+### Preconditions
+
+- None
+
+### Postconditions
+
+- None
+
+### Extension Points
+
+- None
+
+### Used Use Cases
+
+- None
+
+### Subordinate Use Cases
+
+- None
+
+### Flow of Events
+
+1. Customer opens the loyalty enrollment flow.
+2. Customer provides the required details and consents.
+3. System validates the submission and creates the member account.
+
+### Extensions
+
+- Enrollment is blocked when required consent is missing.
+
+### Secondary Scenarios
+
+No named scenarios documented.
+
+### User Interface
+
+- None
+
+### View of Participating Classes
+
+- None
+
+### Sequence and Interaction Notes
+
+No interaction realization documented.
+
+### Linked Requirements
+
+- None
+
+### Other Artifacts
+
+- None
+
+
+
+
+## Browse Rewards
+
+- ID: `uc-browse`
+- Primary Actor: Customer
+- Supporting Actors: None
+- Priority: Unspecified
+- Status: Unspecified
+- Content Semantics: Unspecified
+- Readiness: unspecified
+- Complexity: average
+- Goal: View eligible rewards and current point balance.
+- Trigger: Unspecified
+- Source: round n/a 
+
+### Brief Description
+
+View eligible rewards and current point balance.
+
+### Preconditions
+
+- None
+
+### Postconditions
+
+- None
+
+### Extension Points
+
+- None
+
+### Used Use Cases
+
+- None
+
+### Subordinate Use Cases
+
+- None
+
+### Flow of Events
+
+1. Customer opens the rewards catalog.
+2. System displays available rewards and points balance.
+3. Customer filters or sorts the catalog.
+
+### Extensions
+
+- Catalog view degrades if an integration is temporarily unavailable.
+
+### Secondary Scenarios
+
+No named scenarios documented.
+
+### User Interface
+
+- None
+
+### View of Participating Classes
+
+- None
+
+### Sequence and Interaction Notes
+
+No interaction realization documented.
+
+### Linked Requirements
+
+- None
+
+### Other Artifacts
+
+- None
+
+
+
+
+## Redeem Reward
+
+- ID: `uc-redeem`
+- Primary Actor: Customer
+- Supporting Actors: None
+- Priority: Unspecified
+- Status: Unspecified
+- Content Semantics: Unspecified
+- Readiness: unspecified
+- Complexity: complex
+- Goal: Redeem a selected reward against available loyalty points.
+- Trigger: Unspecified
+- Source: round n/a 
+
+### Brief Description
+
+Redeem a selected reward against available loyalty points.
+
+### Preconditions
+
+- None
+
+### Postconditions
+
+- None
+
+### Extension Points
+
+- None
+
+### Used Use Cases
+
+- None
+
+### Subordinate Use Cases
+
+- None
+
+### Flow of Events
+
+1. Customer selects a reward.
+2. System validates reward eligibility and available points.
+3. System reserves the reward and updates the member balance.
+4. System confirms redemption to the customer.
+
+### Extensions
+
+- Reward inventory is exhausted before completion.
+- Customer does not have enough points.
+- Payment confirmation is missing for a reward that depends on purchase completion.
+
+### Secondary Scenarios
+
+No named scenarios documented.
+
+### User Interface
+
+- None
+
+### View of Participating Classes
+
+- None
+
+### Sequence and Interaction Notes
+
+No interaction realization documented.
+
+### Linked Requirements
+
+- None
+
+### Other Artifacts
+
+- None
+
+
+
+
+## Manage Reward Catalog
+
+- ID: `uc-catalog`
+- Primary Actor: Operations Manager
+- Supporting Actors: None
+- Priority: Unspecified
+- Status: Unspecified
+- Content Semantics: Unspecified
+- Readiness: unspecified
+- Complexity: average
+- Goal: Create or update reward catalog entries and campaign details.
+- Trigger: Unspecified
+- Source: round n/a 
+
+### Brief Description
+
+Create or update reward catalog entries and campaign details.
+
+### Preconditions
+
+- None
+
+### Postconditions
+
+- None
+
+### Extension Points
+
+- None
+
+### Used Use Cases
+
+- None
+
+### Subordinate Use Cases
+
+- None
+
+### Flow of Events
+
+1. Operations Manager opens catalog administration.
+2. Operations Manager updates reward configuration.
+3. System validates and publishes the change.
+
+### Extensions
+
+- A change is rejected because it would make an active reward invalid.
+
+### Secondary Scenarios
+
+No named scenarios documented.
+
+### User Interface
+
+- None
+
+### View of Participating Classes
+
+- None
+
+### Sequence and Interaction Notes
+
+No interaction realization documented.
+
+### Linked Requirements
+
+- None
+
+### Other Artifacts
+
+- None
+
+
+
+
+## Review Redemption Analytics
+
+- ID: `uc-analytics`
+- Primary Actor: Operations Manager
+- Supporting Actors: None
+- Priority: Unspecified
+- Status: Unspecified
+- Content Semantics: Unspecified
+- Readiness: unspecified
+- Complexity: simple
+- Goal: Inspect reward redemption and campaign performance.
+- Trigger: Unspecified
+- Source: round n/a 
+
+### Brief Description
+
+Inspect reward redemption and campaign performance.
+
+### Preconditions
+
+- None
+
+### Postconditions
+
+- None
+
+### Extension Points
+
+- None
+
+### Used Use Cases
+
+- None
+
+### Subordinate Use Cases
+
+- None
+
+### Flow of Events
+
+1. Operations Manager opens the analytics dashboard.
+2. System shows redemption and campaign metrics.
+
+### Extensions
+
+- A reporting data source is delayed.
+
+### Secondary Scenarios
+
+No named scenarios documented.
+
+### User Interface
+
+- None
+
+### View of Participating Classes
+
+- None
+
+### Sequence and Interaction Notes
+
+No interaction realization documented.
+
+### Linked Requirements
+
+- None
+
+### Other Artifacts
+
+- None
+
+
+
+

--- a/examples/loyalty-platform-v2/artifacts/formal/use-case-documents.md
+++ b/examples/loyalty-platform-v2/artifacts/formal/use-case-documents.md
@@ -2,29 +2,29 @@
 
 ## Enroll Member
 
-- ID: `uc-enroll`
-- Primary Actor: Customer
+- ID: `enroll-member`
+- Primary Actor: Unspecified
 - Supporting Actors: None
-- Priority: Unspecified
-- Status: Unspecified
-- Content Semantics: Unspecified
-- Readiness: unspecified
+- Priority: high
+- Status: confirmed
+- Content Semantics: normative
+- Readiness: ready
 - Complexity: simple
-- Goal: Join the loyalty program and activate an account.
+- Goal: Enroll Member
 - Trigger: Unspecified
-- Source: round n/a 
+- Source: round 3 use_cases
 
 ### Brief Description
 
-Join the loyalty program and activate an account.
+Enroll Member
 
 ### Preconditions
 
-- None
+- Customer is not already enrolled
 
 ### Postconditions
 
-- None
+- Member account exists and is active
 
 ### Extension Points
 
@@ -54,15 +54,24 @@ No named scenarios documented.
 
 ### User Interface
 
-- None
+- Member-facing responsive enrollment form with consent capture and validation messaging.
 
 ### View of Participating Classes
 
-- None
+- `entity-member` Member [source: round 5 domain_entities]
 
 ### Sequence and Interaction Notes
 
-No interaction realization documented.
+#### Enroll Member
+
+- Participants: Unspecified
+
+##### Realization Steps
+
+1. Customer opens the loyalty enrollment flow.
+2. Customer provides the required details and consents.
+3. System validates the submission and creates the member account.
+
 
 ### Linked Requirements
 
@@ -73,33 +82,38 @@ No interaction realization documented.
 - None
 
 
+## Use-Case To Analysis Traceability
+
+- `trace-uc-analysis-1` enroll-member -> entity-member (use-case text references analysis object name)
+- `trace-uc-analysis-3` redeem-reward -> entity-member (use-case text references analysis object name)
+
 
 
 ## Browse Rewards
 
-- ID: `uc-browse`
-- Primary Actor: Customer
+- ID: `browse-rewards`
+- Primary Actor: Unspecified
 - Supporting Actors: None
-- Priority: Unspecified
-- Status: Unspecified
-- Content Semantics: Unspecified
-- Readiness: unspecified
+- Priority: high
+- Status: confirmed
+- Content Semantics: normative
+- Readiness: ready
 - Complexity: average
-- Goal: View eligible rewards and current point balance.
+- Goal: Browse Rewards
 - Trigger: Unspecified
-- Source: round n/a 
+- Source: round 3 use_cases
 
 ### Brief Description
 
-View eligible rewards and current point balance.
+Browse Rewards
 
 ### Preconditions
 
-- None
+- Member is enrolled
 
 ### Postconditions
 
-- None
+- Eligible rewards and point balance are visible
 
 ### Extension Points
 
@@ -129,15 +143,24 @@ No named scenarios documented.
 
 ### User Interface
 
-- None
+- Reward catalog view with filters, points balance summary, and eligibility indicators.
 
 ### View of Participating Classes
 
-- None
+- `entity-reward` Reward [source: round 5 domain_entities]
 
 ### Sequence and Interaction Notes
 
-No interaction realization documented.
+#### Browse Rewards
+
+- Participants: Unspecified
+
+##### Realization Steps
+
+1. Customer opens the rewards catalog.
+2. System displays available rewards and points balance.
+3. Customer filters or sorts the catalog.
+
 
 ### Linked Requirements
 
@@ -148,33 +171,40 @@ No interaction realization documented.
 - None
 
 
+## Use-Case To Analysis Traceability
+
+- `trace-uc-analysis-2` browse-rewards -> entity-reward (use-case text references analysis object name)
+- `trace-uc-analysis-4` redeem-reward -> entity-reward (use-case text references analysis object name)
+- `trace-uc-analysis-7` manage-reward-catalog -> entity-reward (use-case text references analysis object name)
+
 
 
 ## Redeem Reward
 
-- ID: `uc-redeem`
-- Primary Actor: Customer
+- ID: `redeem-reward`
+- Primary Actor: Unspecified
 - Supporting Actors: None
-- Priority: Unspecified
-- Status: Unspecified
-- Content Semantics: Unspecified
-- Readiness: unspecified
+- Priority: high
+- Status: confirmed
+- Content Semantics: normative
+- Readiness: ready
 - Complexity: complex
-- Goal: Redeem a selected reward against available loyalty points.
+- Goal: Redeem Reward
 - Trigger: Unspecified
-- Source: round n/a 
+- Source: round 3 use_cases
 
 ### Brief Description
 
-Redeem a selected reward against available loyalty points.
+Redeem Reward
 
 ### Preconditions
 
-- None
+- Member is enrolled
+- Reward is available
 
 ### Postconditions
 
-- None
+- Redemption is recorded and balance is updated
 
 ### Extension Points
 
@@ -203,56 +233,121 @@ Redeem a selected reward against available loyalty points.
 
 ### Secondary Scenarios
 
-No named scenarios documented.
+#### Reward Inventory Exhausted
+
+- Summary: Redemption fails because no reward inventory remains.
+- Priority: high
+- Status: open
+
+##### Flow of Events
+
+1. Customer selects a reward.
+2. System checks reward availability.
+3. System reports that inventory is exhausted.
+
+##### Activity Notes
+
+- None
+
+##### Sequence Notes
+
+- None
+
+
+#### Missing Payment Confirmation
+
+- Summary: Redemption pauses until dependent payment confirmation arrives.
+- Priority: medium
+- Status: open
+
+##### Flow of Events
+
+1. Customer selects a reward.
+2. System requests payment confirmation.
+3. System blocks fulfillment until confirmation arrives.
+
+##### Activity Notes
+
+- None
+
+##### Sequence Notes
+
+- None
+
 
 ### User Interface
 
-- None
+- Reward detail and redemption confirmation flow with explicit failure states.
 
 ### View of Participating Classes
 
-- None
+- `entity-member` Member [source: round 5 domain_entities]
+- `entity-reward` Reward [source: round 5 domain_entities]
+- `entity-redemption` Redemption [source: round 5 domain_entities]
+- `state-entity-redemption` Redemption [source: round 6 state_entities]
 
 ### Sequence and Interaction Notes
 
-No interaction realization documented.
+#### Redeem Reward
+
+- Participants: Unspecified
+
+##### Realization Steps
+
+1. Customer selects a reward.
+2. System validates reward eligibility and available points.
+3. System reserves the reward and updates the member balance.
+4. System confirms redemption to the customer.
+
 
 ### Linked Requirements
 
-- None
+- `non_functional-requirement-6` The system must allow members to redeem rewards when eligibility conditions are satisfied. [source: round 4 non_functional_requirements]
 
 ### Other Artifacts
 
 - None
 
 
+## Use-Case To Analysis Traceability
+
+- `trace-uc-analysis-1` enroll-member -> entity-member (use-case text references analysis object name)
+- `trace-uc-analysis-2` browse-rewards -> entity-reward (use-case text references analysis object name)
+- `trace-uc-analysis-3` redeem-reward -> entity-member (use-case text references analysis object name)
+- `trace-uc-analysis-4` redeem-reward -> entity-reward (use-case text references analysis object name)
+- `trace-uc-analysis-5` redeem-reward -> entity-redemption (use-case text references analysis object name)
+- `trace-uc-analysis-6` redeem-reward -> state-entity-redemption (use-case text references analysis object name)
+- `trace-uc-analysis-7` manage-reward-catalog -> entity-reward (use-case text references analysis object name)
+- `trace-uc-analysis-9` review-redemption-analytics -> entity-redemption (use-case text references analysis object name)
+- `trace-uc-analysis-10` review-redemption-analytics -> state-entity-redemption (use-case text references analysis object name)
+
 
 
 ## Manage Reward Catalog
 
-- ID: `uc-catalog`
-- Primary Actor: Operations Manager
+- ID: `manage-reward-catalog`
+- Primary Actor: Unspecified
 - Supporting Actors: None
-- Priority: Unspecified
-- Status: Unspecified
-- Content Semantics: Unspecified
-- Readiness: unspecified
+- Priority: medium
+- Status: confirmed
+- Content Semantics: normative
+- Readiness: ready
 - Complexity: average
-- Goal: Create or update reward catalog entries and campaign details.
+- Goal: Manage Reward Catalog
 - Trigger: Unspecified
-- Source: round n/a 
+- Source: round 3 use_cases
 
 ### Brief Description
 
-Create or update reward catalog entries and campaign details.
+Manage Reward Catalog
 
 ### Preconditions
 
-- None
+- Operations Manager is authenticated
 
 ### Postconditions
 
-- None
+- Reward catalog change is published
 
 ### Extension Points
 
@@ -278,19 +373,47 @@ Create or update reward catalog entries and campaign details.
 
 ### Secondary Scenarios
 
-No named scenarios documented.
+#### Invalid Catalog Change
+
+- Summary: Publication is rejected because the new reward configuration would break an active offer.
+- Priority: medium
+- Status: open
+
+##### Flow of Events
+
+1. Operations Manager updates reward configuration.
+2. System validates the change.
+3. System rejects the invalid change.
+
+##### Activity Notes
+
+- None
+
+##### Sequence Notes
+
+- None
+
 
 ### User Interface
 
-- None
+- Back-office catalog editor with validation messages before publish.
 
 ### View of Participating Classes
 
-- None
+- `entity-reward` Reward [source: round 5 domain_entities]
 
 ### Sequence and Interaction Notes
 
-No interaction realization documented.
+#### Manage Reward Catalog
+
+- Participants: Unspecified
+
+##### Realization Steps
+
+1. Operations Manager opens catalog administration.
+2. Operations Manager updates reward configuration.
+3. System validates and publishes the change.
+
 
 ### Linked Requirements
 
@@ -301,33 +424,39 @@ No interaction realization documented.
 - None
 
 
+## Use-Case To Analysis Traceability
+
+- `trace-uc-analysis-2` browse-rewards -> entity-reward (use-case text references analysis object name)
+- `trace-uc-analysis-4` redeem-reward -> entity-reward (use-case text references analysis object name)
+- `trace-uc-analysis-7` manage-reward-catalog -> entity-reward (use-case text references analysis object name)
+
 
 
 ## Review Redemption Analytics
 
-- ID: `uc-analytics`
-- Primary Actor: Operations Manager
+- ID: `review-redemption-analytics`
+- Primary Actor: Unspecified
 - Supporting Actors: None
-- Priority: Unspecified
-- Status: Unspecified
-- Content Semantics: Unspecified
-- Readiness: unspecified
+- Priority: medium
+- Status: confirmed
+- Content Semantics: normative
+- Readiness: ready
 - Complexity: simple
-- Goal: Inspect reward redemption and campaign performance.
+- Goal: Review Redemption Analytics
 - Trigger: Unspecified
-- Source: round n/a 
+- Source: round 3 use_cases
 
 ### Brief Description
 
-Inspect reward redemption and campaign performance.
+Review Redemption Analytics
 
 ### Preconditions
 
-- None
+- Reporting data is available
 
 ### Postconditions
 
-- None
+- Operations Manager can inspect campaign and redemption metrics
 
 ### Extension Points
 
@@ -352,19 +481,48 @@ Inspect reward redemption and campaign performance.
 
 ### Secondary Scenarios
 
-No named scenarios documented.
+#### Reporting Delay
+
+- Summary: Analytics view is partial because a reporting source is delayed.
+- Priority: low
+- Status: open
+
+##### Flow of Events
+
+1. Operations Manager opens the analytics dashboard.
+2. System detects delayed reporting data.
+3. System shows a partial-data warning.
+
+##### Activity Notes
+
+- None
+
+##### Sequence Notes
+
+- None
+
 
 ### User Interface
 
-- None
+- Operational dashboard summarizing redemptions, campaigns, and freshness warnings.
 
 ### View of Participating Classes
 
-- None
+- `entity-campaign` Campaign [source: round 5 domain_entities]
+- `entity-redemption` Redemption [source: round 5 domain_entities]
+- `state-entity-redemption` Redemption [source: round 6 state_entities]
 
 ### Sequence and Interaction Notes
 
-No interaction realization documented.
+#### Review Redemption Analytics
+
+- Participants: Unspecified
+
+##### Realization Steps
+
+1. Operations Manager opens the analytics dashboard.
+2. System shows redemption and campaign metrics.
+
 
 ### Linked Requirements
 
@@ -375,5 +533,25 @@ No interaction realization documented.
 - None
 
 
+## Use-Case To Analysis Traceability
 
+- `trace-uc-analysis-5` redeem-reward -> entity-redemption (use-case text references analysis object name)
+- `trace-uc-analysis-6` redeem-reward -> state-entity-redemption (use-case text references analysis object name)
+- `trace-uc-analysis-8` review-redemption-analytics -> entity-campaign (use-case text references analysis object name)
+- `trace-uc-analysis-9` review-redemption-analytics -> entity-redemption (use-case text references analysis object name)
+- `trace-uc-analysis-10` review-redemption-analytics -> state-entity-redemption (use-case text references analysis object name)
+
+
+
+## Artifact Lineage
+
+- `trace-artifact-use-case-documents-use-case-documents-enroll-member` enroll-member -> use-case-documents.md#use-case documents (canonical use-case documents object renders into use-case-documents.md)
+- `trace-artifact-use-case-documents-use-case-documents-browse-rewards` browse-rewards -> use-case-documents.md#use-case documents (canonical use-case documents object renders into use-case-documents.md)
+- `trace-artifact-use-case-documents-use-case-documents-redeem-reward` redeem-reward -> use-case-documents.md#use-case documents (canonical use-case documents object renders into use-case-documents.md)
+- `trace-artifact-use-case-documents-use-case-documents-manage-reward-catalog` manage-reward-catalog -> use-case-documents.md#use-case documents (canonical use-case documents object renders into use-case-documents.md)
+- `trace-artifact-use-case-documents-use-case-documents-review-redemption-analytics` review-redemption-analytics -> use-case-documents.md#use-case documents (canonical use-case documents object renders into use-case-documents.md)
+- `trace-artifact-use-case-documents-scenario-summaries-scenario-reward-inventory-exhausted` scenario-reward-inventory-exhausted -> use-case-documents.md#scenario summaries (canonical scenario summaries object renders into use-case-documents.md)
+- `trace-artifact-use-case-documents-scenario-summaries-scenario-missing-payment-confirmation` scenario-missing-payment-confirmation -> use-case-documents.md#scenario summaries (canonical scenario summaries object renders into use-case-documents.md)
+- `trace-artifact-use-case-documents-scenario-summaries-scenario-invalid-catalog-change` scenario-invalid-catalog-change -> use-case-documents.md#scenario summaries (canonical scenario summaries object renders into use-case-documents.md)
+- `trace-artifact-use-case-documents-scenario-summaries-scenario-reporting-delay` scenario-reporting-delay -> use-case-documents.md#scenario summaries (canonical scenario summaries object renders into use-case-documents.md)
 

--- a/examples/loyalty-platform-v2/artifacts/formal/use-case-model.md
+++ b/examples/loyalty-platform-v2/artifacts/formal/use-case-model.md
@@ -1,0 +1,107 @@
+# Use-Case Model
+
+## Actors
+
+- `customer` Customer (human, complex): A loyalty member using the digital experience to enroll, browse, and redeem rewards.
+- `ops-manager` Operations Manager (human, average): An internal operator responsible for campaigns, catalog changes, and reporting.
+- `payment-gateway` Payment Gateway (system, simple): An external system that confirms payment completion for eligible transactions.
+
+## Use Cases
+
+### Enroll Member
+
+- ID: `uc-enroll`
+- Primary actor: Customer
+- Complexity: simple
+- Goal: Join the loyalty program and activate an account.
+- Source: round n/a 
+
+#### Main Success Scenario
+
+1. Customer opens the loyalty enrollment flow.
+2. Customer provides the required details and consents.
+3. System validates the submission and creates the member account.
+
+#### Extensions
+
+- Enrollment is blocked when required consent is missing.
+
+### Browse Rewards
+
+- ID: `uc-browse`
+- Primary actor: Customer
+- Complexity: average
+- Goal: View eligible rewards and current point balance.
+- Source: round n/a 
+
+#### Main Success Scenario
+
+1. Customer opens the rewards catalog.
+2. System displays available rewards and points balance.
+3. Customer filters or sorts the catalog.
+
+#### Extensions
+
+- Catalog view degrades if an integration is temporarily unavailable.
+
+### Redeem Reward
+
+- ID: `uc-redeem`
+- Primary actor: Customer
+- Complexity: complex
+- Goal: Redeem a selected reward against available loyalty points.
+- Source: round n/a 
+
+#### Main Success Scenario
+
+1. Customer selects a reward.
+2. System validates reward eligibility and available points.
+3. System reserves the reward and updates the member balance.
+4. System confirms redemption to the customer.
+
+#### Extensions
+
+- Reward inventory is exhausted before completion.
+- Customer does not have enough points.
+- Payment confirmation is missing for a reward that depends on purchase completion.
+
+### Manage Reward Catalog
+
+- ID: `uc-catalog`
+- Primary actor: Operations Manager
+- Complexity: average
+- Goal: Create or update reward catalog entries and campaign details.
+- Source: round n/a 
+
+#### Main Success Scenario
+
+1. Operations Manager opens catalog administration.
+2. Operations Manager updates reward configuration.
+3. System validates and publishes the change.
+
+#### Extensions
+
+- A change is rejected because it would make an active reward invalid.
+
+### Review Redemption Analytics
+
+- ID: `uc-analytics`
+- Primary actor: Operations Manager
+- Complexity: simple
+- Goal: Inspect reward redemption and campaign performance.
+- Source: round n/a 
+
+#### Main Success Scenario
+
+1. Operations Manager opens the analytics dashboard.
+2. System shows redemption and campaign metrics.
+
+#### Extensions
+
+- A reporting data source is delayed.
+
+
+
+
+
+

--- a/examples/loyalty-platform-v2/artifacts/formal/use-case-model.md
+++ b/examples/loyalty-platform-v2/artifacts/formal/use-case-model.md
@@ -2,19 +2,19 @@
 
 ## Actors
 
-- `customer` Customer (human, complex): A loyalty member using the digital experience to enroll, browse, and redeem rewards.
-- `ops-manager` Operations Manager (human, average): An internal operator responsible for campaigns, catalog changes, and reporting.
-- `payment-gateway` Payment Gateway (system, simple): An external system that confirms payment completion for eligible transactions.
+- `customer` Customer (human, complex):  [source: round 3 actors]
+- `operations-manager` Operations Manager (human, average):  [source: round 3 actors]
+- `payment-gateway` Payment Gateway (system, simple):  [source: round 3 actors]
 
 ## Use Cases
 
 ### Enroll Member
 
-- ID: `uc-enroll`
-- Primary actor: Customer
+- ID: `enroll-member`
+- Primary actor: Unspecified
 - Complexity: simple
-- Goal: Join the loyalty program and activate an account.
-- Source: round n/a 
+- Goal: Enroll Member
+- Source: round 3 use_cases
 
 #### Main Success Scenario
 
@@ -28,11 +28,11 @@
 
 ### Browse Rewards
 
-- ID: `uc-browse`
-- Primary actor: Customer
+- ID: `browse-rewards`
+- Primary actor: Unspecified
 - Complexity: average
-- Goal: View eligible rewards and current point balance.
-- Source: round n/a 
+- Goal: Browse Rewards
+- Source: round 3 use_cases
 
 #### Main Success Scenario
 
@@ -46,11 +46,11 @@
 
 ### Redeem Reward
 
-- ID: `uc-redeem`
-- Primary actor: Customer
+- ID: `redeem-reward`
+- Primary actor: Unspecified
 - Complexity: complex
-- Goal: Redeem a selected reward against available loyalty points.
-- Source: round n/a 
+- Goal: Redeem Reward
+- Source: round 3 use_cases
 
 #### Main Success Scenario
 
@@ -67,11 +67,11 @@
 
 ### Manage Reward Catalog
 
-- ID: `uc-catalog`
-- Primary actor: Operations Manager
+- ID: `manage-reward-catalog`
+- Primary actor: Unspecified
 - Complexity: average
-- Goal: Create or update reward catalog entries and campaign details.
-- Source: round n/a 
+- Goal: Manage Reward Catalog
+- Source: round 3 use_cases
 
 #### Main Success Scenario
 
@@ -85,11 +85,11 @@
 
 ### Review Redemption Analytics
 
-- ID: `uc-analytics`
-- Primary actor: Operations Manager
+- ID: `review-redemption-analytics`
+- Primary actor: Unspecified
 - Complexity: simple
-- Goal: Inspect reward redemption and campaign performance.
-- Source: round n/a 
+- Goal: Review Redemption Analytics
+- Source: round 3 use_cases
 
 #### Main Success Scenario
 
@@ -101,7 +101,44 @@
 - A reporting data source is delayed.
 
 
+## States and Transitions
+
+- `state-transition-1` Redemption: Requested -> Validated -> Fulfilled [source: round 6 states_and_transitions]
+- `state-transition-2` Redemption: Requested -> Validated -> Fulfilled [source: round 6 states_and_transitions]
+- `state-transition-3` Redemption: Requested -> Rejected [source: round 6 states_and_transitions]
+- `state-transition-4` Reward Catalog Entry: Draft -> Published -> Retired [source: round 6 states_and_transitions]
+- `state-transition-5` Reward Catalog Entry: Draft -> Published -> Retired [source: round 6 states_and_transitions]
 
 
+## Triggers and Approvals
 
+- `trigger-1` Payment confirmation triggers redemption fulfillment [source: round 6 triggers_and_approvals]
+- `trigger-2` Catalog validation approval is required before a reward becomes Published [source: round 6 triggers_and_approvals]
+
+
+## Interfaces and Integrations
+
+- `interface-1` Member App calls Loyalty API [source: round 7 interfaces_and_integrations]
+- `interface-2` Operations Console calls Loyalty API [source: round 7 interfaces_and_integrations]
+- `interface-3` Loyalty API calls Payment Gateway Adapter [source: round 7 interfaces_and_integrations]
+- `interface-4` Loyalty API sends Analytics Service [source: round 7 interfaces_and_integrations]
+
+
+## Requirement To Use-Case Traceability
+
+- `trace-req-uc-1` non_functional-requirement-6 -> redeem-reward (requirement statement references use-case name)
+
+
+## Use-Case To Analysis Traceability
+
+- `trace-uc-analysis-1` enroll-member -> entity-member (use-case text references analysis object name)
+- `trace-uc-analysis-2` browse-rewards -> entity-reward (use-case text references analysis object name)
+- `trace-uc-analysis-3` redeem-reward -> entity-member (use-case text references analysis object name)
+- `trace-uc-analysis-4` redeem-reward -> entity-reward (use-case text references analysis object name)
+- `trace-uc-analysis-5` redeem-reward -> entity-redemption (use-case text references analysis object name)
+- `trace-uc-analysis-6` redeem-reward -> state-entity-redemption (use-case text references analysis object name)
+- `trace-uc-analysis-7` manage-reward-catalog -> entity-reward (use-case text references analysis object name)
+- `trace-uc-analysis-8` review-redemption-analytics -> entity-campaign (use-case text references analysis object name)
+- `trace-uc-analysis-9` review-redemption-analytics -> entity-redemption (use-case text references analysis object name)
+- `trace-uc-analysis-10` review-redemption-analytics -> state-entity-redemption (use-case text references analysis object name)
 

--- a/examples/loyalty-platform-v2/artifacts/mermaid/deployment-model.mmd
+++ b/examples/loyalty-platform-v2/artifacts/mermaid/deployment-model.mmd
@@ -1,0 +1,1 @@
+flowchart LR

--- a/examples/loyalty-platform-v2/artifacts/mermaid/deployment-model.mmd
+++ b/examples/loyalty-platform-v2/artifacts/mermaid/deployment-model.mmd
@@ -1,1 +1,12 @@
 flowchart LR
+Member_App["Member App"]
+Loyalty_API["Loyalty API"]
+Operations_Console["Operations Console"]
+Analytics_Service["Analytics Service"]
+Payment_Gateway_Adapter["Payment Gateway Adapter"]
+Member_App -->|"Member App calls Loyalty API"| Loyalty_API
+Operations_Console -->|"Operations Console calls Loyalty API"| Loyalty_API
+Loyalty_API -->|"Loyalty API calls Payment Gateway Adapter"| Payment_Gateway_Adapter
+Loyalty_API -->|"Loyalty API sends Analytics Service"| Analytics_Service
+RuntimeBoundary_1["Member-facing apps and operations console run separately from the core API"]
+RuntimeBoundary_2["Payment Gateway Adapter crosses an external boundary"]

--- a/examples/loyalty-platform-v2/artifacts/mermaid/domain-model.mmd
+++ b/examples/loyalty-platform-v2/artifacts/mermaid/domain-model.mmd
@@ -1,0 +1,1 @@
+classDiagram

--- a/examples/loyalty-platform-v2/artifacts/mermaid/domain-model.mmd
+++ b/examples/loyalty-platform-v2/artifacts/mermaid/domain-model.mmd
@@ -1,1 +1,18 @@
 classDiagram
+class Member {
+}
+class Reward {
+}
+class Reward_Catalog_Entry {
+}
+class Campaign {
+}
+class Redemption {
+}
+class Payment_Confirmation {
+}
+class Analytics_Report {
+}
+Member "1" --> "*" Redemption : has_many
+Campaign "1" --> "*" Reward_Catalog_Entry : has_many
+Analytics_Report "1" --> "*" Redemption : has_many

--- a/examples/loyalty-platform-v2/artifacts/mermaid/interaction-model.mmd
+++ b/examples/loyalty-platform-v2/artifacts/mermaid/interaction-model.mmd
@@ -1,0 +1,1 @@
+sequenceDiagram

--- a/examples/loyalty-platform-v2/artifacts/mermaid/interaction-model.mmd
+++ b/examples/loyalty-platform-v2/artifacts/mermaid/interaction-model.mmd
@@ -1,1 +1,10 @@
 sequenceDiagram
+participant Member_App as "Member App"
+participant Loyalty_API as "Loyalty API"
+participant Operations_Console as "Operations Console"
+participant Payment_Gateway_Adapter as "Payment Gateway Adapter"
+participant Analytics_Service as "Analytics Service"
+Member_App->>Loyalty_API: Member App calls Loyalty API
+Operations_Console->>Loyalty_API: Operations Console calls Loyalty API
+Loyalty_API->>Payment_Gateway_Adapter: Loyalty API calls Payment Gateway Adapter
+Loyalty_API->>Analytics_Service: Loyalty API sends Analytics Service

--- a/examples/loyalty-platform-v2/artifacts/mermaid/state-model.mmd
+++ b/examples/loyalty-platform-v2/artifacts/mermaid/state-model.mmd
@@ -1,0 +1,1 @@
+stateDiagram-v2

--- a/examples/loyalty-platform-v2/artifacts/mermaid/state-model.mmd
+++ b/examples/loyalty-platform-v2/artifacts/mermaid/state-model.mmd
@@ -1,1 +1,16 @@
 stateDiagram-v2
+state "Requested" as Requested
+state "Validated" as Validated
+Requested --> Validated : Redemption
+state "Validated" as Validated
+state "Fulfilled" as Fulfilled
+Validated --> Fulfilled : Redemption | terminal
+state "Requested" as Requested
+state "Rejected" as Rejected
+Requested --> Rejected : Redemption | exception | terminal
+state "Draft" as Draft
+state "Published" as Published
+Draft --> Published : Reward Catalog Entry
+state "Published" as Published
+state "Retired" as Retired
+Published --> Retired : Reward Catalog Entry

--- a/examples/loyalty-platform-v2/artifacts/ucp/ucp-estimate.md
+++ b/examples/loyalty-platform-v2/artifacts/ucp/ucp-estimate.md
@@ -22,10 +22,8 @@ Loyalty Platform
 
 ## Assumptions
 
-- The first delivery increment focuses on a single market and one loyalty program configuration.
-- A single product team delivers the first release.
+- None
 
 ## Open Questions
 
-- Should partner merchants be modeled as separate actors in V1?
-- What reporting latency is acceptable for operational analytics?
+- None

--- a/examples/loyalty-platform-v2/artifacts/ucp/ucp-estimate.md
+++ b/examples/loyalty-platform-v2/artifacts/ucp/ucp-estimate.md
@@ -1,0 +1,31 @@
+# UCP Estimate
+
+## Project
+
+Loyalty Platform
+
+## Summary
+
+- `UAW`: 6.00
+- `UUCW`: 45.00
+- `UUCP`: 51.00
+- `TCF`: 1.010
+- `EF`: 0.785
+- `UCP`: 40.435
+- `Effort Hours`: 808.71
+
+## Inputs
+
+- Technical factor weighted sum: 41.00
+- Environmental factor weighted sum: 20.50
+- Productivity hours per UCP: 20.00
+
+## Assumptions
+
+- The first delivery increment focuses on a single market and one loyalty program configuration.
+- A single product team delivers the first release.
+
+## Open Questions
+
+- Should partner merchants be modeled as separate actors in V1?
+- What reporting latency is acceptable for operational analytics?

--- a/examples/loyalty-platform-v2/bundle-manifest.json
+++ b/examples/loyalty-platform-v2/bundle-manifest.json
@@ -1,0 +1,47 @@
+{
+  "bundle_metadata": {
+    "bundle_kind": "rupify_specification_publication_bundle",
+    "generated_artifact_families": [
+      "formal",
+      "ucp",
+      "domain-mermaid",
+      "interaction-mermaid",
+      "deployment-mermaid",
+      "state-mermaid",
+      "speckify-planning-export"
+    ],
+    "schema_version": 1,
+    "source_model_change_metadata": {},
+    "source_model_semantic_id": ""
+  },
+  "layout": {
+    "formal_artifacts": [
+      "artifacts/formal/deployment-model.md",
+      "artifacts/formal/domain-model.md",
+      "artifacts/formal/interaction-model.md",
+      "artifacts/formal/requirements-spec.md",
+      "artifacts/formal/scenario-documents.md",
+      "artifacts/formal/state-model.md",
+      "artifacts/formal/system-document.md",
+      "artifacts/formal/use-case-documents.md",
+      "artifacts/formal/use-case-model.md"
+    ],
+    "mermaid_artifacts": [
+      "artifacts/mermaid/deployment-model.mmd",
+      "artifacts/mermaid/domain-model.mmd",
+      "artifacts/mermaid/interaction-model.mmd",
+      "artifacts/mermaid/state-model.mmd"
+    ],
+    "model": "model/rupify-model.json",
+    "planning_export": "exports/speckify-planning-export.json",
+    "ucp_artifacts": [
+      "artifacts/ucp/ucp-estimate.md"
+    ]
+  },
+  "summary": {
+    "file_count": 17,
+    "formal_artifact_count": 9,
+    "mermaid_artifact_count": 4,
+    "ucp_artifact_count": 1
+  }
+}

--- a/examples/loyalty-platform-v2/bundle-manifest.json
+++ b/examples/loyalty-platform-v2/bundle-manifest.json
@@ -11,8 +11,15 @@
       "speckify-planning-export"
     ],
     "schema_version": 1,
-    "source_model_change_metadata": {},
-    "source_model_semantic_id": ""
+    "source_model_change_metadata": {
+      "change_source": "normalize_replay_to_model",
+      "last_changed_at": "",
+      "regenerated_from_version": "",
+      "semantic_hash": "f53b334e86e54b91",
+      "semantic_version": 1,
+      "supersedes": []
+    },
+    "source_model_semantic_id": "rupify-model"
   },
   "layout": {
     "formal_artifacts": [

--- a/examples/loyalty-platform-v2/exports/speckify-planning-export.json
+++ b/examples/loyalty-platform-v2/exports/speckify-planning-export.json
@@ -1,0 +1,21 @@
+{
+  "blocking_ambiguities": [],
+  "elements": [],
+  "export_metadata": {
+    "export_kind": "speckify_planning_export",
+    "schema_version": 1,
+    "source_model_change_metadata": {},
+    "source_model_semantic_id": ""
+  },
+  "ready_normative_elements": [],
+  "summary": {
+    "blocking_ambiguity_count": 0,
+    "blocking_ambiguity_ids": [],
+    "element_count": 0,
+    "partial_or_blocked_normative_ids": [],
+    "ready_normative_count": 0,
+    "ready_normative_ids": [],
+    "trace_link_count": 0
+  },
+  "trace_links": []
+}

--- a/examples/loyalty-platform-v2/exports/speckify-planning-export.json
+++ b/examples/loyalty-platform-v2/exports/speckify-planning-export.json
@@ -1,21 +1,7310 @@
 {
   "blocking_ambiguities": [],
-  "elements": [],
+  "elements": [
+    {
+      "attributes": {
+        "constraint_kind": "non_functional_requirement",
+        "source_requirement_id": "non_functional-requirement-1"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_acceptance_constraints",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "94812897dc06184b",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "acceptance_constraints",
+      "id": "acceptance-constraint-requirement-1",
+      "missing_fields": [],
+      "name": "Acceptance Constraint 1",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "acceptance-constraint-requirement-1",
+      "source_key": "constraints",
+      "source_round": 2,
+      "text": "The system must protect member and reward transactions with appropriate security controls."
+    },
+    {
+      "attributes": {
+        "constraint_kind": "non_functional_requirement",
+        "source_requirement_id": "non_functional-requirement-2"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_acceptance_constraints",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "9dc0f244dacd87c2",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "acceptance_constraints",
+      "id": "acceptance-constraint-requirement-2",
+      "missing_fields": [],
+      "name": "Acceptance Constraint 2",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "acceptance-constraint-requirement-2",
+      "source_key": "constraints",
+      "source_round": 2,
+      "text": "The member-facing experience must remain usable on common digital channels."
+    },
+    {
+      "attributes": {
+        "constraint_kind": "non_functional_requirement",
+        "source_requirement_id": "non_functional-requirement-3"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_acceptance_constraints",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "2ff2dee2880ffd8d",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "acceptance_constraints",
+      "id": "acceptance-constraint-requirement-3",
+      "missing_fields": [],
+      "name": "Acceptance Constraint 3",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "acceptance-constraint-requirement-3",
+      "source_key": "constraints",
+      "source_round": 2,
+      "text": "The platform must support integrations with external systems such as payment confirmation and reporting sources."
+    },
+    {
+      "attributes": {
+        "constraint_kind": "non_functional_requirement",
+        "source_requirement_id": "non_functional-requirement-4"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_acceptance_constraints",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "257c1792f5ca8674",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "acceptance_constraints",
+      "id": "acceptance-constraint-requirement-4",
+      "missing_fields": [],
+      "name": "Acceptance Constraint 4",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "acceptance-constraint-requirement-4",
+      "source_key": "non_functional_requirements",
+      "source_round": 4,
+      "text": "The system must allow customers to enroll in the loyalty program digitally."
+    },
+    {
+      "attributes": {
+        "constraint_kind": "non_functional_requirement",
+        "source_requirement_id": "non_functional-requirement-5"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_acceptance_constraints",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "bd76e87bf7d763f7",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "acceptance_constraints",
+      "id": "acceptance-constraint-requirement-5",
+      "missing_fields": [],
+      "name": "Acceptance Constraint 5",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "acceptance-constraint-requirement-5",
+      "source_key": "non_functional_requirements",
+      "source_round": 4,
+      "text": "The system must show point balance and available rewards to eligible members."
+    },
+    {
+      "attributes": {
+        "constraint_kind": "non_functional_requirement",
+        "source_requirement_id": "non_functional-requirement-6"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_acceptance_constraints",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "a705e18f2183b881",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "acceptance_constraints",
+      "id": "acceptance-constraint-requirement-6",
+      "missing_fields": [],
+      "name": "Acceptance Constraint 6",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "acceptance-constraint-requirement-6",
+      "source_key": "non_functional_requirements",
+      "source_round": 4,
+      "text": "The system must allow members to redeem rewards when eligibility conditions are satisfied."
+    },
+    {
+      "attributes": {
+        "constraint_kind": "non_functional_requirement",
+        "source_requirement_id": "non_functional-requirement-7"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_acceptance_constraints",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "b4be53384966216f",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "acceptance_constraints",
+      "id": "acceptance-constraint-requirement-7",
+      "missing_fields": [],
+      "name": "Acceptance Constraint 7",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "acceptance-constraint-requirement-7",
+      "source_key": "non_functional_requirements",
+      "source_round": 4,
+      "text": "The system must provide reporting on redemptions and campaign performance."
+    },
+    {
+      "attributes": {
+        "constraint_kind": "success_criterion"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_acceptance_constraints",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "50e151c1183f5872",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "acceptance_constraints",
+      "id": "acceptance-constraint-success-1",
+      "missing_fields": [],
+      "name": "Success Criterion 1",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "acceptance-constraint-success-1",
+      "source_key": "success_criteria",
+      "source_round": 2,
+      "text": "Members can enroll and redeem rewards through one coherent digital journey."
+    },
+    {
+      "attributes": {
+        "constraint_kind": "success_criterion"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_acceptance_constraints",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "2abb9a2aa9983c0a",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "acceptance_constraints",
+      "id": "acceptance-constraint-success-2",
+      "missing_fields": [],
+      "name": "Success Criterion 2",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "acceptance-constraint-success-2",
+      "source_key": "success_criteria",
+      "source_round": 2,
+      "text": "Operations managers can update the reward catalog without engineering support for routine changes."
+    },
+    {
+      "attributes": {
+        "constraint_kind": "success_criterion"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_acceptance_constraints",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "489ea823b5173325",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "acceptance_constraints",
+      "id": "acceptance-constraint-success-3",
+      "missing_fields": [],
+      "name": "Success Criterion 3",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "acceptance-constraint-success-3",
+      "source_key": "success_criteria",
+      "source_round": 2,
+      "text": "The business can review redemption and campaign performance in one reporting workflow."
+    },
+    {
+      "attributes": {
+        "complexity": "complex"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_3",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "4d72ad153ef59283",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "informative",
+      "family": "actors",
+      "id": "customer",
+      "missing_fields": [],
+      "name": "Customer",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "customer",
+      "source_key": "actors",
+      "source_round": 3,
+      "text": "Customer"
+    },
+    {
+      "attributes": {
+        "complexity": "average"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_3",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "91465f76185d5319",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "informative",
+      "family": "actors",
+      "id": "operations-manager",
+      "missing_fields": [],
+      "name": "Operations Manager",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "operations-manager",
+      "source_key": "actors",
+      "source_round": 3,
+      "text": "Operations Manager"
+    },
+    {
+      "attributes": {
+        "complexity": "simple"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_3",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "3958318885b97c2a",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "informative",
+      "family": "actors",
+      "id": "payment-gateway",
+      "missing_fields": [],
+      "name": "Payment Gateway",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "payment-gateway",
+      "source_key": "actors",
+      "source_round": 3,
+      "text": "Payment Gateway"
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_5",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "31ed3a5922b7f6f7",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "business_rules",
+      "id": "business-rule-1",
+      "missing_fields": [],
+      "name": "Rule 1",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "business-rule-1",
+      "source_key": "business_rules",
+      "source_round": 5,
+      "text": "A Redemption must not be fulfilled unless reward eligibility and available points are confirmed."
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_5",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "c647a6ca1c45f1eb",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "business_rules",
+      "id": "business-rule-2",
+      "missing_fields": [],
+      "name": "Rule 2",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "business-rule-2",
+      "source_key": "business_rules",
+      "source_round": 5,
+      "text": "A Reward Catalog Entry must be validated before it becomes Published."
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_5",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "0a51c9b642e8f7bb",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "business_rules",
+      "id": "business-rule-3",
+      "missing_fields": [],
+      "name": "Rule 3",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "business-rule-3",
+      "source_key": "business_rules",
+      "source_round": 5,
+      "text": "A Member must provide the required details and consents before enrollment completes."
+    },
+    {
+      "attributes": {
+        "component_kind": "service"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_7",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "825204eaa1cc1e79",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "informative",
+      "family": "components",
+      "id": "component-analytics-service",
+      "missing_fields": [],
+      "name": "Analytics Service",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "component-analytics-service",
+      "source_key": "components_and_services",
+      "source_round": 7,
+      "text": "Analytics Service"
+    },
+    {
+      "attributes": {
+        "component_kind": "api"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_7",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "380953097eae22f1",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "informative",
+      "family": "components",
+      "id": "component-loyalty-api",
+      "missing_fields": [],
+      "name": "Loyalty API",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "component-loyalty-api",
+      "source_key": "components_and_services",
+      "source_round": 7,
+      "text": "Loyalty API"
+    },
+    {
+      "attributes": {
+        "component_kind": "component"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_7",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "485e0e9ff431ce7c",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "informative",
+      "family": "components",
+      "id": "component-member-app",
+      "missing_fields": [],
+      "name": "Member App",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "component-member-app",
+      "source_key": "components_and_services",
+      "source_round": 7,
+      "text": "Member App"
+    },
+    {
+      "attributes": {
+        "component_kind": "component"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_7",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "7edbfa3a396b9716",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "informative",
+      "family": "components",
+      "id": "component-operations-console",
+      "missing_fields": [],
+      "name": "Operations Console",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "component-operations-console",
+      "source_key": "components_and_services",
+      "source_round": 7,
+      "text": "Operations Console"
+    },
+    {
+      "attributes": {
+        "component_kind": "component"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_7",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "59fe92cc65024873",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "informative",
+      "family": "components",
+      "id": "component-payment-gateway-adapter",
+      "missing_fields": [],
+      "name": "Payment Gateway Adapter",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "component-payment-gateway-adapter",
+      "source_key": "components_and_services",
+      "source_round": 7,
+      "text": "Payment Gateway Adapter"
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_5",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "2dae1906e4d468a1",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "domain_entities",
+      "id": "entity-analytics-report",
+      "missing_fields": [],
+      "name": "Analytics Report",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "entity-analytics-report",
+      "source_key": "domain_entities",
+      "source_round": 5,
+      "text": "Analytics Report"
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_5",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "6201c0d87098e9ce",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "domain_entities",
+      "id": "entity-campaign",
+      "missing_fields": [],
+      "name": "Campaign",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "entity-campaign",
+      "source_key": "domain_entities",
+      "source_round": 5,
+      "text": "Campaign"
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_5",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "88db15323024bb83",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "domain_entities",
+      "id": "entity-member",
+      "missing_fields": [],
+      "name": "Member",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "entity-member",
+      "source_key": "domain_entities",
+      "source_round": 5,
+      "text": "Member"
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_5",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "636404d9ab89daba",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "domain_entities",
+      "id": "entity-payment-confirmation",
+      "missing_fields": [],
+      "name": "Payment Confirmation",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "entity-payment-confirmation",
+      "source_key": "domain_entities",
+      "source_round": 5,
+      "text": "Payment Confirmation"
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_5",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "00eaa33d6b332bcb",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "domain_entities",
+      "id": "entity-redemption",
+      "missing_fields": [],
+      "name": "Redemption",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "entity-redemption",
+      "source_key": "domain_entities",
+      "source_round": 5,
+      "text": "Redemption"
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_5",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "c77a1b736f14366c",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "domain_entities",
+      "id": "entity-reward",
+      "missing_fields": [],
+      "name": "Reward",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "entity-reward",
+      "source_key": "domain_entities",
+      "source_round": 5,
+      "text": "Reward"
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_5",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "2df4a67e03f7f9a6",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "domain_entities",
+      "id": "entity-reward-catalog-entry",
+      "missing_fields": [],
+      "name": "Reward Catalog Entry",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "entity-reward-catalog-entry",
+      "source_key": "domain_entities",
+      "source_round": 5,
+      "text": "Reward Catalog Entry"
+    },
+    {
+      "attributes": {
+        "scope_entity_ids": [
+          "entity-reward",
+          "entity-redemption"
+        ],
+        "source_business_rule_id": "business-rule-1"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_domain_invariants",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "9bdd873c55f95c20",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "domain_invariants",
+      "id": "domain-invariant-1",
+      "missing_fields": [],
+      "name": "Rule 1",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "domain-invariant-1",
+      "source_key": "business_rules",
+      "source_round": 5,
+      "text": "A Redemption must not be fulfilled unless reward eligibility and available points are confirmed."
+    },
+    {
+      "attributes": {
+        "scope_entity_ids": [
+          "entity-reward",
+          "entity-reward-catalog-entry"
+        ],
+        "source_business_rule_id": "business-rule-2"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_domain_invariants",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "a637b3e22f50cdd4",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "domain_invariants",
+      "id": "domain-invariant-2",
+      "missing_fields": [],
+      "name": "Rule 2",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "domain-invariant-2",
+      "source_key": "business_rules",
+      "source_round": 5,
+      "text": "A Reward Catalog Entry must be validated before it becomes Published."
+    },
+    {
+      "attributes": {
+        "scope_entity_ids": [
+          "entity-member"
+        ],
+        "source_business_rule_id": "business-rule-3"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_domain_invariants",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "c2cf041e428bfa76",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "domain_invariants",
+      "id": "domain-invariant-3",
+      "missing_fields": [],
+      "name": "Rule 3",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "domain-invariant-3",
+      "source_key": "business_rules",
+      "source_round": 5,
+      "text": "A Member must provide the required details and consents before enrollment completes."
+    },
+    {
+      "attributes": {
+        "source_business_rule_id": "business-rule-1"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_forbidden_transitions",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "793aa682141bec56",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "forbidden_transitions",
+      "id": "forbidden-transition-1",
+      "missing_fields": [],
+      "name": "Forbidden Transition 1",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "forbidden-transition-1",
+      "source_key": "business_rules",
+      "source_round": 5,
+      "text": "A Redemption must not be fulfilled unless reward eligibility and available points are confirmed."
+    },
+    {
+      "attributes": {
+        "requirement_kind": "functional"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "requirements",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "50ca3d7990de2576",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "functional_requirements",
+      "id": "functional-requirement-1",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "functional-requirement-1",
+      "source_key": "workflow_scope",
+      "source_round": 4,
+      "text": "The system must allow operations managers to maintain reward catalog entries and campaign rules."
+    },
+    {
+      "attributes": {
+        "requirement_kind": "functional"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "requirements",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "137be52a3e449f36",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "functional_requirements",
+      "id": "functional-requirement-2",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "functional-requirement-2",
+      "source_key": "integrations",
+      "source_round": 3,
+      "text": "The platform must integrate with payment confirmation and downstream reporting sources."
+    },
+    {
+      "attributes": {
+        "source_trigger_id": "trigger-1",
+        "state_entity_ids": [
+          "state-entity-redemption"
+        ]
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_guard_conditions",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "5af79f330a184976",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "guard_conditions",
+      "id": "guard-condition-1",
+      "missing_fields": [
+        "related_transition_ids"
+      ],
+      "name": "Payment confirmation",
+      "normative_ready": false,
+      "readiness_status": "blocked",
+      "semantic_id": "guard-condition-1",
+      "source_key": "triggers_and_approvals",
+      "source_round": 6,
+      "text": "Payment confirmation triggers redemption fulfillment"
+    },
+    {
+      "attributes": {
+        "related_transition_ids": [
+          "state-transition-1",
+          "state-transition-2",
+          "state-transition-3",
+          "state-transition-4",
+          "state-transition-5"
+        ],
+        "source_trigger_id": "trigger-2"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_guard_conditions",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "8c5e2e061f6f6c0b",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "guard_conditions",
+      "id": "guard-condition-2",
+      "missing_fields": [],
+      "name": "Guard Condition 2",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "guard-condition-2",
+      "source_key": "triggers_and_approvals",
+      "source_round": 6,
+      "text": "Catalog validation approval is required before a reward becomes Published"
+    },
+    {
+      "attributes": {
+        "interaction_verb": "calls"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_interaction_view",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "d81ef89599054303",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "",
+      "family": "interaction_messages",
+      "id": "interaction-message-1",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "interaction-message-1",
+      "source_key": "interfaces_and_integrations",
+      "source_round": 7,
+      "text": "Member App calls Loyalty API"
+    },
+    {
+      "attributes": {
+        "interaction_verb": "calls"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_interaction_view",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "b9c14dee92d31afe",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "",
+      "family": "interaction_messages",
+      "id": "interaction-message-2",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "interaction-message-2",
+      "source_key": "interfaces_and_integrations",
+      "source_round": 7,
+      "text": "Operations Console calls Loyalty API"
+    },
+    {
+      "attributes": {
+        "interaction_verb": "calls"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_interaction_view",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "1c5a2beab2b1083f",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "",
+      "family": "interaction_messages",
+      "id": "interaction-message-3",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "interaction-message-3",
+      "source_key": "interfaces_and_integrations",
+      "source_round": 7,
+      "text": "Loyalty API calls Payment Gateway Adapter"
+    },
+    {
+      "attributes": {
+        "interaction_verb": "sends"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_interaction_view",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "7d39ed8491c50cd0",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "",
+      "family": "interaction_messages",
+      "id": "interaction-message-4",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "interaction-message-4",
+      "source_key": "interfaces_and_integrations",
+      "source_round": 7,
+      "text": "Loyalty API sends Analytics Service"
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_interaction_view",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "2afd4f714cbb6387",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "",
+      "family": "interaction_realizations",
+      "id": "interaction-realization-1",
+      "missing_fields": [],
+      "name": "Enroll Member",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "interaction-realization-1",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": ""
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_interaction_view",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "03bda7f663ea5513",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "",
+      "family": "interaction_realizations",
+      "id": "interaction-realization-2",
+      "missing_fields": [],
+      "name": "Browse Rewards",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "interaction-realization-2",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": ""
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_interaction_view",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "6e6e35c313c02a6c",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "",
+      "family": "interaction_realizations",
+      "id": "interaction-realization-3",
+      "missing_fields": [],
+      "name": "Redeem Reward",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "interaction-realization-3",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": ""
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_interaction_view",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "2e012933135718dd",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "",
+      "family": "interaction_realizations",
+      "id": "interaction-realization-4",
+      "missing_fields": [],
+      "name": "Manage Reward Catalog",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "interaction-realization-4",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": ""
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_interaction_view",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "12255a520e6ed1e3",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "",
+      "family": "interaction_realizations",
+      "id": "interaction-realization-5",
+      "missing_fields": [],
+      "name": "Review Redemption Analytics",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "interaction-realization-5",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": ""
+    },
+    {
+      "attributes": {
+        "interaction_verb": "calls",
+        "source_component_id": "component-member-app",
+        "target_component_id": "component-loyalty-api"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_7",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "a3984a295ae19859",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "informative",
+      "family": "interfaces",
+      "id": "interface-1",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "interface-1",
+      "source_key": "interfaces_and_integrations",
+      "source_round": 7,
+      "text": "Member App calls Loyalty API"
+    },
+    {
+      "attributes": {
+        "interaction_verb": "calls",
+        "source_component_id": "component-operations-console",
+        "target_component_id": "component-loyalty-api"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_7",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "e0ecb350f7ee466a",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "informative",
+      "family": "interfaces",
+      "id": "interface-2",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "interface-2",
+      "source_key": "interfaces_and_integrations",
+      "source_round": 7,
+      "text": "Operations Console calls Loyalty API"
+    },
+    {
+      "attributes": {
+        "interaction_verb": "calls",
+        "source_component_id": "component-loyalty-api",
+        "target_component_id": "component-payment-gateway-adapter"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_7",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "baf47c736888625f",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "informative",
+      "family": "interfaces",
+      "id": "interface-3",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "interface-3",
+      "source_key": "interfaces_and_integrations",
+      "source_round": 7,
+      "text": "Loyalty API calls Payment Gateway Adapter"
+    },
+    {
+      "attributes": {
+        "interaction_verb": "sends",
+        "source_component_id": "component-loyalty-api",
+        "target_component_id": "component-analytics-service"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_7",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "fcd26a3322838b1a",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "informative",
+      "family": "interfaces",
+      "id": "interface-4",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "interface-4",
+      "source_key": "interfaces_and_integrations",
+      "source_round": 7,
+      "text": "Loyalty API sends Analytics Service"
+    },
+    {
+      "attributes": {
+        "requirement_kind": "non_functional"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "requirements",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "6d25cd70cc309bd6",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "non_functional_requirements",
+      "id": "non_functional-requirement-1",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "non_functional-requirement-1",
+      "source_key": "constraints",
+      "source_round": 2,
+      "text": "The system must protect member and reward transactions with appropriate security controls."
+    },
+    {
+      "attributes": {
+        "requirement_kind": "non_functional"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "requirements",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "3c50cc9fdf143ffc",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "non_functional_requirements",
+      "id": "non_functional-requirement-2",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "non_functional-requirement-2",
+      "source_key": "constraints",
+      "source_round": 2,
+      "text": "The member-facing experience must remain usable on common digital channels."
+    },
+    {
+      "attributes": {
+        "requirement_kind": "non_functional"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "requirements",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "123d736840c12b01",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "non_functional_requirements",
+      "id": "non_functional-requirement-3",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "non_functional-requirement-3",
+      "source_key": "constraints",
+      "source_round": 2,
+      "text": "The platform must support integrations with external systems such as payment confirmation and reporting sources."
+    },
+    {
+      "attributes": {
+        "requirement_kind": "non_functional"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "requirements",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "91b01cf0f9df4489",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "non_functional_requirements",
+      "id": "non_functional-requirement-4",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "non_functional-requirement-4",
+      "source_key": "non_functional_requirements",
+      "source_round": 4,
+      "text": "The system must allow customers to enroll in the loyalty program digitally."
+    },
+    {
+      "attributes": {
+        "requirement_kind": "non_functional"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "requirements",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "c869b78025ab245a",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "non_functional_requirements",
+      "id": "non_functional-requirement-5",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "non_functional-requirement-5",
+      "source_key": "non_functional_requirements",
+      "source_round": 4,
+      "text": "The system must show point balance and available rewards to eligible members."
+    },
+    {
+      "attributes": {
+        "linked_use_case_ids": [
+          "redeem-reward"
+        ],
+        "requirement_kind": "non_functional"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "requirements",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "5f03cdaaa89ad4e1",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "non_functional_requirements",
+      "id": "non_functional-requirement-6",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "non_functional-requirement-6",
+      "source_key": "non_functional_requirements",
+      "source_round": 4,
+      "text": "The system must allow members to redeem rewards when eligibility conditions are satisfied."
+    },
+    {
+      "attributes": {
+        "requirement_kind": "non_functional"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "requirements",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "925c5506da0bb97a",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "non_functional_requirements",
+      "id": "non_functional-requirement-7",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "non_functional-requirement-7",
+      "source_key": "non_functional_requirements",
+      "source_round": 4,
+      "text": "The system must provide reporting on redemptions and campaign performance."
+    },
+    {
+      "attributes": {
+        "source_entity_id": "entity-member",
+        "target_entity_id": "entity-redemption"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_5",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "53cea002c83a9170",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "relationships",
+      "id": "relationship-1",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "relationship-1",
+      "source_key": "relationships",
+      "source_round": 5,
+      "text": "A Member has many Redemptions"
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_5",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "a9a577dfd3c66013",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "relationships",
+      "id": "relationship-2",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "relationship-2",
+      "source_key": "relationships",
+      "source_round": 5,
+      "text": "A Reward Catalog Entry has one Reward"
+    },
+    {
+      "attributes": {
+        "source_entity_id": "entity-campaign",
+        "target_entity_id": "entity-reward-catalog-entry"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_5",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "a1a2ce18eb6193fc",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "relationships",
+      "id": "relationship-3",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "relationship-3",
+      "source_key": "relationships",
+      "source_round": 5,
+      "text": "A Campaign has many Reward Catalog Entries"
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_5",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "8042da34054a4968",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "relationships",
+      "id": "relationship-4",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "relationship-4",
+      "source_key": "relationships",
+      "source_round": 5,
+      "text": "A Redemption has one Payment Confirmation"
+    },
+    {
+      "attributes": {
+        "source_entity_id": "entity-analytics-report",
+        "target_entity_id": "entity-redemption"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_5",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "d221c438f9391632",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "relationships",
+      "id": "relationship-5",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "relationship-5",
+      "source_key": "relationships",
+      "source_round": 5,
+      "text": "An Analytics Report has many Redemptions"
+    },
+    {
+      "attributes": {
+        "priority": "high",
+        "status": "open"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_12",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "959edee70758d343",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "informative",
+      "family": "risks",
+      "id": "risk-payment-confirmation-dependency",
+      "missing_fields": [],
+      "name": "Payment confirmation dependency",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "risk-payment-confirmation-dependency",
+      "source_key": "risks",
+      "source_round": 12,
+      "text": "Payment confirmation dependency"
+    },
+    {
+      "attributes": {
+        "priority": "medium",
+        "status": "open"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_12",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "48493fb41f5362d7",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "informative",
+      "family": "risks",
+      "id": "risk-reporting-latency",
+      "missing_fields": [],
+      "name": "Reporting latency",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "risk-reporting-latency",
+      "source_key": "risks",
+      "source_round": 12,
+      "text": "Reporting latency"
+    },
+    {
+      "attributes": {
+        "priority": "medium",
+        "status": "open"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_12",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "d4eb70816cb7a815",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "informative",
+      "family": "risks",
+      "id": "risk-reward-configuration-errors",
+      "missing_fields": [],
+      "name": "Reward configuration errors",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "risk-reward-configuration-errors",
+      "source_key": "risks",
+      "source_round": 12,
+      "text": "Reward configuration errors"
+    },
+    {
+      "attributes": {
+        "boundary_type": "runtime_separation"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_7",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "fb259936168e3113",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "informative",
+      "family": "runtime_boundaries",
+      "id": "runtime-boundary-1",
+      "missing_fields": [],
+      "name": "Runtime Boundary 1",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "runtime-boundary-1",
+      "source_key": "runtime_boundaries",
+      "source_round": 7,
+      "text": "Member-facing apps and operations console run separately from the core API"
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_7",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "3760f53ac22faa26",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "informative",
+      "family": "runtime_boundaries",
+      "id": "runtime-boundary-2",
+      "missing_fields": [],
+      "name": "Runtime Boundary 2",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "runtime-boundary-2",
+      "source_key": "runtime_boundaries",
+      "source_round": 7,
+      "text": "Payment Gateway Adapter crosses an external boundary"
+    },
+    {
+      "attributes": {
+        "flow_of_events": [
+          "Operations Manager updates reward configuration.",
+          "System validates the change.",
+          "System rejects the invalid change."
+        ],
+        "priority": "medium",
+        "status": "open"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_13",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "08157c043930c28b",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "scenarios",
+      "id": "scenario-invalid-catalog-change",
+      "missing_fields": [],
+      "name": "Invalid Catalog Change",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "scenario-invalid-catalog-change",
+      "source_key": "scenarios",
+      "source_round": 13,
+      "text": "Publication is rejected because the new reward configuration would break an active offer."
+    },
+    {
+      "attributes": {
+        "flow_of_events": [
+          "Customer selects a reward.",
+          "System requests payment confirmation.",
+          "System blocks fulfillment until confirmation arrives."
+        ],
+        "priority": "medium",
+        "status": "open"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_13",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "1467185c4aeb36b1",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "scenarios",
+      "id": "scenario-missing-payment-confirmation",
+      "missing_fields": [],
+      "name": "Missing Payment Confirmation",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "scenario-missing-payment-confirmation",
+      "source_key": "scenarios",
+      "source_round": 13,
+      "text": "Redemption pauses until dependent payment confirmation arrives."
+    },
+    {
+      "attributes": {
+        "flow_of_events": [
+          "Operations Manager opens the analytics dashboard.",
+          "System detects delayed reporting data.",
+          "System shows a partial-data warning."
+        ],
+        "priority": "low",
+        "status": "open"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_13",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "1e8c371b106e161c",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "scenarios",
+      "id": "scenario-reporting-delay",
+      "missing_fields": [],
+      "name": "Reporting Delay",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "scenario-reporting-delay",
+      "source_key": "scenarios",
+      "source_round": 13,
+      "text": "Analytics view is partial because a reporting source is delayed."
+    },
+    {
+      "attributes": {
+        "flow_of_events": [
+          "Customer selects a reward.",
+          "System checks reward availability.",
+          "System reports that inventory is exhausted."
+        ],
+        "priority": "high",
+        "status": "open"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_13",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "f0edac8165649917",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "scenarios",
+      "id": "scenario-reward-inventory-exhausted",
+      "missing_fields": [],
+      "name": "Reward Inventory Exhausted",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "scenario-reward-inventory-exhausted",
+      "source_key": "scenarios",
+      "source_round": 13,
+      "text": "Redemption fails because no reward inventory remains."
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_6",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "43f1a133415a38bb",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "state_entities",
+      "id": "state-entity-redemption",
+      "missing_fields": [],
+      "name": "Redemption",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "state-entity-redemption",
+      "source_key": "state_entities",
+      "source_round": 6,
+      "text": "Redemption"
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_6",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "c145d5a38fe40ca1",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "state_entities",
+      "id": "state-entity-reward-catalog-entry",
+      "missing_fields": [],
+      "name": "Reward Catalog Entry",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "state-entity-reward-catalog-entry",
+      "source_key": "state_entities",
+      "source_round": 6,
+      "text": "Reward Catalog Entry"
+    },
+    {
+      "attributes": {
+        "source_business_rule_id": "business-rule-1",
+        "state_entity_ids": [
+          "state-entity-redemption"
+        ]
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_state_invariants",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "1001f94a08fd8f05",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "state_invariants",
+      "id": "state-invariant-1",
+      "missing_fields": [],
+      "name": "Rule 1",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "state-invariant-1",
+      "source_key": "business_rules",
+      "source_round": 5,
+      "text": "A Redemption must not be fulfilled unless reward eligibility and available points are confirmed."
+    },
+    {
+      "attributes": {
+        "source_business_rule_id": "business-rule-2",
+        "state_entity_ids": [
+          "state-entity-reward-catalog-entry"
+        ]
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_state_invariants",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "da255172f2fcc35e",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "state_invariants",
+      "id": "state-invariant-2",
+      "missing_fields": [],
+      "name": "Rule 2",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "state-invariant-2",
+      "source_key": "business_rules",
+      "source_round": 5,
+      "text": "A Reward Catalog Entry must be validated before it becomes Published."
+    },
+    {
+      "attributes": {
+        "from_state": "Requested",
+        "state_entity_id": "state-entity-redemption",
+        "to_state": "Validated"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_6",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "d5953bdf2d9317ff",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "state_transitions",
+      "id": "state-transition-1",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "state-transition-1",
+      "source_key": "states_and_transitions",
+      "source_round": 6,
+      "text": "Redemption: Requested -> Validated -> Fulfilled"
+    },
+    {
+      "attributes": {
+        "from_state": "Validated",
+        "state_entity_id": "state-entity-redemption",
+        "to_state": "Fulfilled"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_6",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "11aeec55110ebd28",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "state_transitions",
+      "id": "state-transition-2",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "state-transition-2",
+      "source_key": "states_and_transitions",
+      "source_round": 6,
+      "text": "Redemption: Requested -> Validated -> Fulfilled"
+    },
+    {
+      "attributes": {
+        "from_state": "Requested",
+        "state_entity_id": "state-entity-redemption",
+        "to_state": "Rejected"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_6",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "e46f9325295e1da2",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "state_transitions",
+      "id": "state-transition-3",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "state-transition-3",
+      "source_key": "states_and_transitions",
+      "source_round": 6,
+      "text": "Redemption: Requested -> Rejected"
+    },
+    {
+      "attributes": {
+        "from_state": "Draft",
+        "state_entity_id": "state-entity-reward-catalog-entry",
+        "to_state": "Published"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_6",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "25b25e4f3f2e7e93",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "state_transitions",
+      "id": "state-transition-4",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "state-transition-4",
+      "source_key": "states_and_transitions",
+      "source_round": 6,
+      "text": "Reward Catalog Entry: Draft -> Published -> Retired"
+    },
+    {
+      "attributes": {
+        "from_state": "Published",
+        "state_entity_id": "state-entity-reward-catalog-entry",
+        "to_state": "Retired"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_6",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "321f360989484fde",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "state_transitions",
+      "id": "state-transition-5",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "state-transition-5",
+      "source_key": "states_and_transitions",
+      "source_round": 6,
+      "text": "Reward Catalog Entry: Draft -> Published -> Retired"
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_6",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "e538e9a9d69eae52",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "triggers",
+      "id": "trigger-1",
+      "missing_fields": [],
+      "name": "Payment confirmation",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "trigger-1",
+      "source_key": "triggers_and_approvals",
+      "source_round": 6,
+      "text": "Payment confirmation triggers redemption fulfillment"
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_6",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "1f509a6eabb650c0",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "triggers",
+      "id": "trigger-2",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": false,
+      "readiness_status": "",
+      "semantic_id": "trigger-2",
+      "source_key": "triggers_and_approvals",
+      "source_round": 6,
+      "text": "Catalog validation approval is required before a reward becomes Published"
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_use_case_steps",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "ef38d2cd32f6264d",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_case_steps",
+      "id": "browse-rewards-extension-1",
+      "missing_fields": [],
+      "name": "Browse Rewards",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "browse-rewards-extension-1",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "Catalog view degrades if an integration is temporarily unavailable."
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_use_case_steps",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "895b68cbcc6073f9",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_case_steps",
+      "id": "browse-rewards-step-1",
+      "missing_fields": [],
+      "name": "Browse Rewards",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "browse-rewards-step-1",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "Customer opens the rewards catalog."
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_use_case_steps",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "dd86222bb48004ab",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_case_steps",
+      "id": "browse-rewards-step-2",
+      "missing_fields": [],
+      "name": "Browse Rewards",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "browse-rewards-step-2",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "System displays available rewards and points balance."
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_use_case_steps",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "96b05cd90d750571",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_case_steps",
+      "id": "browse-rewards-step-3",
+      "missing_fields": [],
+      "name": "Browse Rewards",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "browse-rewards-step-3",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "Customer filters or sorts the catalog."
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_use_case_steps",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "5084306fb28e98a8",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_case_steps",
+      "id": "enroll-member-extension-1",
+      "missing_fields": [],
+      "name": "Enroll Member",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "enroll-member-extension-1",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "Enrollment is blocked when required consent is missing."
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_use_case_steps",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "e7ec46c41fe9cf12",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_case_steps",
+      "id": "enroll-member-step-1",
+      "missing_fields": [],
+      "name": "Enroll Member",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "enroll-member-step-1",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "Customer opens the loyalty enrollment flow."
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_use_case_steps",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "8c937b53f0ae3e91",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_case_steps",
+      "id": "enroll-member-step-2",
+      "missing_fields": [],
+      "name": "Enroll Member",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "enroll-member-step-2",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "Customer provides the required details and consents."
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_use_case_steps",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "13ee1230b8fb95f9",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_case_steps",
+      "id": "enroll-member-step-3",
+      "missing_fields": [],
+      "name": "Enroll Member",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "enroll-member-step-3",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "System validates the submission and creates the member account."
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_use_case_steps",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "52b5017dbd2c3ecf",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_case_steps",
+      "id": "manage-reward-catalog-extension-1",
+      "missing_fields": [],
+      "name": "Manage Reward Catalog",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "manage-reward-catalog-extension-1",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "A change is rejected because it would make an active reward invalid."
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_use_case_steps",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "3018683e51bb8375",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_case_steps",
+      "id": "manage-reward-catalog-step-1",
+      "missing_fields": [],
+      "name": "Manage Reward Catalog",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "manage-reward-catalog-step-1",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "Operations Manager opens catalog administration."
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_use_case_steps",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "0c9fe51d87cb9b58",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_case_steps",
+      "id": "manage-reward-catalog-step-2",
+      "missing_fields": [],
+      "name": "Manage Reward Catalog",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "manage-reward-catalog-step-2",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "Operations Manager updates reward configuration."
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_use_case_steps",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "7dc4a38b3ca526b1",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_case_steps",
+      "id": "manage-reward-catalog-step-3",
+      "missing_fields": [],
+      "name": "Manage Reward Catalog",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "manage-reward-catalog-step-3",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "System validates and publishes the change."
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_use_case_steps",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "187482a4d085efc5",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_case_steps",
+      "id": "redeem-reward-extension-1",
+      "missing_fields": [],
+      "name": "Redeem Reward",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "redeem-reward-extension-1",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "Reward inventory is exhausted before completion."
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_use_case_steps",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "00dfc60e4b370401",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_case_steps",
+      "id": "redeem-reward-extension-2",
+      "missing_fields": [],
+      "name": "Redeem Reward",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "redeem-reward-extension-2",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "Customer does not have enough points."
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_use_case_steps",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "f97975616da77c4d",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_case_steps",
+      "id": "redeem-reward-extension-3",
+      "missing_fields": [],
+      "name": "Redeem Reward",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "redeem-reward-extension-3",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "Payment confirmation is missing for a reward that depends on purchase completion."
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_use_case_steps",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "dcf9844b30ea0150",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_case_steps",
+      "id": "redeem-reward-step-1",
+      "missing_fields": [],
+      "name": "Redeem Reward",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "redeem-reward-step-1",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "Customer selects a reward."
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_use_case_steps",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "c92276c94c67212a",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_case_steps",
+      "id": "redeem-reward-step-2",
+      "missing_fields": [],
+      "name": "Redeem Reward",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "redeem-reward-step-2",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "System validates reward eligibility and available points."
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_use_case_steps",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "1c4797621e3c0bc5",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_case_steps",
+      "id": "redeem-reward-step-3",
+      "missing_fields": [],
+      "name": "Redeem Reward",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "redeem-reward-step-3",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "System reserves the reward and updates the member balance."
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_use_case_steps",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "6b2b2b1e56451842",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_case_steps",
+      "id": "redeem-reward-step-4",
+      "missing_fields": [],
+      "name": "Redeem Reward",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "redeem-reward-step-4",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "System confirms redemption to the customer."
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_use_case_steps",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "32969fc50ee511ae",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_case_steps",
+      "id": "review-redemption-analytics-extension-1",
+      "missing_fields": [],
+      "name": "Review Redemption Analytics",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "review-redemption-analytics-extension-1",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "A reporting data source is delayed."
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_use_case_steps",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "2ad74b487836732e",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_case_steps",
+      "id": "review-redemption-analytics-step-1",
+      "missing_fields": [],
+      "name": "Review Redemption Analytics",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "review-redemption-analytics-step-1",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "Operations Manager opens the analytics dashboard."
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_use_case_steps",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "c20a2d3b710b92b7",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_case_steps",
+      "id": "review-redemption-analytics-step-2",
+      "missing_fields": [],
+      "name": "Review Redemption Analytics",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "review-redemption-analytics-step-2",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "System shows redemption and campaign metrics."
+    },
+    {
+      "attributes": {
+        "complexity": "average",
+        "extensions": [
+          "Catalog view degrades if an integration is temporarily unavailable."
+        ],
+        "main_success_scenario": [
+          "Customer opens the rewards catalog.",
+          "System displays available rewards and points balance.",
+          "Customer filters or sorts the catalog."
+        ],
+        "postconditions": [
+          "Eligible rewards and point balance are visible"
+        ],
+        "preconditions": [
+          "Member is enrolled"
+        ],
+        "priority": "high",
+        "status": "confirmed"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_3",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "88feb125b5f936b0",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_cases",
+      "id": "browse-rewards",
+      "missing_fields": [],
+      "name": "Browse Rewards",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "browse-rewards",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "Browse Rewards"
+    },
+    {
+      "attributes": {
+        "complexity": "simple",
+        "extensions": [
+          "Enrollment is blocked when required consent is missing."
+        ],
+        "main_success_scenario": [
+          "Customer opens the loyalty enrollment flow.",
+          "Customer provides the required details and consents.",
+          "System validates the submission and creates the member account."
+        ],
+        "postconditions": [
+          "Member account exists and is active"
+        ],
+        "preconditions": [
+          "Customer is not already enrolled"
+        ],
+        "priority": "high",
+        "status": "confirmed"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_3",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "e3815fbbb87f8b5d",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_cases",
+      "id": "enroll-member",
+      "missing_fields": [],
+      "name": "Enroll Member",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "enroll-member",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "Enroll Member"
+    },
+    {
+      "attributes": {
+        "complexity": "average",
+        "extensions": [
+          "A change is rejected because it would make an active reward invalid."
+        ],
+        "main_success_scenario": [
+          "Operations Manager opens catalog administration.",
+          "Operations Manager updates reward configuration.",
+          "System validates and publishes the change."
+        ],
+        "postconditions": [
+          "Reward catalog change is published"
+        ],
+        "preconditions": [
+          "Operations Manager is authenticated"
+        ],
+        "priority": "medium",
+        "scenario_ids": [
+          "scenario-invalid-catalog-change"
+        ],
+        "status": "confirmed"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_3",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "7b9ec30b01092bc0",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_cases",
+      "id": "manage-reward-catalog",
+      "missing_fields": [],
+      "name": "Manage Reward Catalog",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "manage-reward-catalog",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "Manage Reward Catalog"
+    },
+    {
+      "attributes": {
+        "complexity": "complex",
+        "extensions": [
+          "Reward inventory is exhausted before completion.",
+          "Customer does not have enough points.",
+          "Payment confirmation is missing for a reward that depends on purchase completion."
+        ],
+        "main_success_scenario": [
+          "Customer selects a reward.",
+          "System validates reward eligibility and available points.",
+          "System reserves the reward and updates the member balance.",
+          "System confirms redemption to the customer."
+        ],
+        "postconditions": [
+          "Redemption is recorded and balance is updated"
+        ],
+        "preconditions": [
+          "Member is enrolled",
+          "Reward is available"
+        ],
+        "priority": "high",
+        "scenario_ids": [
+          "scenario-reward-inventory-exhausted",
+          "scenario-missing-payment-confirmation"
+        ],
+        "status": "confirmed"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_3",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "ff5a198c0a1a3706",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_cases",
+      "id": "redeem-reward",
+      "missing_fields": [],
+      "name": "Redeem Reward",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "redeem-reward",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "Redeem Reward"
+    },
+    {
+      "attributes": {
+        "complexity": "simple",
+        "extensions": [
+          "A reporting data source is delayed."
+        ],
+        "main_success_scenario": [
+          "Operations Manager opens the analytics dashboard.",
+          "System shows redemption and campaign metrics."
+        ],
+        "postconditions": [
+          "Operations Manager can inspect campaign and redemption metrics"
+        ],
+        "preconditions": [
+          "Reporting data is available"
+        ],
+        "priority": "medium",
+        "scenario_ids": [
+          "scenario-reporting-delay"
+        ],
+        "status": "confirmed"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_3",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "3504f84a0df0905e",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_cases",
+      "id": "review-redemption-analytics",
+      "missing_fields": [],
+      "name": "Review Redemption Analytics",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "review-redemption-analytics",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "Review Redemption Analytics"
+    }
+  ],
   "export_metadata": {
     "export_kind": "speckify_planning_export",
     "schema_version": 1,
-    "source_model_change_metadata": {},
-    "source_model_semantic_id": ""
+    "source_model_change_metadata": {
+      "change_source": "normalize_replay_to_model",
+      "last_changed_at": "",
+      "regenerated_from_version": "",
+      "semantic_hash": "f53b334e86e54b91",
+      "semantic_version": 1,
+      "supersedes": []
+    },
+    "source_model_semantic_id": "rupify-model"
   },
-  "ready_normative_elements": [],
+  "ready_normative_elements": [
+    {
+      "attributes": {
+        "constraint_kind": "non_functional_requirement",
+        "source_requirement_id": "non_functional-requirement-1"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_acceptance_constraints",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "94812897dc06184b",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "acceptance_constraints",
+      "id": "acceptance-constraint-requirement-1",
+      "missing_fields": [],
+      "name": "Acceptance Constraint 1",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "acceptance-constraint-requirement-1",
+      "source_key": "constraints",
+      "source_round": 2,
+      "text": "The system must protect member and reward transactions with appropriate security controls."
+    },
+    {
+      "attributes": {
+        "constraint_kind": "non_functional_requirement",
+        "source_requirement_id": "non_functional-requirement-2"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_acceptance_constraints",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "9dc0f244dacd87c2",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "acceptance_constraints",
+      "id": "acceptance-constraint-requirement-2",
+      "missing_fields": [],
+      "name": "Acceptance Constraint 2",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "acceptance-constraint-requirement-2",
+      "source_key": "constraints",
+      "source_round": 2,
+      "text": "The member-facing experience must remain usable on common digital channels."
+    },
+    {
+      "attributes": {
+        "constraint_kind": "non_functional_requirement",
+        "source_requirement_id": "non_functional-requirement-3"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_acceptance_constraints",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "2ff2dee2880ffd8d",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "acceptance_constraints",
+      "id": "acceptance-constraint-requirement-3",
+      "missing_fields": [],
+      "name": "Acceptance Constraint 3",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "acceptance-constraint-requirement-3",
+      "source_key": "constraints",
+      "source_round": 2,
+      "text": "The platform must support integrations with external systems such as payment confirmation and reporting sources."
+    },
+    {
+      "attributes": {
+        "constraint_kind": "non_functional_requirement",
+        "source_requirement_id": "non_functional-requirement-4"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_acceptance_constraints",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "257c1792f5ca8674",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "acceptance_constraints",
+      "id": "acceptance-constraint-requirement-4",
+      "missing_fields": [],
+      "name": "Acceptance Constraint 4",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "acceptance-constraint-requirement-4",
+      "source_key": "non_functional_requirements",
+      "source_round": 4,
+      "text": "The system must allow customers to enroll in the loyalty program digitally."
+    },
+    {
+      "attributes": {
+        "constraint_kind": "non_functional_requirement",
+        "source_requirement_id": "non_functional-requirement-5"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_acceptance_constraints",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "bd76e87bf7d763f7",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "acceptance_constraints",
+      "id": "acceptance-constraint-requirement-5",
+      "missing_fields": [],
+      "name": "Acceptance Constraint 5",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "acceptance-constraint-requirement-5",
+      "source_key": "non_functional_requirements",
+      "source_round": 4,
+      "text": "The system must show point balance and available rewards to eligible members."
+    },
+    {
+      "attributes": {
+        "constraint_kind": "non_functional_requirement",
+        "source_requirement_id": "non_functional-requirement-6"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_acceptance_constraints",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "a705e18f2183b881",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "acceptance_constraints",
+      "id": "acceptance-constraint-requirement-6",
+      "missing_fields": [],
+      "name": "Acceptance Constraint 6",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "acceptance-constraint-requirement-6",
+      "source_key": "non_functional_requirements",
+      "source_round": 4,
+      "text": "The system must allow members to redeem rewards when eligibility conditions are satisfied."
+    },
+    {
+      "attributes": {
+        "constraint_kind": "non_functional_requirement",
+        "source_requirement_id": "non_functional-requirement-7"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_acceptance_constraints",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "b4be53384966216f",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "acceptance_constraints",
+      "id": "acceptance-constraint-requirement-7",
+      "missing_fields": [],
+      "name": "Acceptance Constraint 7",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "acceptance-constraint-requirement-7",
+      "source_key": "non_functional_requirements",
+      "source_round": 4,
+      "text": "The system must provide reporting on redemptions and campaign performance."
+    },
+    {
+      "attributes": {
+        "constraint_kind": "success_criterion"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_acceptance_constraints",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "50e151c1183f5872",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "acceptance_constraints",
+      "id": "acceptance-constraint-success-1",
+      "missing_fields": [],
+      "name": "Success Criterion 1",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "acceptance-constraint-success-1",
+      "source_key": "success_criteria",
+      "source_round": 2,
+      "text": "Members can enroll and redeem rewards through one coherent digital journey."
+    },
+    {
+      "attributes": {
+        "constraint_kind": "success_criterion"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_acceptance_constraints",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "2abb9a2aa9983c0a",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "acceptance_constraints",
+      "id": "acceptance-constraint-success-2",
+      "missing_fields": [],
+      "name": "Success Criterion 2",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "acceptance-constraint-success-2",
+      "source_key": "success_criteria",
+      "source_round": 2,
+      "text": "Operations managers can update the reward catalog without engineering support for routine changes."
+    },
+    {
+      "attributes": {
+        "constraint_kind": "success_criterion"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_acceptance_constraints",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "489ea823b5173325",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "acceptance_constraints",
+      "id": "acceptance-constraint-success-3",
+      "missing_fields": [],
+      "name": "Success Criterion 3",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "acceptance-constraint-success-3",
+      "source_key": "success_criteria",
+      "source_round": 2,
+      "text": "The business can review redemption and campaign performance in one reporting workflow."
+    },
+    {
+      "attributes": {
+        "scope_entity_ids": [
+          "entity-reward",
+          "entity-redemption"
+        ],
+        "source_business_rule_id": "business-rule-1"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_domain_invariants",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "9bdd873c55f95c20",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "domain_invariants",
+      "id": "domain-invariant-1",
+      "missing_fields": [],
+      "name": "Rule 1",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "domain-invariant-1",
+      "source_key": "business_rules",
+      "source_round": 5,
+      "text": "A Redemption must not be fulfilled unless reward eligibility and available points are confirmed."
+    },
+    {
+      "attributes": {
+        "scope_entity_ids": [
+          "entity-reward",
+          "entity-reward-catalog-entry"
+        ],
+        "source_business_rule_id": "business-rule-2"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_domain_invariants",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "a637b3e22f50cdd4",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "domain_invariants",
+      "id": "domain-invariant-2",
+      "missing_fields": [],
+      "name": "Rule 2",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "domain-invariant-2",
+      "source_key": "business_rules",
+      "source_round": 5,
+      "text": "A Reward Catalog Entry must be validated before it becomes Published."
+    },
+    {
+      "attributes": {
+        "scope_entity_ids": [
+          "entity-member"
+        ],
+        "source_business_rule_id": "business-rule-3"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_domain_invariants",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "c2cf041e428bfa76",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "domain_invariants",
+      "id": "domain-invariant-3",
+      "missing_fields": [],
+      "name": "Rule 3",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "domain-invariant-3",
+      "source_key": "business_rules",
+      "source_round": 5,
+      "text": "A Member must provide the required details and consents before enrollment completes."
+    },
+    {
+      "attributes": {
+        "source_business_rule_id": "business-rule-1"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_forbidden_transitions",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "793aa682141bec56",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "forbidden_transitions",
+      "id": "forbidden-transition-1",
+      "missing_fields": [],
+      "name": "Forbidden Transition 1",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "forbidden-transition-1",
+      "source_key": "business_rules",
+      "source_round": 5,
+      "text": "A Redemption must not be fulfilled unless reward eligibility and available points are confirmed."
+    },
+    {
+      "attributes": {
+        "requirement_kind": "functional"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "requirements",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "50ca3d7990de2576",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "functional_requirements",
+      "id": "functional-requirement-1",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "functional-requirement-1",
+      "source_key": "workflow_scope",
+      "source_round": 4,
+      "text": "The system must allow operations managers to maintain reward catalog entries and campaign rules."
+    },
+    {
+      "attributes": {
+        "requirement_kind": "functional"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "requirements",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "137be52a3e449f36",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "functional_requirements",
+      "id": "functional-requirement-2",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "functional-requirement-2",
+      "source_key": "integrations",
+      "source_round": 3,
+      "text": "The platform must integrate with payment confirmation and downstream reporting sources."
+    },
+    {
+      "attributes": {
+        "related_transition_ids": [
+          "state-transition-1",
+          "state-transition-2",
+          "state-transition-3",
+          "state-transition-4",
+          "state-transition-5"
+        ],
+        "source_trigger_id": "trigger-2"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_guard_conditions",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "8c5e2e061f6f6c0b",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "guard_conditions",
+      "id": "guard-condition-2",
+      "missing_fields": [],
+      "name": "Guard Condition 2",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "guard-condition-2",
+      "source_key": "triggers_and_approvals",
+      "source_round": 6,
+      "text": "Catalog validation approval is required before a reward becomes Published"
+    },
+    {
+      "attributes": {
+        "requirement_kind": "non_functional"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "requirements",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "6d25cd70cc309bd6",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "non_functional_requirements",
+      "id": "non_functional-requirement-1",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "non_functional-requirement-1",
+      "source_key": "constraints",
+      "source_round": 2,
+      "text": "The system must protect member and reward transactions with appropriate security controls."
+    },
+    {
+      "attributes": {
+        "requirement_kind": "non_functional"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "requirements",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "3c50cc9fdf143ffc",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "non_functional_requirements",
+      "id": "non_functional-requirement-2",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "non_functional-requirement-2",
+      "source_key": "constraints",
+      "source_round": 2,
+      "text": "The member-facing experience must remain usable on common digital channels."
+    },
+    {
+      "attributes": {
+        "requirement_kind": "non_functional"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "requirements",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "123d736840c12b01",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "non_functional_requirements",
+      "id": "non_functional-requirement-3",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "non_functional-requirement-3",
+      "source_key": "constraints",
+      "source_round": 2,
+      "text": "The platform must support integrations with external systems such as payment confirmation and reporting sources."
+    },
+    {
+      "attributes": {
+        "requirement_kind": "non_functional"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "requirements",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "91b01cf0f9df4489",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "non_functional_requirements",
+      "id": "non_functional-requirement-4",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "non_functional-requirement-4",
+      "source_key": "non_functional_requirements",
+      "source_round": 4,
+      "text": "The system must allow customers to enroll in the loyalty program digitally."
+    },
+    {
+      "attributes": {
+        "requirement_kind": "non_functional"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "requirements",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "c869b78025ab245a",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "non_functional_requirements",
+      "id": "non_functional-requirement-5",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "non_functional-requirement-5",
+      "source_key": "non_functional_requirements",
+      "source_round": 4,
+      "text": "The system must show point balance and available rewards to eligible members."
+    },
+    {
+      "attributes": {
+        "linked_use_case_ids": [
+          "redeem-reward"
+        ],
+        "requirement_kind": "non_functional"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "requirements",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "5f03cdaaa89ad4e1",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "non_functional_requirements",
+      "id": "non_functional-requirement-6",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "non_functional-requirement-6",
+      "source_key": "non_functional_requirements",
+      "source_round": 4,
+      "text": "The system must allow members to redeem rewards when eligibility conditions are satisfied."
+    },
+    {
+      "attributes": {
+        "requirement_kind": "non_functional"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "requirements",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "925c5506da0bb97a",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "non_functional_requirements",
+      "id": "non_functional-requirement-7",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "non_functional-requirement-7",
+      "source_key": "non_functional_requirements",
+      "source_round": 4,
+      "text": "The system must provide reporting on redemptions and campaign performance."
+    },
+    {
+      "attributes": {
+        "flow_of_events": [
+          "Operations Manager updates reward configuration.",
+          "System validates the change.",
+          "System rejects the invalid change."
+        ],
+        "priority": "medium",
+        "status": "open"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_13",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "08157c043930c28b",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "scenarios",
+      "id": "scenario-invalid-catalog-change",
+      "missing_fields": [],
+      "name": "Invalid Catalog Change",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "scenario-invalid-catalog-change",
+      "source_key": "scenarios",
+      "source_round": 13,
+      "text": "Publication is rejected because the new reward configuration would break an active offer."
+    },
+    {
+      "attributes": {
+        "flow_of_events": [
+          "Customer selects a reward.",
+          "System requests payment confirmation.",
+          "System blocks fulfillment until confirmation arrives."
+        ],
+        "priority": "medium",
+        "status": "open"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_13",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "1467185c4aeb36b1",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "scenarios",
+      "id": "scenario-missing-payment-confirmation",
+      "missing_fields": [],
+      "name": "Missing Payment Confirmation",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "scenario-missing-payment-confirmation",
+      "source_key": "scenarios",
+      "source_round": 13,
+      "text": "Redemption pauses until dependent payment confirmation arrives."
+    },
+    {
+      "attributes": {
+        "flow_of_events": [
+          "Operations Manager opens the analytics dashboard.",
+          "System detects delayed reporting data.",
+          "System shows a partial-data warning."
+        ],
+        "priority": "low",
+        "status": "open"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_13",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "1e8c371b106e161c",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "scenarios",
+      "id": "scenario-reporting-delay",
+      "missing_fields": [],
+      "name": "Reporting Delay",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "scenario-reporting-delay",
+      "source_key": "scenarios",
+      "source_round": 13,
+      "text": "Analytics view is partial because a reporting source is delayed."
+    },
+    {
+      "attributes": {
+        "flow_of_events": [
+          "Customer selects a reward.",
+          "System checks reward availability.",
+          "System reports that inventory is exhausted."
+        ],
+        "priority": "high",
+        "status": "open"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_13",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "f0edac8165649917",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "scenarios",
+      "id": "scenario-reward-inventory-exhausted",
+      "missing_fields": [],
+      "name": "Reward Inventory Exhausted",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "scenario-reward-inventory-exhausted",
+      "source_key": "scenarios",
+      "source_round": 13,
+      "text": "Redemption fails because no reward inventory remains."
+    },
+    {
+      "attributes": {
+        "source_business_rule_id": "business-rule-1",
+        "state_entity_ids": [
+          "state-entity-redemption"
+        ]
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_state_invariants",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "1001f94a08fd8f05",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "state_invariants",
+      "id": "state-invariant-1",
+      "missing_fields": [],
+      "name": "Rule 1",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "state-invariant-1",
+      "source_key": "business_rules",
+      "source_round": 5,
+      "text": "A Redemption must not be fulfilled unless reward eligibility and available points are confirmed."
+    },
+    {
+      "attributes": {
+        "source_business_rule_id": "business-rule-2",
+        "state_entity_ids": [
+          "state-entity-reward-catalog-entry"
+        ]
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_state_invariants",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "da255172f2fcc35e",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "state_invariants",
+      "id": "state-invariant-2",
+      "missing_fields": [],
+      "name": "Rule 2",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "state-invariant-2",
+      "source_key": "business_rules",
+      "source_round": 5,
+      "text": "A Reward Catalog Entry must be validated before it becomes Published."
+    },
+    {
+      "attributes": {
+        "from_state": "Requested",
+        "state_entity_id": "state-entity-redemption",
+        "to_state": "Validated"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_6",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "d5953bdf2d9317ff",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "state_transitions",
+      "id": "state-transition-1",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "state-transition-1",
+      "source_key": "states_and_transitions",
+      "source_round": 6,
+      "text": "Redemption: Requested -> Validated -> Fulfilled"
+    },
+    {
+      "attributes": {
+        "from_state": "Validated",
+        "state_entity_id": "state-entity-redemption",
+        "to_state": "Fulfilled"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_6",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "11aeec55110ebd28",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "state_transitions",
+      "id": "state-transition-2",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "state-transition-2",
+      "source_key": "states_and_transitions",
+      "source_round": 6,
+      "text": "Redemption: Requested -> Validated -> Fulfilled"
+    },
+    {
+      "attributes": {
+        "from_state": "Requested",
+        "state_entity_id": "state-entity-redemption",
+        "to_state": "Rejected"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_6",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "e46f9325295e1da2",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "state_transitions",
+      "id": "state-transition-3",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "state-transition-3",
+      "source_key": "states_and_transitions",
+      "source_round": 6,
+      "text": "Redemption: Requested -> Rejected"
+    },
+    {
+      "attributes": {
+        "from_state": "Draft",
+        "state_entity_id": "state-entity-reward-catalog-entry",
+        "to_state": "Published"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_6",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "25b25e4f3f2e7e93",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "state_transitions",
+      "id": "state-transition-4",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "state-transition-4",
+      "source_key": "states_and_transitions",
+      "source_round": 6,
+      "text": "Reward Catalog Entry: Draft -> Published -> Retired"
+    },
+    {
+      "attributes": {
+        "from_state": "Published",
+        "state_entity_id": "state-entity-reward-catalog-entry",
+        "to_state": "Retired"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_6",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "321f360989484fde",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "state_transitions",
+      "id": "state-transition-5",
+      "missing_fields": [],
+      "name": "",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "state-transition-5",
+      "source_key": "states_and_transitions",
+      "source_round": 6,
+      "text": "Reward Catalog Entry: Draft -> Published -> Retired"
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_use_case_steps",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "ef38d2cd32f6264d",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_case_steps",
+      "id": "browse-rewards-extension-1",
+      "missing_fields": [],
+      "name": "Browse Rewards",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "browse-rewards-extension-1",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "Catalog view degrades if an integration is temporarily unavailable."
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_use_case_steps",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "895b68cbcc6073f9",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_case_steps",
+      "id": "browse-rewards-step-1",
+      "missing_fields": [],
+      "name": "Browse Rewards",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "browse-rewards-step-1",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "Customer opens the rewards catalog."
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_use_case_steps",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "dd86222bb48004ab",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_case_steps",
+      "id": "browse-rewards-step-2",
+      "missing_fields": [],
+      "name": "Browse Rewards",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "browse-rewards-step-2",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "System displays available rewards and points balance."
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_use_case_steps",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "96b05cd90d750571",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_case_steps",
+      "id": "browse-rewards-step-3",
+      "missing_fields": [],
+      "name": "Browse Rewards",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "browse-rewards-step-3",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "Customer filters or sorts the catalog."
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_use_case_steps",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "5084306fb28e98a8",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_case_steps",
+      "id": "enroll-member-extension-1",
+      "missing_fields": [],
+      "name": "Enroll Member",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "enroll-member-extension-1",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "Enrollment is blocked when required consent is missing."
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_use_case_steps",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "e7ec46c41fe9cf12",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_case_steps",
+      "id": "enroll-member-step-1",
+      "missing_fields": [],
+      "name": "Enroll Member",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "enroll-member-step-1",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "Customer opens the loyalty enrollment flow."
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_use_case_steps",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "8c937b53f0ae3e91",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_case_steps",
+      "id": "enroll-member-step-2",
+      "missing_fields": [],
+      "name": "Enroll Member",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "enroll-member-step-2",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "Customer provides the required details and consents."
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_use_case_steps",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "13ee1230b8fb95f9",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_case_steps",
+      "id": "enroll-member-step-3",
+      "missing_fields": [],
+      "name": "Enroll Member",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "enroll-member-step-3",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "System validates the submission and creates the member account."
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_use_case_steps",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "52b5017dbd2c3ecf",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_case_steps",
+      "id": "manage-reward-catalog-extension-1",
+      "missing_fields": [],
+      "name": "Manage Reward Catalog",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "manage-reward-catalog-extension-1",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "A change is rejected because it would make an active reward invalid."
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_use_case_steps",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "3018683e51bb8375",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_case_steps",
+      "id": "manage-reward-catalog-step-1",
+      "missing_fields": [],
+      "name": "Manage Reward Catalog",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "manage-reward-catalog-step-1",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "Operations Manager opens catalog administration."
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_use_case_steps",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "0c9fe51d87cb9b58",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_case_steps",
+      "id": "manage-reward-catalog-step-2",
+      "missing_fields": [],
+      "name": "Manage Reward Catalog",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "manage-reward-catalog-step-2",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "Operations Manager updates reward configuration."
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_use_case_steps",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "7dc4a38b3ca526b1",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_case_steps",
+      "id": "manage-reward-catalog-step-3",
+      "missing_fields": [],
+      "name": "Manage Reward Catalog",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "manage-reward-catalog-step-3",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "System validates and publishes the change."
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_use_case_steps",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "187482a4d085efc5",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_case_steps",
+      "id": "redeem-reward-extension-1",
+      "missing_fields": [],
+      "name": "Redeem Reward",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "redeem-reward-extension-1",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "Reward inventory is exhausted before completion."
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_use_case_steps",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "00dfc60e4b370401",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_case_steps",
+      "id": "redeem-reward-extension-2",
+      "missing_fields": [],
+      "name": "Redeem Reward",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "redeem-reward-extension-2",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "Customer does not have enough points."
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_use_case_steps",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "f97975616da77c4d",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_case_steps",
+      "id": "redeem-reward-extension-3",
+      "missing_fields": [],
+      "name": "Redeem Reward",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "redeem-reward-extension-3",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "Payment confirmation is missing for a reward that depends on purchase completion."
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_use_case_steps",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "dcf9844b30ea0150",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_case_steps",
+      "id": "redeem-reward-step-1",
+      "missing_fields": [],
+      "name": "Redeem Reward",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "redeem-reward-step-1",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "Customer selects a reward."
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_use_case_steps",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "c92276c94c67212a",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_case_steps",
+      "id": "redeem-reward-step-2",
+      "missing_fields": [],
+      "name": "Redeem Reward",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "redeem-reward-step-2",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "System validates reward eligibility and available points."
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_use_case_steps",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "1c4797621e3c0bc5",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_case_steps",
+      "id": "redeem-reward-step-3",
+      "missing_fields": [],
+      "name": "Redeem Reward",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "redeem-reward-step-3",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "System reserves the reward and updates the member balance."
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_use_case_steps",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "6b2b2b1e56451842",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_case_steps",
+      "id": "redeem-reward-step-4",
+      "missing_fields": [],
+      "name": "Redeem Reward",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "redeem-reward-step-4",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "System confirms redemption to the customer."
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_use_case_steps",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "32969fc50ee511ae",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_case_steps",
+      "id": "review-redemption-analytics-extension-1",
+      "missing_fields": [],
+      "name": "Review Redemption Analytics",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "review-redemption-analytics-extension-1",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "A reporting data source is delayed."
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_use_case_steps",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "2ad74b487836732e",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_case_steps",
+      "id": "review-redemption-analytics-step-1",
+      "missing_fields": [],
+      "name": "Review Redemption Analytics",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "review-redemption-analytics-step-1",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "Operations Manager opens the analytics dashboard."
+    },
+    {
+      "attributes": {},
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "derived_use_case_steps",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "c20a2d3b710b92b7",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_case_steps",
+      "id": "review-redemption-analytics-step-2",
+      "missing_fields": [],
+      "name": "Review Redemption Analytics",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "review-redemption-analytics-step-2",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "System shows redemption and campaign metrics."
+    },
+    {
+      "attributes": {
+        "complexity": "average",
+        "extensions": [
+          "Catalog view degrades if an integration is temporarily unavailable."
+        ],
+        "main_success_scenario": [
+          "Customer opens the rewards catalog.",
+          "System displays available rewards and points balance.",
+          "Customer filters or sorts the catalog."
+        ],
+        "postconditions": [
+          "Eligible rewards and point balance are visible"
+        ],
+        "preconditions": [
+          "Member is enrolled"
+        ],
+        "priority": "high",
+        "status": "confirmed"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_3",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "88feb125b5f936b0",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_cases",
+      "id": "browse-rewards",
+      "missing_fields": [],
+      "name": "Browse Rewards",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "browse-rewards",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "Browse Rewards"
+    },
+    {
+      "attributes": {
+        "complexity": "simple",
+        "extensions": [
+          "Enrollment is blocked when required consent is missing."
+        ],
+        "main_success_scenario": [
+          "Customer opens the loyalty enrollment flow.",
+          "Customer provides the required details and consents.",
+          "System validates the submission and creates the member account."
+        ],
+        "postconditions": [
+          "Member account exists and is active"
+        ],
+        "preconditions": [
+          "Customer is not already enrolled"
+        ],
+        "priority": "high",
+        "status": "confirmed"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_3",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "e3815fbbb87f8b5d",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_cases",
+      "id": "enroll-member",
+      "missing_fields": [],
+      "name": "Enroll Member",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "enroll-member",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "Enroll Member"
+    },
+    {
+      "attributes": {
+        "complexity": "average",
+        "extensions": [
+          "A change is rejected because it would make an active reward invalid."
+        ],
+        "main_success_scenario": [
+          "Operations Manager opens catalog administration.",
+          "Operations Manager updates reward configuration.",
+          "System validates and publishes the change."
+        ],
+        "postconditions": [
+          "Reward catalog change is published"
+        ],
+        "preconditions": [
+          "Operations Manager is authenticated"
+        ],
+        "priority": "medium",
+        "scenario_ids": [
+          "scenario-invalid-catalog-change"
+        ],
+        "status": "confirmed"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_3",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "7b9ec30b01092bc0",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_cases",
+      "id": "manage-reward-catalog",
+      "missing_fields": [],
+      "name": "Manage Reward Catalog",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "manage-reward-catalog",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "Manage Reward Catalog"
+    },
+    {
+      "attributes": {
+        "complexity": "complex",
+        "extensions": [
+          "Reward inventory is exhausted before completion.",
+          "Customer does not have enough points.",
+          "Payment confirmation is missing for a reward that depends on purchase completion."
+        ],
+        "main_success_scenario": [
+          "Customer selects a reward.",
+          "System validates reward eligibility and available points.",
+          "System reserves the reward and updates the member balance.",
+          "System confirms redemption to the customer."
+        ],
+        "postconditions": [
+          "Redemption is recorded and balance is updated"
+        ],
+        "preconditions": [
+          "Member is enrolled",
+          "Reward is available"
+        ],
+        "priority": "high",
+        "scenario_ids": [
+          "scenario-reward-inventory-exhausted",
+          "scenario-missing-payment-confirmation"
+        ],
+        "status": "confirmed"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_3",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "ff5a198c0a1a3706",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_cases",
+      "id": "redeem-reward",
+      "missing_fields": [],
+      "name": "Redeem Reward",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "redeem-reward",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "Redeem Reward"
+    },
+    {
+      "attributes": {
+        "complexity": "simple",
+        "extensions": [
+          "A reporting data source is delayed."
+        ],
+        "main_success_scenario": [
+          "Operations Manager opens the analytics dashboard.",
+          "System shows redemption and campaign metrics."
+        ],
+        "postconditions": [
+          "Operations Manager can inspect campaign and redemption metrics"
+        ],
+        "preconditions": [
+          "Reporting data is available"
+        ],
+        "priority": "medium",
+        "scenario_ids": [
+          "scenario-reporting-delay"
+        ],
+        "status": "confirmed"
+      },
+      "blocking_ambiguity_ids": [],
+      "change_metadata": {
+        "change_source": "round_3",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "3504f84a0df0905e",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "family": "use_cases",
+      "id": "review-redemption-analytics",
+      "missing_fields": [],
+      "name": "Review Redemption Analytics",
+      "normative_ready": true,
+      "readiness_status": "ready",
+      "semantic_id": "review-redemption-analytics",
+      "source_key": "use_cases",
+      "source_round": 3,
+      "text": "Review Redemption Analytics"
+    }
+  ],
   "summary": {
     "blocking_ambiguity_count": 0,
     "blocking_ambiguity_ids": [],
-    "element_count": 0,
-    "partial_or_blocked_normative_ids": [],
-    "ready_normative_count": 0,
-    "ready_normative_ids": [],
-    "trace_link_count": 0
+    "element_count": 108,
+    "partial_or_blocked_normative_ids": [
+      "business-rule-1",
+      "business-rule-2",
+      "business-rule-3",
+      "entity-analytics-report",
+      "entity-campaign",
+      "entity-member",
+      "entity-payment-confirmation",
+      "entity-redemption",
+      "entity-reward",
+      "entity-reward-catalog-entry",
+      "guard-condition-1",
+      "relationship-1",
+      "relationship-2",
+      "relationship-3",
+      "relationship-4",
+      "relationship-5",
+      "state-entity-redemption",
+      "state-entity-reward-catalog-entry",
+      "trigger-1",
+      "trigger-2"
+    ],
+    "ready_normative_count": 62,
+    "ready_normative_ids": [
+      "acceptance-constraint-requirement-1",
+      "acceptance-constraint-requirement-2",
+      "acceptance-constraint-requirement-3",
+      "acceptance-constraint-requirement-4",
+      "acceptance-constraint-requirement-5",
+      "acceptance-constraint-requirement-6",
+      "acceptance-constraint-requirement-7",
+      "acceptance-constraint-success-1",
+      "acceptance-constraint-success-2",
+      "acceptance-constraint-success-3",
+      "domain-invariant-1",
+      "domain-invariant-2",
+      "domain-invariant-3",
+      "forbidden-transition-1",
+      "functional-requirement-1",
+      "functional-requirement-2",
+      "guard-condition-2",
+      "non_functional-requirement-1",
+      "non_functional-requirement-2",
+      "non_functional-requirement-3",
+      "non_functional-requirement-4",
+      "non_functional-requirement-5",
+      "non_functional-requirement-6",
+      "non_functional-requirement-7",
+      "scenario-invalid-catalog-change",
+      "scenario-missing-payment-confirmation",
+      "scenario-reporting-delay",
+      "scenario-reward-inventory-exhausted",
+      "state-invariant-1",
+      "state-invariant-2",
+      "state-transition-1",
+      "state-transition-2",
+      "state-transition-3",
+      "state-transition-4",
+      "state-transition-5",
+      "browse-rewards-extension-1",
+      "browse-rewards-step-1",
+      "browse-rewards-step-2",
+      "browse-rewards-step-3",
+      "enroll-member-extension-1",
+      "enroll-member-step-1",
+      "enroll-member-step-2",
+      "enroll-member-step-3",
+      "manage-reward-catalog-extension-1",
+      "manage-reward-catalog-step-1",
+      "manage-reward-catalog-step-2",
+      "manage-reward-catalog-step-3",
+      "redeem-reward-extension-1",
+      "redeem-reward-extension-2",
+      "redeem-reward-extension-3",
+      "redeem-reward-step-1",
+      "redeem-reward-step-2",
+      "redeem-reward-step-3",
+      "redeem-reward-step-4",
+      "review-redemption-analytics-extension-1",
+      "review-redemption-analytics-step-1",
+      "review-redemption-analytics-step-2",
+      "browse-rewards",
+      "enroll-member",
+      "manage-reward-catalog",
+      "redeem-reward",
+      "review-redemption-analytics"
+    ],
+    "trace_link_count": 144
   },
-  "trace_links": []
+  "trace_links": [
+    {
+      "artifact_section": "",
+      "basis": "acceptance constraint is derived from canonical requirement",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "f499408c812a5b1f",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "acceptance_constraint_to_requirement",
+      "from_id": "acceptance-constraint-requirement-1",
+      "id": "trace-acceptance-constraint-requirement-1",
+      "link_type": "acceptance_constraint_to_requirement",
+      "semantic_id": "trace-acceptance-constraint-requirement-1",
+      "to_artifact": "",
+      "to_id": "non_functional-requirement-1"
+    },
+    {
+      "artifact_section": "",
+      "basis": "acceptance constraint is derived from canonical requirement",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "2a8f30551fd123cf",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "acceptance_constraint_to_requirement",
+      "from_id": "acceptance-constraint-requirement-2",
+      "id": "trace-acceptance-constraint-requirement-2",
+      "link_type": "acceptance_constraint_to_requirement",
+      "semantic_id": "trace-acceptance-constraint-requirement-2",
+      "to_artifact": "",
+      "to_id": "non_functional-requirement-2"
+    },
+    {
+      "artifact_section": "",
+      "basis": "acceptance constraint is derived from canonical requirement",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "1042f169ffa0dfac",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "acceptance_constraint_to_requirement",
+      "from_id": "acceptance-constraint-requirement-3",
+      "id": "trace-acceptance-constraint-requirement-3",
+      "link_type": "acceptance_constraint_to_requirement",
+      "semantic_id": "trace-acceptance-constraint-requirement-3",
+      "to_artifact": "",
+      "to_id": "non_functional-requirement-3"
+    },
+    {
+      "artifact_section": "",
+      "basis": "acceptance constraint is derived from canonical requirement",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "c159e8e6b122d0a5",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "acceptance_constraint_to_requirement",
+      "from_id": "acceptance-constraint-requirement-4",
+      "id": "trace-acceptance-constraint-requirement-4",
+      "link_type": "acceptance_constraint_to_requirement",
+      "semantic_id": "trace-acceptance-constraint-requirement-4",
+      "to_artifact": "",
+      "to_id": "non_functional-requirement-4"
+    },
+    {
+      "artifact_section": "",
+      "basis": "acceptance constraint is derived from canonical requirement",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "7093ee6afe35b701",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "acceptance_constraint_to_requirement",
+      "from_id": "acceptance-constraint-requirement-5",
+      "id": "trace-acceptance-constraint-requirement-5",
+      "link_type": "acceptance_constraint_to_requirement",
+      "semantic_id": "trace-acceptance-constraint-requirement-5",
+      "to_artifact": "",
+      "to_id": "non_functional-requirement-5"
+    },
+    {
+      "artifact_section": "",
+      "basis": "acceptance constraint is derived from canonical requirement",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "d21a0052e99e9f96",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "acceptance_constraint_to_requirement",
+      "from_id": "acceptance-constraint-requirement-6",
+      "id": "trace-acceptance-constraint-requirement-6",
+      "link_type": "acceptance_constraint_to_requirement",
+      "semantic_id": "trace-acceptance-constraint-requirement-6",
+      "to_artifact": "",
+      "to_id": "non_functional-requirement-6"
+    },
+    {
+      "artifact_section": "",
+      "basis": "acceptance constraint is derived from canonical requirement",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "925ad8c492270e3b",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "acceptance_constraint_to_requirement",
+      "from_id": "acceptance-constraint-requirement-7",
+      "id": "trace-acceptance-constraint-requirement-7",
+      "link_type": "acceptance_constraint_to_requirement",
+      "semantic_id": "trace-acceptance-constraint-requirement-7",
+      "to_artifact": "",
+      "to_id": "non_functional-requirement-7"
+    },
+    {
+      "artifact_section": "",
+      "basis": "design component name references analysis object name",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "cfc827de3bcb0695",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "analysis_to_design",
+      "from_id": "entity-member",
+      "id": "trace-analysis-design-1",
+      "link_type": "analysis_to_design",
+      "semantic_id": "trace-analysis-design-1",
+      "to_artifact": "",
+      "to_id": "component-member-app"
+    },
+    {
+      "artifact_section": "components",
+      "basis": "canonical components object renders into deployment-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "44de6c32dd3650b9",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "component-analytics-service",
+      "id": "trace-artifact-deployment-model-components-component-analytics-service",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-deployment-model-components-component-analytics-service",
+      "to_artifact": "deployment-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "components",
+      "basis": "canonical components object renders into deployment-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "ea4f2781a9abdbe3",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "component-loyalty-api",
+      "id": "trace-artifact-deployment-model-components-component-loyalty-api",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-deployment-model-components-component-loyalty-api",
+      "to_artifact": "deployment-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "components",
+      "basis": "canonical components object renders into deployment-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "8395e6e65900e4e9",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "component-member-app",
+      "id": "trace-artifact-deployment-model-components-component-member-app",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-deployment-model-components-component-member-app",
+      "to_artifact": "deployment-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "components",
+      "basis": "canonical components object renders into deployment-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "96f0faa3577c5958",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "component-operations-console",
+      "id": "trace-artifact-deployment-model-components-component-operations-console",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-deployment-model-components-component-operations-console",
+      "to_artifact": "deployment-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "components",
+      "basis": "canonical components object renders into deployment-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "3f7e60f42de57872",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "component-payment-gateway-adapter",
+      "id": "trace-artifact-deployment-model-components-component-payment-gateway-adapter",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-deployment-model-components-component-payment-gateway-adapter",
+      "to_artifact": "deployment-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "interfaces and integrations",
+      "basis": "canonical interfaces and integrations object renders into deployment-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "4185f4411a623540",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "interface-1",
+      "id": "trace-artifact-deployment-model-interfaces-and-integrations-interface-1",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-deployment-model-interfaces-and-integrations-interface-1",
+      "to_artifact": "deployment-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "interfaces and integrations",
+      "basis": "canonical interfaces and integrations object renders into deployment-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "a17ccea49d467835",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "interface-2",
+      "id": "trace-artifact-deployment-model-interfaces-and-integrations-interface-2",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-deployment-model-interfaces-and-integrations-interface-2",
+      "to_artifact": "deployment-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "interfaces and integrations",
+      "basis": "canonical interfaces and integrations object renders into deployment-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "719e067b7da57776",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "interface-3",
+      "id": "trace-artifact-deployment-model-interfaces-and-integrations-interface-3",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-deployment-model-interfaces-and-integrations-interface-3",
+      "to_artifact": "deployment-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "interfaces and integrations",
+      "basis": "canonical interfaces and integrations object renders into deployment-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "d485ae144f6a5bcd",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "interface-4",
+      "id": "trace-artifact-deployment-model-interfaces-and-integrations-interface-4",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-deployment-model-interfaces-and-integrations-interface-4",
+      "to_artifact": "deployment-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "runtime boundaries",
+      "basis": "canonical runtime boundaries object renders into deployment-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "be72109b76fcb841",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "runtime-boundary-1",
+      "id": "trace-artifact-deployment-model-runtime-boundaries-runtime-boundary-1",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-deployment-model-runtime-boundaries-runtime-boundary-1",
+      "to_artifact": "deployment-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "runtime boundaries",
+      "basis": "canonical runtime boundaries object renders into deployment-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "5fc33d4f7c95f26d",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "runtime-boundary-2",
+      "id": "trace-artifact-deployment-model-runtime-boundaries-runtime-boundary-2",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-deployment-model-runtime-boundaries-runtime-boundary-2",
+      "to_artifact": "deployment-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "business rules",
+      "basis": "canonical business rules object renders into domain-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "78dc7ea16d834a20",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "business-rule-1",
+      "id": "trace-artifact-domain-model-business-rules-business-rule-1",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-domain-model-business-rules-business-rule-1",
+      "to_artifact": "domain-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "business rules",
+      "basis": "canonical business rules object renders into domain-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "e6182870d05b9f7a",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "business-rule-2",
+      "id": "trace-artifact-domain-model-business-rules-business-rule-2",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-domain-model-business-rules-business-rule-2",
+      "to_artifact": "domain-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "business rules",
+      "basis": "canonical business rules object renders into domain-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "db08e5f8695442da",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "business-rule-3",
+      "id": "trace-artifact-domain-model-business-rules-business-rule-3",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-domain-model-business-rules-business-rule-3",
+      "to_artifact": "domain-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "domain entities",
+      "basis": "canonical domain entities object renders into domain-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "9fe9db5e8ebe0a9d",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "entity-analytics-report",
+      "id": "trace-artifact-domain-model-domain-entities-entity-analytics-report",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-domain-model-domain-entities-entity-analytics-report",
+      "to_artifact": "domain-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "domain entities",
+      "basis": "canonical domain entities object renders into domain-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "44286f94447c6a66",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "entity-campaign",
+      "id": "trace-artifact-domain-model-domain-entities-entity-campaign",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-domain-model-domain-entities-entity-campaign",
+      "to_artifact": "domain-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "domain entities",
+      "basis": "canonical domain entities object renders into domain-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "5715c34f1dfa4e05",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "entity-member",
+      "id": "trace-artifact-domain-model-domain-entities-entity-member",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-domain-model-domain-entities-entity-member",
+      "to_artifact": "domain-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "domain entities",
+      "basis": "canonical domain entities object renders into domain-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "7a5039186ff20b9e",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "entity-payment-confirmation",
+      "id": "trace-artifact-domain-model-domain-entities-entity-payment-confirmation",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-domain-model-domain-entities-entity-payment-confirmation",
+      "to_artifact": "domain-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "domain entities",
+      "basis": "canonical domain entities object renders into domain-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "570b377125ed0a71",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "entity-redemption",
+      "id": "trace-artifact-domain-model-domain-entities-entity-redemption",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-domain-model-domain-entities-entity-redemption",
+      "to_artifact": "domain-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "domain entities",
+      "basis": "canonical domain entities object renders into domain-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "f79f540905c9e20f",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "entity-reward",
+      "id": "trace-artifact-domain-model-domain-entities-entity-reward",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-domain-model-domain-entities-entity-reward",
+      "to_artifact": "domain-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "domain entities",
+      "basis": "canonical domain entities object renders into domain-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "cfd432da03fdb5ab",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "entity-reward-catalog-entry",
+      "id": "trace-artifact-domain-model-domain-entities-entity-reward-catalog-entry",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-domain-model-domain-entities-entity-reward-catalog-entry",
+      "to_artifact": "domain-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "domain invariants",
+      "basis": "canonical domain invariants object renders into domain-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "a90aa119fd188cdf",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "domain-invariant-1",
+      "id": "trace-artifact-domain-model-domain-invariants-domain-invariant-1",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-domain-model-domain-invariants-domain-invariant-1",
+      "to_artifact": "domain-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "domain invariants",
+      "basis": "canonical domain invariants object renders into domain-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "c954802ff4fd4b50",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "domain-invariant-2",
+      "id": "trace-artifact-domain-model-domain-invariants-domain-invariant-2",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-domain-model-domain-invariants-domain-invariant-2",
+      "to_artifact": "domain-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "domain invariants",
+      "basis": "canonical domain invariants object renders into domain-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "122fe94f2ccfd8f9",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "domain-invariant-3",
+      "id": "trace-artifact-domain-model-domain-invariants-domain-invariant-3",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-domain-model-domain-invariants-domain-invariant-3",
+      "to_artifact": "domain-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "relationships",
+      "basis": "canonical relationships object renders into domain-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "3f9d110e45e868b3",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "relationship-1",
+      "id": "trace-artifact-domain-model-relationships-relationship-1",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-domain-model-relationships-relationship-1",
+      "to_artifact": "domain-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "relationships",
+      "basis": "canonical relationships object renders into domain-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "82d26cc72fe3d665",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "relationship-2",
+      "id": "trace-artifact-domain-model-relationships-relationship-2",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-domain-model-relationships-relationship-2",
+      "to_artifact": "domain-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "relationships",
+      "basis": "canonical relationships object renders into domain-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "aed3828f4d7ff3e1",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "relationship-3",
+      "id": "trace-artifact-domain-model-relationships-relationship-3",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-domain-model-relationships-relationship-3",
+      "to_artifact": "domain-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "relationships",
+      "basis": "canonical relationships object renders into domain-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "f87566d9edb20283",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "relationship-4",
+      "id": "trace-artifact-domain-model-relationships-relationship-4",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-domain-model-relationships-relationship-4",
+      "to_artifact": "domain-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "relationships",
+      "basis": "canonical relationships object renders into domain-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "aa3eb4ffa7b6066e",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "relationship-5",
+      "id": "trace-artifact-domain-model-relationships-relationship-5",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-domain-model-relationships-relationship-5",
+      "to_artifact": "domain-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "message flows",
+      "basis": "canonical message flows object renders into interaction-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "0b3a7106bfe418b7",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "interaction-message-1",
+      "id": "trace-artifact-interaction-model-message-flows-interaction-message-1",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-interaction-model-message-flows-interaction-message-1",
+      "to_artifact": "interaction-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "message flows",
+      "basis": "canonical message flows object renders into interaction-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "7b943cc11b7a8f88",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "interaction-message-2",
+      "id": "trace-artifact-interaction-model-message-flows-interaction-message-2",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-interaction-model-message-flows-interaction-message-2",
+      "to_artifact": "interaction-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "message flows",
+      "basis": "canonical message flows object renders into interaction-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "99be2280bd0aec6f",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "interaction-message-3",
+      "id": "trace-artifact-interaction-model-message-flows-interaction-message-3",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-interaction-model-message-flows-interaction-message-3",
+      "to_artifact": "interaction-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "message flows",
+      "basis": "canonical message flows object renders into interaction-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "e36cb245800b685b",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "interaction-message-4",
+      "id": "trace-artifact-interaction-model-message-flows-interaction-message-4",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-interaction-model-message-flows-interaction-message-4",
+      "to_artifact": "interaction-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "use-case realizations",
+      "basis": "canonical use-case realizations object renders into interaction-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "c1b6823d2aeeb87a",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "interaction-realization-1",
+      "id": "trace-artifact-interaction-model-use-case-realizations-interaction-realization-1",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-interaction-model-use-case-realizations-interaction-realization-1",
+      "to_artifact": "interaction-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "use-case realizations",
+      "basis": "canonical use-case realizations object renders into interaction-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "ff275c3ef6eda3ed",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "interaction-realization-2",
+      "id": "trace-artifact-interaction-model-use-case-realizations-interaction-realization-2",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-interaction-model-use-case-realizations-interaction-realization-2",
+      "to_artifact": "interaction-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "use-case realizations",
+      "basis": "canonical use-case realizations object renders into interaction-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "7e4fb0b4c67991c7",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "interaction-realization-3",
+      "id": "trace-artifact-interaction-model-use-case-realizations-interaction-realization-3",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-interaction-model-use-case-realizations-interaction-realization-3",
+      "to_artifact": "interaction-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "use-case realizations",
+      "basis": "canonical use-case realizations object renders into interaction-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "19f77e4577165002",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "interaction-realization-4",
+      "id": "trace-artifact-interaction-model-use-case-realizations-interaction-realization-4",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-interaction-model-use-case-realizations-interaction-realization-4",
+      "to_artifact": "interaction-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "use-case realizations",
+      "basis": "canonical use-case realizations object renders into interaction-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "c9a030230c311202",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "interaction-realization-5",
+      "id": "trace-artifact-interaction-model-use-case-realizations-interaction-realization-5",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-interaction-model-use-case-realizations-interaction-realization-5",
+      "to_artifact": "interaction-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "acceptance constraints",
+      "basis": "canonical acceptance constraints object renders into requirements-spec.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "b9a087737158f727",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "acceptance-constraint-requirement-1",
+      "id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-1",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-1",
+      "to_artifact": "requirements-spec.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "acceptance constraints",
+      "basis": "canonical acceptance constraints object renders into requirements-spec.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "b2270d7e957c58fa",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "acceptance-constraint-requirement-2",
+      "id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-2",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-2",
+      "to_artifact": "requirements-spec.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "acceptance constraints",
+      "basis": "canonical acceptance constraints object renders into requirements-spec.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "8180562a372ad219",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "acceptance-constraint-requirement-3",
+      "id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-3",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-3",
+      "to_artifact": "requirements-spec.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "acceptance constraints",
+      "basis": "canonical acceptance constraints object renders into requirements-spec.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "46ebf22f963fa28d",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "acceptance-constraint-requirement-4",
+      "id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-4",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-4",
+      "to_artifact": "requirements-spec.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "acceptance constraints",
+      "basis": "canonical acceptance constraints object renders into requirements-spec.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "9434a1c4a8ceb824",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "acceptance-constraint-requirement-5",
+      "id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-5",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-5",
+      "to_artifact": "requirements-spec.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "acceptance constraints",
+      "basis": "canonical acceptance constraints object renders into requirements-spec.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "d855358cded4ea44",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "acceptance-constraint-requirement-6",
+      "id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-6",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-6",
+      "to_artifact": "requirements-spec.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "acceptance constraints",
+      "basis": "canonical acceptance constraints object renders into requirements-spec.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "ea6de4221e2055e8",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "acceptance-constraint-requirement-7",
+      "id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-7",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-7",
+      "to_artifact": "requirements-spec.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "acceptance constraints",
+      "basis": "canonical acceptance constraints object renders into requirements-spec.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "9a069ddc773b3326",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "acceptance-constraint-success-1",
+      "id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-success-1",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-success-1",
+      "to_artifact": "requirements-spec.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "acceptance constraints",
+      "basis": "canonical acceptance constraints object renders into requirements-spec.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "b4f52e328a66f8b5",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "acceptance-constraint-success-2",
+      "id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-success-2",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-success-2",
+      "to_artifact": "requirements-spec.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "acceptance constraints",
+      "basis": "canonical acceptance constraints object renders into requirements-spec.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "6fc7c34127a50714",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "acceptance-constraint-success-3",
+      "id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-success-3",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-success-3",
+      "to_artifact": "requirements-spec.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "functional requirements",
+      "basis": "canonical functional requirements object renders into requirements-spec.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "fec25440bb6afe79",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "functional-requirement-1",
+      "id": "trace-artifact-requirements-spec-functional-requirements-functional-requirement-1",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-requirements-spec-functional-requirements-functional-requirement-1",
+      "to_artifact": "requirements-spec.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "functional requirements",
+      "basis": "canonical functional requirements object renders into requirements-spec.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "49f0e4b5d57e2433",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "functional-requirement-2",
+      "id": "trace-artifact-requirements-spec-functional-requirements-functional-requirement-2",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-requirements-spec-functional-requirements-functional-requirement-2",
+      "to_artifact": "requirements-spec.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "functional requirements",
+      "basis": "canonical functional requirements object renders into requirements-spec.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "366d3df1f215edf6",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "non_functional-requirement-1",
+      "id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-1",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-1",
+      "to_artifact": "requirements-spec.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "functional requirements",
+      "basis": "canonical functional requirements object renders into requirements-spec.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "553fc29268eb54af",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "non_functional-requirement-2",
+      "id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-2",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-2",
+      "to_artifact": "requirements-spec.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "functional requirements",
+      "basis": "canonical functional requirements object renders into requirements-spec.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "45842652ab1a37ac",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "non_functional-requirement-3",
+      "id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-3",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-3",
+      "to_artifact": "requirements-spec.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "functional requirements",
+      "basis": "canonical functional requirements object renders into requirements-spec.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "deffbd4b51a070ad",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "non_functional-requirement-4",
+      "id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-4",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-4",
+      "to_artifact": "requirements-spec.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "functional requirements",
+      "basis": "canonical functional requirements object renders into requirements-spec.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "5d7714100200c16f",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "non_functional-requirement-5",
+      "id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-5",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-5",
+      "to_artifact": "requirements-spec.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "functional requirements",
+      "basis": "canonical functional requirements object renders into requirements-spec.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "f3c17e6b06f0c694",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "non_functional-requirement-6",
+      "id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-6",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-6",
+      "to_artifact": "requirements-spec.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "functional requirements",
+      "basis": "canonical functional requirements object renders into requirements-spec.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "515decfb51f1bc20",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "non_functional-requirement-7",
+      "id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-7",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-7",
+      "to_artifact": "requirements-spec.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "scenario documents",
+      "basis": "canonical scenario documents object renders into scenario-documents.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "12865275064988a6",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "scenario-invalid-catalog-change",
+      "id": "trace-artifact-scenario-documents-scenario-documents-scenario-invalid-catalog-change",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-scenario-documents-scenario-documents-scenario-invalid-catalog-change",
+      "to_artifact": "scenario-documents.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "scenario documents",
+      "basis": "canonical scenario documents object renders into scenario-documents.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "1a18be66ca23decb",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "scenario-missing-payment-confirmation",
+      "id": "trace-artifact-scenario-documents-scenario-documents-scenario-missing-payment-confirmation",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-scenario-documents-scenario-documents-scenario-missing-payment-confirmation",
+      "to_artifact": "scenario-documents.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "scenario documents",
+      "basis": "canonical scenario documents object renders into scenario-documents.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "fa0ad0ccb4ad2e5e",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "scenario-reporting-delay",
+      "id": "trace-artifact-scenario-documents-scenario-documents-scenario-reporting-delay",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-scenario-documents-scenario-documents-scenario-reporting-delay",
+      "to_artifact": "scenario-documents.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "scenario documents",
+      "basis": "canonical scenario documents object renders into scenario-documents.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "de4fc6eeb45a6f6a",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "scenario-reward-inventory-exhausted",
+      "id": "trace-artifact-scenario-documents-scenario-documents-scenario-reward-inventory-exhausted",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-scenario-documents-scenario-documents-scenario-reward-inventory-exhausted",
+      "to_artifact": "scenario-documents.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "forbidden transitions",
+      "basis": "canonical forbidden transitions object renders into state-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "6bfa72e54c78fc26",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "forbidden-transition-1",
+      "id": "trace-artifact-state-model-forbidden-transitions-forbidden-transition-1",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-state-model-forbidden-transitions-forbidden-transition-1",
+      "to_artifact": "state-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "guard conditions",
+      "basis": "canonical guard conditions object renders into state-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "e6c1be629fc829cf",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "guard-condition-1",
+      "id": "trace-artifact-state-model-guard-conditions-guard-condition-1",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-state-model-guard-conditions-guard-condition-1",
+      "to_artifact": "state-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "guard conditions",
+      "basis": "canonical guard conditions object renders into state-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "0135f82024c2d563",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "guard-condition-2",
+      "id": "trace-artifact-state-model-guard-conditions-guard-condition-2",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-state-model-guard-conditions-guard-condition-2",
+      "to_artifact": "state-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "state entities",
+      "basis": "canonical state entities object renders into state-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "01a71d64da8739d7",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "state-entity-redemption",
+      "id": "trace-artifact-state-model-state-entities-state-entity-redemption",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-state-model-state-entities-state-entity-redemption",
+      "to_artifact": "state-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "state entities",
+      "basis": "canonical state entities object renders into state-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "5792f5ce12819ca0",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "state-entity-reward-catalog-entry",
+      "id": "trace-artifact-state-model-state-entities-state-entity-reward-catalog-entry",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-state-model-state-entities-state-entity-reward-catalog-entry",
+      "to_artifact": "state-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "state invariants",
+      "basis": "canonical state invariants object renders into state-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "0fc9afd4b2b4d208",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "state-invariant-1",
+      "id": "trace-artifact-state-model-state-invariants-state-invariant-1",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-state-model-state-invariants-state-invariant-1",
+      "to_artifact": "state-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "state invariants",
+      "basis": "canonical state invariants object renders into state-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "7ca8114c140d58c2",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "state-invariant-2",
+      "id": "trace-artifact-state-model-state-invariants-state-invariant-2",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-state-model-state-invariants-state-invariant-2",
+      "to_artifact": "state-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "state transitions",
+      "basis": "canonical state transitions object renders into state-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "5e3bb5d335f535a0",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "state-transition-1",
+      "id": "trace-artifact-state-model-state-transitions-state-transition-1",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-state-model-state-transitions-state-transition-1",
+      "to_artifact": "state-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "state transitions",
+      "basis": "canonical state transitions object renders into state-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "3c2aa5a1b7def9a0",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "state-transition-2",
+      "id": "trace-artifact-state-model-state-transitions-state-transition-2",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-state-model-state-transitions-state-transition-2",
+      "to_artifact": "state-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "state transitions",
+      "basis": "canonical state transitions object renders into state-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "1af79bac5dae50d9",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "state-transition-3",
+      "id": "trace-artifact-state-model-state-transitions-state-transition-3",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-state-model-state-transitions-state-transition-3",
+      "to_artifact": "state-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "state transitions",
+      "basis": "canonical state transitions object renders into state-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "facb3d54f01b3e57",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "state-transition-4",
+      "id": "trace-artifact-state-model-state-transitions-state-transition-4",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-state-model-state-transitions-state-transition-4",
+      "to_artifact": "state-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "state transitions",
+      "basis": "canonical state transitions object renders into state-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "3d31fb335559e5d9",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "state-transition-5",
+      "id": "trace-artifact-state-model-state-transitions-state-transition-5",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-state-model-state-transitions-state-transition-5",
+      "to_artifact": "state-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "triggers and approvals",
+      "basis": "canonical triggers and approvals object renders into state-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "c82280ef83063a38",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "trigger-1",
+      "id": "trace-artifact-state-model-triggers-and-approvals-trigger-1",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-state-model-triggers-and-approvals-trigger-1",
+      "to_artifact": "state-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "triggers and approvals",
+      "basis": "canonical triggers and approvals object renders into state-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "826c99d687ec2f69",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "trigger-2",
+      "id": "trace-artifact-state-model-triggers-and-approvals-trigger-2",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-state-model-triggers-and-approvals-trigger-2",
+      "to_artifact": "state-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "architecture overview",
+      "basis": "canonical architecture overview object renders into system-document.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "c38fad4d9335c9a1",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "component-analytics-service",
+      "id": "trace-artifact-system-document-architecture-overview-component-analytics-service",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-system-document-architecture-overview-component-analytics-service",
+      "to_artifact": "system-document.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "architecture overview",
+      "basis": "canonical architecture overview object renders into system-document.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "f3ef9d85c34fba70",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "component-loyalty-api",
+      "id": "trace-artifact-system-document-architecture-overview-component-loyalty-api",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-system-document-architecture-overview-component-loyalty-api",
+      "to_artifact": "system-document.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "architecture overview",
+      "basis": "canonical architecture overview object renders into system-document.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "1b9fb24dc405ffbc",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "component-member-app",
+      "id": "trace-artifact-system-document-architecture-overview-component-member-app",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-system-document-architecture-overview-component-member-app",
+      "to_artifact": "system-document.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "architecture overview",
+      "basis": "canonical architecture overview object renders into system-document.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "b2ea526f66c7c4ed",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "component-operations-console",
+      "id": "trace-artifact-system-document-architecture-overview-component-operations-console",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-system-document-architecture-overview-component-operations-console",
+      "to_artifact": "system-document.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "architecture overview",
+      "basis": "canonical architecture overview object renders into system-document.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "59e7c77ec4879db4",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "component-payment-gateway-adapter",
+      "id": "trace-artifact-system-document-architecture-overview-component-payment-gateway-adapter",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-system-document-architecture-overview-component-payment-gateway-adapter",
+      "to_artifact": "system-document.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "interfaces and integrations",
+      "basis": "canonical interfaces and integrations object renders into system-document.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "91eece8d26d5ed9b",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "interface-1",
+      "id": "trace-artifact-system-document-interfaces-and-integrations-interface-1",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-system-document-interfaces-and-integrations-interface-1",
+      "to_artifact": "system-document.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "interfaces and integrations",
+      "basis": "canonical interfaces and integrations object renders into system-document.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "3f042eff6cee48d3",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "interface-2",
+      "id": "trace-artifact-system-document-interfaces-and-integrations-interface-2",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-system-document-interfaces-and-integrations-interface-2",
+      "to_artifact": "system-document.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "interfaces and integrations",
+      "basis": "canonical interfaces and integrations object renders into system-document.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "722e6e57b38642dc",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "interface-3",
+      "id": "trace-artifact-system-document-interfaces-and-integrations-interface-3",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-system-document-interfaces-and-integrations-interface-3",
+      "to_artifact": "system-document.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "interfaces and integrations",
+      "basis": "canonical interfaces and integrations object renders into system-document.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "70a9c9c226d9b9b2",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "interface-4",
+      "id": "trace-artifact-system-document-interfaces-and-integrations-interface-4",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-system-document-interfaces-and-integrations-interface-4",
+      "to_artifact": "system-document.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "risk factors",
+      "basis": "canonical risk factors object renders into system-document.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "6e46bfebcf530db4",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "risk-payment-confirmation-dependency",
+      "id": "trace-artifact-system-document-risk-factors-risk-payment-confirmation-dependency",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-system-document-risk-factors-risk-payment-confirmation-dependency",
+      "to_artifact": "system-document.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "risk factors",
+      "basis": "canonical risk factors object renders into system-document.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "62f3c4291f6e74b8",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "risk-reporting-latency",
+      "id": "trace-artifact-system-document-risk-factors-risk-reporting-latency",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-system-document-risk-factors-risk-reporting-latency",
+      "to_artifact": "system-document.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "risk factors",
+      "basis": "canonical risk factors object renders into system-document.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "04e8c96dbefa590c",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "risk-reward-configuration-errors",
+      "id": "trace-artifact-system-document-risk-factors-risk-reward-configuration-errors",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-system-document-risk-factors-risk-reward-configuration-errors",
+      "to_artifact": "system-document.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "runtime boundaries",
+      "basis": "canonical runtime boundaries object renders into system-document.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "fdf54dd2f5e1e22b",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "runtime-boundary-1",
+      "id": "trace-artifact-system-document-runtime-boundaries-runtime-boundary-1",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-system-document-runtime-boundaries-runtime-boundary-1",
+      "to_artifact": "system-document.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "runtime boundaries",
+      "basis": "canonical runtime boundaries object renders into system-document.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "6cfa760423dde8f8",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "runtime-boundary-2",
+      "id": "trace-artifact-system-document-runtime-boundaries-runtime-boundary-2",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-system-document-runtime-boundaries-runtime-boundary-2",
+      "to_artifact": "system-document.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "system-level use cases",
+      "basis": "canonical system-level use cases object renders into system-document.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "33184aff67d70b17",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "browse-rewards",
+      "id": "trace-artifact-system-document-system-level-use-cases-browse-rewards",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-system-document-system-level-use-cases-browse-rewards",
+      "to_artifact": "system-document.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "system-level use cases",
+      "basis": "canonical system-level use cases object renders into system-document.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "55052802958f7158",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "enroll-member",
+      "id": "trace-artifact-system-document-system-level-use-cases-enroll-member",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-system-document-system-level-use-cases-enroll-member",
+      "to_artifact": "system-document.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "system-level use cases",
+      "basis": "canonical system-level use cases object renders into system-document.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "df35c4ca38515a93",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "manage-reward-catalog",
+      "id": "trace-artifact-system-document-system-level-use-cases-manage-reward-catalog",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-system-document-system-level-use-cases-manage-reward-catalog",
+      "to_artifact": "system-document.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "system-level use cases",
+      "basis": "canonical system-level use cases object renders into system-document.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "1ea0237fc96b5059",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "redeem-reward",
+      "id": "trace-artifact-system-document-system-level-use-cases-redeem-reward",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-system-document-system-level-use-cases-redeem-reward",
+      "to_artifact": "system-document.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "system-level use cases",
+      "basis": "canonical system-level use cases object renders into system-document.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "7f7ccd0b92b1e57a",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "review-redemption-analytics",
+      "id": "trace-artifact-system-document-system-level-use-cases-review-redemption-analytics",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-system-document-system-level-use-cases-review-redemption-analytics",
+      "to_artifact": "system-document.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "scenario summaries",
+      "basis": "canonical scenario summaries object renders into use-case-documents.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "9127a8b8141a378a",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "scenario-invalid-catalog-change",
+      "id": "trace-artifact-use-case-documents-scenario-summaries-scenario-invalid-catalog-change",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-use-case-documents-scenario-summaries-scenario-invalid-catalog-change",
+      "to_artifact": "use-case-documents.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "scenario summaries",
+      "basis": "canonical scenario summaries object renders into use-case-documents.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "d05ee9a42ad5e5da",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "scenario-missing-payment-confirmation",
+      "id": "trace-artifact-use-case-documents-scenario-summaries-scenario-missing-payment-confirmation",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-use-case-documents-scenario-summaries-scenario-missing-payment-confirmation",
+      "to_artifact": "use-case-documents.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "scenario summaries",
+      "basis": "canonical scenario summaries object renders into use-case-documents.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "8ea8956cb20af4d9",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "scenario-reporting-delay",
+      "id": "trace-artifact-use-case-documents-scenario-summaries-scenario-reporting-delay",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-use-case-documents-scenario-summaries-scenario-reporting-delay",
+      "to_artifact": "use-case-documents.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "scenario summaries",
+      "basis": "canonical scenario summaries object renders into use-case-documents.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "f2d962fe68b4788e",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "scenario-reward-inventory-exhausted",
+      "id": "trace-artifact-use-case-documents-scenario-summaries-scenario-reward-inventory-exhausted",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-use-case-documents-scenario-summaries-scenario-reward-inventory-exhausted",
+      "to_artifact": "use-case-documents.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "use-case documents",
+      "basis": "canonical use-case documents object renders into use-case-documents.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "68f3ec23c9b542c5",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "browse-rewards",
+      "id": "trace-artifact-use-case-documents-use-case-documents-browse-rewards",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-use-case-documents-use-case-documents-browse-rewards",
+      "to_artifact": "use-case-documents.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "use-case documents",
+      "basis": "canonical use-case documents object renders into use-case-documents.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "153925ccce33cb78",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "enroll-member",
+      "id": "trace-artifact-use-case-documents-use-case-documents-enroll-member",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-use-case-documents-use-case-documents-enroll-member",
+      "to_artifact": "use-case-documents.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "use-case documents",
+      "basis": "canonical use-case documents object renders into use-case-documents.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "5921276218b129e7",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "manage-reward-catalog",
+      "id": "trace-artifact-use-case-documents-use-case-documents-manage-reward-catalog",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-use-case-documents-use-case-documents-manage-reward-catalog",
+      "to_artifact": "use-case-documents.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "use-case documents",
+      "basis": "canonical use-case documents object renders into use-case-documents.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "bff0fb6c9906df6a",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "redeem-reward",
+      "id": "trace-artifact-use-case-documents-use-case-documents-redeem-reward",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-use-case-documents-use-case-documents-redeem-reward",
+      "to_artifact": "use-case-documents.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "use-case documents",
+      "basis": "canonical use-case documents object renders into use-case-documents.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "4412e29544f26156",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "review-redemption-analytics",
+      "id": "trace-artifact-use-case-documents-use-case-documents-review-redemption-analytics",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-use-case-documents-use-case-documents-review-redemption-analytics",
+      "to_artifact": "use-case-documents.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "use cases",
+      "basis": "canonical use cases object renders into use-case-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "514f95ad0fca3cbd",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "browse-rewards",
+      "id": "trace-artifact-use-case-model-use-cases-browse-rewards",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-use-case-model-use-cases-browse-rewards",
+      "to_artifact": "use-case-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "use cases",
+      "basis": "canonical use cases object renders into use-case-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "377e8a49e3eda19f",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "enroll-member",
+      "id": "trace-artifact-use-case-model-use-cases-enroll-member",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-use-case-model-use-cases-enroll-member",
+      "to_artifact": "use-case-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "use cases",
+      "basis": "canonical use cases object renders into use-case-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "bad8490420fc1c58",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "manage-reward-catalog",
+      "id": "trace-artifact-use-case-model-use-cases-manage-reward-catalog",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-use-case-model-use-cases-manage-reward-catalog",
+      "to_artifact": "use-case-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "use cases",
+      "basis": "canonical use cases object renders into use-case-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "7b90b75db6633f28",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "redeem-reward",
+      "id": "trace-artifact-use-case-model-use-cases-redeem-reward",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-use-case-model-use-cases-redeem-reward",
+      "to_artifact": "use-case-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "use cases",
+      "basis": "canonical use cases object renders into use-case-model.md",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "5e968f92ec1f975c",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "artifact_lineage",
+      "from_id": "review-redemption-analytics",
+      "id": "trace-artifact-use-case-model-use-cases-review-redemption-analytics",
+      "link_type": "artifact_lineage",
+      "semantic_id": "trace-artifact-use-case-model-use-cases-review-redemption-analytics",
+      "to_artifact": "use-case-model.md",
+      "to_id": ""
+    },
+    {
+      "artifact_section": "",
+      "basis": "business rule scope references state transition text",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "8330b21dc06c3215",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "business_rule_to_transition",
+      "from_id": "business-rule-1",
+      "id": "trace-rule-transition-1",
+      "link_type": "business_rule_to_transition",
+      "semantic_id": "trace-rule-transition-1",
+      "to_artifact": "",
+      "to_id": "state-transition-1"
+    },
+    {
+      "artifact_section": "",
+      "basis": "business rule scope references state transition text",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "38ebf4886c4cbd8a",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "business_rule_to_transition",
+      "from_id": "business-rule-1",
+      "id": "trace-rule-transition-2",
+      "link_type": "business_rule_to_transition",
+      "semantic_id": "trace-rule-transition-2",
+      "to_artifact": "",
+      "to_id": "state-transition-2"
+    },
+    {
+      "artifact_section": "",
+      "basis": "business rule scope references state transition text",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "2de406aa503c0e3c",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "business_rule_to_transition",
+      "from_id": "business-rule-1",
+      "id": "trace-rule-transition-3",
+      "link_type": "business_rule_to_transition",
+      "semantic_id": "trace-rule-transition-3",
+      "to_artifact": "",
+      "to_id": "state-transition-3"
+    },
+    {
+      "artifact_section": "",
+      "basis": "business rule scope references state transition text",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "746a76a9ed5eebc0",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "business_rule_to_transition",
+      "from_id": "business-rule-2",
+      "id": "trace-rule-transition-4",
+      "link_type": "business_rule_to_transition",
+      "semantic_id": "trace-rule-transition-4",
+      "to_artifact": "",
+      "to_id": "state-transition-4"
+    },
+    {
+      "artifact_section": "",
+      "basis": "business rule scope references state transition text",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "f54fae653699b4f1",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "business_rule_to_transition",
+      "from_id": "business-rule-2",
+      "id": "trace-rule-transition-5",
+      "link_type": "business_rule_to_transition",
+      "semantic_id": "trace-rule-transition-5",
+      "to_artifact": "",
+      "to_id": "state-transition-5"
+    },
+    {
+      "artifact_section": "",
+      "basis": "domain invariant scope references domain entity",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "4c34571873064995",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "domain_invariant_to_entity",
+      "from_id": "domain-invariant-1",
+      "id": "trace-domain-invariant-entity-1",
+      "link_type": "domain_invariant_to_entity",
+      "semantic_id": "trace-domain-invariant-entity-1",
+      "to_artifact": "",
+      "to_id": "entity-reward"
+    },
+    {
+      "artifact_section": "",
+      "basis": "domain invariant scope references domain entity",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "d5a48ebbb564f1b9",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "domain_invariant_to_entity",
+      "from_id": "domain-invariant-1",
+      "id": "trace-domain-invariant-entity-2",
+      "link_type": "domain_invariant_to_entity",
+      "semantic_id": "trace-domain-invariant-entity-2",
+      "to_artifact": "",
+      "to_id": "entity-redemption"
+    },
+    {
+      "artifact_section": "",
+      "basis": "domain invariant scope references domain entity",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "e872c7c2a3472ad3",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "domain_invariant_to_entity",
+      "from_id": "domain-invariant-2",
+      "id": "trace-domain-invariant-entity-3",
+      "link_type": "domain_invariant_to_entity",
+      "semantic_id": "trace-domain-invariant-entity-3",
+      "to_artifact": "",
+      "to_id": "entity-reward"
+    },
+    {
+      "artifact_section": "",
+      "basis": "domain invariant scope references domain entity",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "9847fab45fcd3007",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "domain_invariant_to_entity",
+      "from_id": "domain-invariant-2",
+      "id": "trace-domain-invariant-entity-4",
+      "link_type": "domain_invariant_to_entity",
+      "semantic_id": "trace-domain-invariant-entity-4",
+      "to_artifact": "",
+      "to_id": "entity-reward-catalog-entry"
+    },
+    {
+      "artifact_section": "",
+      "basis": "domain invariant scope references domain entity",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "662fede529199607",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "domain_invariant_to_entity",
+      "from_id": "domain-invariant-3",
+      "id": "trace-domain-invariant-entity-5",
+      "link_type": "domain_invariant_to_entity",
+      "semantic_id": "trace-domain-invariant-entity-5",
+      "to_artifact": "",
+      "to_id": "entity-member"
+    },
+    {
+      "artifact_section": "",
+      "basis": "guard condition text references state transition",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "ffeaa64c1319eaec",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "guard_to_transition",
+      "from_id": "guard-condition-2",
+      "id": "trace-guard-transition-1",
+      "link_type": "guard_to_transition",
+      "semantic_id": "trace-guard-transition-1",
+      "to_artifact": "",
+      "to_id": "state-transition-1"
+    },
+    {
+      "artifact_section": "",
+      "basis": "guard condition text references state transition",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "28200a1b6227b96a",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "guard_to_transition",
+      "from_id": "guard-condition-2",
+      "id": "trace-guard-transition-2",
+      "link_type": "guard_to_transition",
+      "semantic_id": "trace-guard-transition-2",
+      "to_artifact": "",
+      "to_id": "state-transition-2"
+    },
+    {
+      "artifact_section": "",
+      "basis": "guard condition text references state transition",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "de6d1aebf218ed11",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "guard_to_transition",
+      "from_id": "guard-condition-2",
+      "id": "trace-guard-transition-3",
+      "link_type": "guard_to_transition",
+      "semantic_id": "trace-guard-transition-3",
+      "to_artifact": "",
+      "to_id": "state-transition-3"
+    },
+    {
+      "artifact_section": "",
+      "basis": "guard condition text references state transition",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "6ade68ccb7e4ee66",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "guard_to_transition",
+      "from_id": "guard-condition-2",
+      "id": "trace-guard-transition-4",
+      "link_type": "guard_to_transition",
+      "semantic_id": "trace-guard-transition-4",
+      "to_artifact": "",
+      "to_id": "state-transition-4"
+    },
+    {
+      "artifact_section": "",
+      "basis": "guard condition text references state transition",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "e959f2cc324ea0ec",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "guard_to_transition",
+      "from_id": "guard-condition-2",
+      "id": "trace-guard-transition-5",
+      "link_type": "guard_to_transition",
+      "semantic_id": "trace-guard-transition-5",
+      "to_artifact": "",
+      "to_id": "state-transition-5"
+    },
+    {
+      "artifact_section": "",
+      "basis": "requirement statement references use-case name",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "2c984dd2ee5f4f3a",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "requirement_to_use_case",
+      "from_id": "non_functional-requirement-6",
+      "id": "trace-req-uc-1",
+      "link_type": "requirement_to_use_case",
+      "semantic_id": "trace-req-uc-1",
+      "to_artifact": "",
+      "to_id": "redeem-reward"
+    },
+    {
+      "artifact_section": "",
+      "basis": "state invariant scope references state entity",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "766a8d44492d1f83",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "state_invariant_to_state",
+      "from_id": "state-invariant-1",
+      "id": "trace-state-invariant-state-1",
+      "link_type": "state_invariant_to_state",
+      "semantic_id": "trace-state-invariant-state-1",
+      "to_artifact": "",
+      "to_id": "state-entity-redemption"
+    },
+    {
+      "artifact_section": "",
+      "basis": "state invariant scope references state entity",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "c1063178b053ccb7",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "state_invariant_to_state",
+      "from_id": "state-invariant-2",
+      "id": "trace-state-invariant-state-2",
+      "link_type": "state_invariant_to_state",
+      "semantic_id": "trace-state-invariant-state-2",
+      "to_artifact": "",
+      "to_id": "state-entity-reward-catalog-entry"
+    },
+    {
+      "artifact_section": "",
+      "basis": "use-case text references analysis object name",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "c134de4b34669066",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "use_case_to_analysis",
+      "from_id": "enroll-member",
+      "id": "trace-uc-analysis-1",
+      "link_type": "use_case_to_analysis",
+      "semantic_id": "trace-uc-analysis-1",
+      "to_artifact": "",
+      "to_id": "entity-member"
+    },
+    {
+      "artifact_section": "",
+      "basis": "use-case text references analysis object name",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "5febd6fdc31d15e8",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "use_case_to_analysis",
+      "from_id": "review-redemption-analytics",
+      "id": "trace-uc-analysis-10",
+      "link_type": "use_case_to_analysis",
+      "semantic_id": "trace-uc-analysis-10",
+      "to_artifact": "",
+      "to_id": "state-entity-redemption"
+    },
+    {
+      "artifact_section": "",
+      "basis": "use-case text references analysis object name",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "0bc5570be1c4d457",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "use_case_to_analysis",
+      "from_id": "browse-rewards",
+      "id": "trace-uc-analysis-2",
+      "link_type": "use_case_to_analysis",
+      "semantic_id": "trace-uc-analysis-2",
+      "to_artifact": "",
+      "to_id": "entity-reward"
+    },
+    {
+      "artifact_section": "",
+      "basis": "use-case text references analysis object name",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "c0b977e16e09bd25",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "use_case_to_analysis",
+      "from_id": "redeem-reward",
+      "id": "trace-uc-analysis-3",
+      "link_type": "use_case_to_analysis",
+      "semantic_id": "trace-uc-analysis-3",
+      "to_artifact": "",
+      "to_id": "entity-member"
+    },
+    {
+      "artifact_section": "",
+      "basis": "use-case text references analysis object name",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "a29aced625d11c99",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "use_case_to_analysis",
+      "from_id": "redeem-reward",
+      "id": "trace-uc-analysis-4",
+      "link_type": "use_case_to_analysis",
+      "semantic_id": "trace-uc-analysis-4",
+      "to_artifact": "",
+      "to_id": "entity-reward"
+    },
+    {
+      "artifact_section": "",
+      "basis": "use-case text references analysis object name",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "aecca953333a3ace",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "use_case_to_analysis",
+      "from_id": "redeem-reward",
+      "id": "trace-uc-analysis-5",
+      "link_type": "use_case_to_analysis",
+      "semantic_id": "trace-uc-analysis-5",
+      "to_artifact": "",
+      "to_id": "entity-redemption"
+    },
+    {
+      "artifact_section": "",
+      "basis": "use-case text references analysis object name",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "b5d4f782f2aff706",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "use_case_to_analysis",
+      "from_id": "redeem-reward",
+      "id": "trace-uc-analysis-6",
+      "link_type": "use_case_to_analysis",
+      "semantic_id": "trace-uc-analysis-6",
+      "to_artifact": "",
+      "to_id": "state-entity-redemption"
+    },
+    {
+      "artifact_section": "",
+      "basis": "use-case text references analysis object name",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "69563f29e908f0b3",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "use_case_to_analysis",
+      "from_id": "manage-reward-catalog",
+      "id": "trace-uc-analysis-7",
+      "link_type": "use_case_to_analysis",
+      "semantic_id": "trace-uc-analysis-7",
+      "to_artifact": "",
+      "to_id": "entity-reward"
+    },
+    {
+      "artifact_section": "",
+      "basis": "use-case text references analysis object name",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "eaf0a3cdbb72e03b",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "use_case_to_analysis",
+      "from_id": "review-redemption-analytics",
+      "id": "trace-uc-analysis-8",
+      "link_type": "use_case_to_analysis",
+      "semantic_id": "trace-uc-analysis-8",
+      "to_artifact": "",
+      "to_id": "entity-campaign"
+    },
+    {
+      "artifact_section": "",
+      "basis": "use-case text references analysis object name",
+      "change_metadata": {
+        "change_source": "derived_traceability",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "ce8e9d6703423e26",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "family": "use_case_to_analysis",
+      "from_id": "review-redemption-analytics",
+      "id": "trace-uc-analysis-9",
+      "link_type": "use_case_to_analysis",
+      "semantic_id": "trace-uc-analysis-9",
+      "to_artifact": "",
+      "to_id": "entity-redemption"
+    }
+  ]
 }

--- a/examples/loyalty-platform-v2/model/rupify-model.json
+++ b/examples/loyalty-platform-v2/model/rupify-model.json
@@ -1,69 +1,9332 @@
 {
   "actors": [
     {
+      "change_metadata": {
+        "change_source": "round_3",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "4d72ad153ef59283",
+        "semantic_version": 1,
+        "supersedes": []
+      },
       "complexity": "complex",
-      "description": "A loyalty member using the digital experience to enroll, browse, and redeem rewards.",
+      "complexity_trace": {
+        "source_key": "actor_complexity",
+        "source_round": 8
+      },
+      "content_semantics": "informative",
+      "description": "",
       "id": "customer",
+      "interaction_style": "user_interface",
+      "model_layer": "analysis",
       "name": "Customer",
+      "responsibilities": [],
+      "semantic_id": "customer",
+      "trace": {
+        "source_key": "actors",
+        "source_round": 3
+      },
       "type": "human"
     },
     {
+      "change_metadata": {
+        "change_source": "round_3",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "91465f76185d5319",
+        "semantic_version": 1,
+        "supersedes": []
+      },
       "complexity": "average",
-      "description": "An internal operator responsible for campaigns, catalog changes, and reporting.",
-      "id": "ops-manager",
+      "complexity_trace": {
+        "source_key": "actor_complexity",
+        "source_round": 8
+      },
+      "content_semantics": "informative",
+      "description": "",
+      "id": "operations-manager",
+      "interaction_style": "user_interface",
+      "model_layer": "analysis",
       "name": "Operations Manager",
+      "responsibilities": [],
+      "semantic_id": "operations-manager",
+      "trace": {
+        "source_key": "actors",
+        "source_round": 3
+      },
       "type": "human"
     },
     {
+      "change_metadata": {
+        "change_source": "round_3",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "3958318885b97c2a",
+        "semantic_version": 1,
+        "supersedes": []
+      },
       "complexity": "simple",
-      "description": "An external system that confirms payment completion for eligible transactions.",
+      "complexity_trace": {
+        "source_key": "actor_complexity",
+        "source_round": 8
+      },
+      "content_semantics": "informative",
+      "description": "",
       "id": "payment-gateway",
+      "interaction_style": "system_interface",
+      "model_layer": "analysis",
       "name": "Payment Gateway",
+      "responsibilities": [],
+      "semantic_id": "payment-gateway",
+      "trace": {
+        "source_key": "actors",
+        "source_round": 3
+      },
       "type": "system"
     }
   ],
-  "assumptions": [
-    "The first delivery increment focuses on a single market and one loyalty program configuration.",
-    "A single product team delivers the first release."
-  ],
+  "ambiguities": [],
+  "analysis_view": {
+    "acceptance_constraint_ids": [
+      "acceptance-constraint-requirement-1",
+      "acceptance-constraint-requirement-2",
+      "acceptance-constraint-requirement-3",
+      "acceptance-constraint-requirement-4",
+      "acceptance-constraint-requirement-5",
+      "acceptance-constraint-requirement-6",
+      "acceptance-constraint-requirement-7",
+      "acceptance-constraint-success-1",
+      "acceptance-constraint-success-2",
+      "acceptance-constraint-success-3"
+    ],
+    "acceptance_constraint_objects": [
+      {
+        "change_metadata": {
+          "change_source": "derived_acceptance_constraints",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "94812897dc06184b",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint_kind": "non_functional_requirement",
+        "content_semantics": "normative",
+        "description": "The system must protect member and reward transactions with appropriate security controls.",
+        "id": "acceptance-constraint-requirement-1",
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "name": "Acceptance Constraint 1",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-requirement-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "acceptance-constraint-requirement-1",
+        "source_requirement_id": "non_functional-requirement-1",
+        "trace": {
+          "source_key": "constraints",
+          "source_round": 2
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_acceptance_constraints",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "9dc0f244dacd87c2",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint_kind": "non_functional_requirement",
+        "content_semantics": "normative",
+        "description": "The member-facing experience must remain usable on common digital channels.",
+        "id": "acceptance-constraint-requirement-2",
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "name": "Acceptance Constraint 2",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-requirement-2",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "acceptance-constraint-requirement-2",
+        "source_requirement_id": "non_functional-requirement-2",
+        "trace": {
+          "source_key": "constraints",
+          "source_round": 2
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_acceptance_constraints",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "2ff2dee2880ffd8d",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint_kind": "non_functional_requirement",
+        "content_semantics": "normative",
+        "description": "The platform must support integrations with external systems such as payment confirmation and reporting sources.",
+        "id": "acceptance-constraint-requirement-3",
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "name": "Acceptance Constraint 3",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-requirement-3",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "acceptance-constraint-requirement-3",
+        "source_requirement_id": "non_functional-requirement-3",
+        "trace": {
+          "source_key": "constraints",
+          "source_round": 2
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_acceptance_constraints",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "257c1792f5ca8674",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint_kind": "non_functional_requirement",
+        "content_semantics": "normative",
+        "description": "The system must allow customers to enroll in the loyalty program digitally.",
+        "id": "acceptance-constraint-requirement-4",
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "name": "Acceptance Constraint 4",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-requirement-4",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "acceptance-constraint-requirement-4",
+        "source_requirement_id": "non_functional-requirement-4",
+        "trace": {
+          "source_key": "non_functional_requirements",
+          "source_round": 4
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_acceptance_constraints",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "bd76e87bf7d763f7",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint_kind": "non_functional_requirement",
+        "content_semantics": "normative",
+        "description": "The system must show point balance and available rewards to eligible members.",
+        "id": "acceptance-constraint-requirement-5",
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "name": "Acceptance Constraint 5",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-requirement-5",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "acceptance-constraint-requirement-5",
+        "source_requirement_id": "non_functional-requirement-5",
+        "trace": {
+          "source_key": "non_functional_requirements",
+          "source_round": 4
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_acceptance_constraints",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "a705e18f2183b881",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint_kind": "non_functional_requirement",
+        "content_semantics": "normative",
+        "description": "The system must allow members to redeem rewards when eligibility conditions are satisfied.",
+        "id": "acceptance-constraint-requirement-6",
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "name": "Acceptance Constraint 6",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-requirement-6",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "acceptance-constraint-requirement-6",
+        "source_requirement_id": "non_functional-requirement-6",
+        "trace": {
+          "source_key": "non_functional_requirements",
+          "source_round": 4
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_acceptance_constraints",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "b4be53384966216f",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint_kind": "non_functional_requirement",
+        "content_semantics": "normative",
+        "description": "The system must provide reporting on redemptions and campaign performance.",
+        "id": "acceptance-constraint-requirement-7",
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "name": "Acceptance Constraint 7",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-requirement-7",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "acceptance-constraint-requirement-7",
+        "source_requirement_id": "non_functional-requirement-7",
+        "trace": {
+          "source_key": "non_functional_requirements",
+          "source_round": 4
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_acceptance_constraints",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "50e151c1183f5872",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint_kind": "success_criterion",
+        "content_semantics": "normative",
+        "description": "Members can enroll and redeem rewards through one coherent digital journey.",
+        "id": "acceptance-constraint-success-1",
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "name": "Success Criterion 1",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-success-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "acceptance-constraint-success-1",
+        "source_requirement_id": "",
+        "trace": {
+          "source_key": "success_criteria",
+          "source_round": 2
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_acceptance_constraints",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "2abb9a2aa9983c0a",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint_kind": "success_criterion",
+        "content_semantics": "normative",
+        "description": "Operations managers can update the reward catalog without engineering support for routine changes.",
+        "id": "acceptance-constraint-success-2",
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "name": "Success Criterion 2",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-success-2",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "acceptance-constraint-success-2",
+        "source_requirement_id": "",
+        "trace": {
+          "source_key": "success_criteria",
+          "source_round": 2
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_acceptance_constraints",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "489ea823b5173325",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint_kind": "success_criterion",
+        "content_semantics": "normative",
+        "description": "The business can review redemption and campaign performance in one reporting workflow.",
+        "id": "acceptance-constraint-success-3",
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "name": "Success Criterion 3",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-success-3",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "acceptance-constraint-success-3",
+        "source_requirement_id": "",
+        "trace": {
+          "source_key": "success_criteria",
+          "source_round": 2
+        }
+      }
+    ],
+    "actor_ids": [
+      "customer",
+      "operations-manager",
+      "payment-gateway"
+    ],
+    "actors": [
+      {
+        "change_metadata": {
+          "change_source": "round_3",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "4d72ad153ef59283",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "complexity": "complex",
+        "complexity_trace": {
+          "source_key": "actor_complexity",
+          "source_round": 8
+        },
+        "content_semantics": "informative",
+        "description": "",
+        "id": "customer",
+        "interaction_style": "user_interface",
+        "model_layer": "analysis",
+        "name": "Customer",
+        "responsibilities": [],
+        "semantic_id": "customer",
+        "trace": {
+          "source_key": "actors",
+          "source_round": 3
+        },
+        "type": "human"
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_3",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "91465f76185d5319",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "complexity": "average",
+        "complexity_trace": {
+          "source_key": "actor_complexity",
+          "source_round": 8
+        },
+        "content_semantics": "informative",
+        "description": "",
+        "id": "operations-manager",
+        "interaction_style": "user_interface",
+        "model_layer": "analysis",
+        "name": "Operations Manager",
+        "responsibilities": [],
+        "semantic_id": "operations-manager",
+        "trace": {
+          "source_key": "actors",
+          "source_round": 3
+        },
+        "type": "human"
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_3",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "3958318885b97c2a",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "complexity": "simple",
+        "complexity_trace": {
+          "source_key": "actor_complexity",
+          "source_round": 8
+        },
+        "content_semantics": "informative",
+        "description": "",
+        "id": "payment-gateway",
+        "interaction_style": "system_interface",
+        "model_layer": "analysis",
+        "name": "Payment Gateway",
+        "responsibilities": [],
+        "semantic_id": "payment-gateway",
+        "trace": {
+          "source_key": "actors",
+          "source_round": 3
+        },
+        "type": "system"
+      }
+    ],
+    "ambiguity_ids": [],
+    "ambiguity_objects": [],
+    "business_rule_ids": [
+      "business-rule-1",
+      "business-rule-2",
+      "business-rule-3"
+    ],
+    "business_rule_objects": [
+      {
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "31ed3a5922b7f6f7",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "id": "business-rule-1",
+        "model_layer": "analysis",
+        "name": "Rule 1",
+        "rule_text": "A Redemption must not be fulfilled unless reward eligibility and available points are confirmed.",
+        "scope": "A Redemption",
+        "semantic_id": "business-rule-1",
+        "trace": {
+          "source_key": "business_rules",
+          "source_round": 5
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "c647a6ca1c45f1eb",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "id": "business-rule-2",
+        "model_layer": "analysis",
+        "name": "Rule 2",
+        "rule_text": "A Reward Catalog Entry must be validated before it becomes Published.",
+        "scope": "A Reward Catalog Entry",
+        "semantic_id": "business-rule-2",
+        "trace": {
+          "source_key": "business_rules",
+          "source_round": 5
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "0a51c9b642e8f7bb",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "id": "business-rule-3",
+        "model_layer": "analysis",
+        "name": "Rule 3",
+        "rule_text": "A Member must provide the required details and consents before enrollment completes.",
+        "scope": "A Member",
+        "semantic_id": "business-rule-3",
+        "trace": {
+          "source_key": "business_rules",
+          "source_round": 5
+        }
+      }
+    ],
+    "domain_entity_ids": [
+      "entity-member",
+      "entity-reward",
+      "entity-reward-catalog-entry",
+      "entity-campaign",
+      "entity-redemption",
+      "entity-payment-confirmation",
+      "entity-analytics-report"
+    ],
+    "domain_entity_objects": [
+      {
+        "attributes": [],
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "88db15323024bb83",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "",
+        "entity_type": "domain_entity",
+        "id": "entity-member",
+        "model_layer": "analysis",
+        "name": "Member",
+        "responsibilities": [],
+        "semantic_id": "entity-member",
+        "trace": {
+          "source_key": "domain_entities",
+          "source_round": 5
+        }
+      },
+      {
+        "attributes": [],
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "c77a1b736f14366c",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "",
+        "entity_type": "domain_entity",
+        "id": "entity-reward",
+        "model_layer": "analysis",
+        "name": "Reward",
+        "responsibilities": [],
+        "semantic_id": "entity-reward",
+        "trace": {
+          "source_key": "domain_entities",
+          "source_round": 5
+        }
+      },
+      {
+        "attributes": [],
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "2df4a67e03f7f9a6",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "",
+        "entity_type": "domain_entity",
+        "id": "entity-reward-catalog-entry",
+        "model_layer": "analysis",
+        "name": "Reward Catalog Entry",
+        "responsibilities": [],
+        "semantic_id": "entity-reward-catalog-entry",
+        "trace": {
+          "source_key": "domain_entities",
+          "source_round": 5
+        }
+      },
+      {
+        "attributes": [],
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "6201c0d87098e9ce",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "",
+        "entity_type": "domain_entity",
+        "id": "entity-campaign",
+        "model_layer": "analysis",
+        "name": "Campaign",
+        "responsibilities": [],
+        "semantic_id": "entity-campaign",
+        "trace": {
+          "source_key": "domain_entities",
+          "source_round": 5
+        }
+      },
+      {
+        "attributes": [],
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "00eaa33d6b332bcb",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "",
+        "entity_type": "domain_entity",
+        "id": "entity-redemption",
+        "model_layer": "analysis",
+        "name": "Redemption",
+        "responsibilities": [],
+        "semantic_id": "entity-redemption",
+        "trace": {
+          "source_key": "domain_entities",
+          "source_round": 5
+        }
+      },
+      {
+        "attributes": [],
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "636404d9ab89daba",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "",
+        "entity_type": "domain_entity",
+        "id": "entity-payment-confirmation",
+        "model_layer": "analysis",
+        "name": "Payment Confirmation",
+        "responsibilities": [],
+        "semantic_id": "entity-payment-confirmation",
+        "trace": {
+          "source_key": "domain_entities",
+          "source_round": 5
+        }
+      },
+      {
+        "attributes": [],
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "2dae1906e4d468a1",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "",
+        "entity_type": "domain_entity",
+        "id": "entity-analytics-report",
+        "model_layer": "analysis",
+        "name": "Analytics Report",
+        "responsibilities": [],
+        "semantic_id": "entity-analytics-report",
+        "trace": {
+          "source_key": "domain_entities",
+          "source_round": 5
+        }
+      }
+    ],
+    "domain_invariant_ids": [
+      "domain-invariant-1",
+      "domain-invariant-2",
+      "domain-invariant-3"
+    ],
+    "domain_invariant_objects": [
+      {
+        "change_metadata": {
+          "change_source": "derived_domain_invariants",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "9bdd873c55f95c20",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "A Redemption must not be fulfilled unless reward eligibility and available points are confirmed.",
+        "id": "domain-invariant-1",
+        "model_layer": "analysis",
+        "name": "Rule 1",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "domain_invariants",
+          "id": "domain-invariant-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "scope_entity_ids": [
+          "entity-reward",
+          "entity-redemption"
+        ],
+        "semantic_id": "domain-invariant-1",
+        "source_business_rule_id": "business-rule-1",
+        "trace": {
+          "source_key": "business_rules",
+          "source_round": 5
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_domain_invariants",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "a637b3e22f50cdd4",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "A Reward Catalog Entry must be validated before it becomes Published.",
+        "id": "domain-invariant-2",
+        "model_layer": "analysis",
+        "name": "Rule 2",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "domain_invariants",
+          "id": "domain-invariant-2",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "scope_entity_ids": [
+          "entity-reward",
+          "entity-reward-catalog-entry"
+        ],
+        "semantic_id": "domain-invariant-2",
+        "source_business_rule_id": "business-rule-2",
+        "trace": {
+          "source_key": "business_rules",
+          "source_round": 5
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_domain_invariants",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "c2cf041e428bfa76",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "A Member must provide the required details and consents before enrollment completes.",
+        "id": "domain-invariant-3",
+        "model_layer": "analysis",
+        "name": "Rule 3",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "domain_invariants",
+          "id": "domain-invariant-3",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "scope_entity_ids": [
+          "entity-member"
+        ],
+        "semantic_id": "domain-invariant-3",
+        "source_business_rule_id": "business-rule-3",
+        "trace": {
+          "source_key": "business_rules",
+          "source_round": 5
+        }
+      }
+    ],
+    "forbidden_transition_ids": [
+      "forbidden-transition-1"
+    ],
+    "forbidden_transition_objects": [
+      {
+        "change_metadata": {
+          "change_source": "derived_forbidden_transitions",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "793aa682141bec56",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "A Redemption must not be fulfilled unless reward eligibility and available points are confirmed.",
+        "from_state": "",
+        "id": "forbidden-transition-1",
+        "model_layer": "analysis",
+        "name": "Forbidden Transition 1",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "forbidden_transitions",
+          "id": "forbidden-transition-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "related_transition_id": "",
+        "semantic_id": "forbidden-transition-1",
+        "source_business_rule_id": "business-rule-1",
+        "state_entity_id": "",
+        "to_state": "",
+        "trace": {
+          "source_key": "business_rules",
+          "source_round": 5
+        }
+      }
+    ],
+    "guard_condition_ids": [
+      "guard-condition-1",
+      "guard-condition-2"
+    ],
+    "guard_condition_objects": [
+      {
+        "change_metadata": {
+          "change_source": "derived_guard_conditions",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "5af79f330a184976",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "condition_text": "Payment confirmation triggers redemption fulfillment",
+        "content_semantics": "normative",
+        "description": "Payment confirmation triggers redemption fulfillment",
+        "id": "guard-condition-1",
+        "model_layer": "analysis",
+        "name": "Payment confirmation",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "guard_conditions",
+          "id": "guard-condition-1",
+          "missing_fields": [
+            "related_transition_ids"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
+        },
+        "related_transition_ids": [],
+        "semantic_id": "guard-condition-1",
+        "source_trigger_id": "trigger-1",
+        "state_entity_ids": [
+          "state-entity-redemption"
+        ],
+        "trace": {
+          "source_key": "triggers_and_approvals",
+          "source_round": 6
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_guard_conditions",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "8c5e2e061f6f6c0b",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "condition_text": "Catalog validation approval is required before a reward becomes Published",
+        "content_semantics": "normative",
+        "description": "Catalog validation approval is required before a reward becomes Published",
+        "id": "guard-condition-2",
+        "model_layer": "analysis",
+        "name": "Guard Condition 2",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "guard_conditions",
+          "id": "guard-condition-2",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "related_transition_ids": [
+          "state-transition-1",
+          "state-transition-2",
+          "state-transition-3",
+          "state-transition-4",
+          "state-transition-5"
+        ],
+        "semantic_id": "guard-condition-2",
+        "source_trigger_id": "trigger-2",
+        "state_entity_ids": [],
+        "trace": {
+          "source_key": "triggers_and_approvals",
+          "source_round": 6
+        }
+      }
+    ],
+    "relationship_ids": [
+      "relationship-1",
+      "relationship-2",
+      "relationship-3",
+      "relationship-4",
+      "relationship-5"
+    ],
+    "relationship_objects": [
+      {
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "53cea002c83a9170",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "A Member has many Redemptions",
+        "id": "relationship-1",
+        "model_layer": "analysis",
+        "relationship_type": "has_many",
+        "semantic_id": "relationship-1",
+        "source_entity_id": "entity-member",
+        "source_multiplicity": "1",
+        "source_name": "A Member",
+        "source_role_name": "redemptions",
+        "target_entity_id": "entity-redemption",
+        "target_multiplicity": "*",
+        "target_name": "Redemptions",
+        "target_role_name": "a_member",
+        "trace": {
+          "source_key": "relationships",
+          "source_round": 5
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "a9a577dfd3c66013",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "A Reward Catalog Entry has one Reward",
+        "id": "relationship-2",
+        "model_layer": "analysis",
+        "relationship_type": "",
+        "semantic_id": "relationship-2",
+        "source_entity_id": "",
+        "source_multiplicity": "",
+        "source_name": "",
+        "source_role_name": "",
+        "target_entity_id": "",
+        "target_multiplicity": "",
+        "target_name": "",
+        "target_role_name": "",
+        "trace": {
+          "source_key": "relationships",
+          "source_round": 5
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "a1a2ce18eb6193fc",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "A Campaign has many Reward Catalog Entries",
+        "id": "relationship-3",
+        "model_layer": "analysis",
+        "relationship_type": "has_many",
+        "semantic_id": "relationship-3",
+        "source_entity_id": "entity-campaign",
+        "source_multiplicity": "1",
+        "source_name": "A Campaign",
+        "source_role_name": "reward_catalog_entries",
+        "target_entity_id": "entity-reward-catalog-entry",
+        "target_multiplicity": "*",
+        "target_name": "Reward Catalog Entries",
+        "target_role_name": "a_campaign",
+        "trace": {
+          "source_key": "relationships",
+          "source_round": 5
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "8042da34054a4968",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "A Redemption has one Payment Confirmation",
+        "id": "relationship-4",
+        "model_layer": "analysis",
+        "relationship_type": "",
+        "semantic_id": "relationship-4",
+        "source_entity_id": "",
+        "source_multiplicity": "",
+        "source_name": "",
+        "source_role_name": "",
+        "target_entity_id": "",
+        "target_multiplicity": "",
+        "target_name": "",
+        "target_role_name": "",
+        "trace": {
+          "source_key": "relationships",
+          "source_round": 5
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "d221c438f9391632",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "An Analytics Report has many Redemptions",
+        "id": "relationship-5",
+        "model_layer": "analysis",
+        "relationship_type": "has_many",
+        "semantic_id": "relationship-5",
+        "source_entity_id": "entity-analytics-report",
+        "source_multiplicity": "1",
+        "source_name": "An Analytics Report",
+        "source_role_name": "redemptions",
+        "target_entity_id": "entity-redemption",
+        "target_multiplicity": "*",
+        "target_name": "Redemptions",
+        "target_role_name": "an_analytics_report",
+        "trace": {
+          "source_key": "relationships",
+          "source_round": 5
+        }
+      }
+    ],
+    "requirement_ids": [
+      "functional-requirement-1",
+      "functional-requirement-2",
+      "non_functional-requirement-1",
+      "non_functional-requirement-2",
+      "non_functional-requirement-3",
+      "non_functional-requirement-4",
+      "non_functional-requirement-5",
+      "non_functional-requirement-6",
+      "non_functional-requirement-7"
+    ],
+    "requirement_objects": [
+      {
+        "change_metadata": {
+          "change_source": "requirements",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "50ca3d7990de2576",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "fit_criterion": "",
+        "id": "functional-requirement-1",
+        "linked_step_ids": [],
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "quality_attribute": "",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "functional-requirement-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "requirement_kind": "functional",
+        "semantic_id": "functional-requirement-1",
+        "statement": "The system must allow operations managers to maintain reward catalog entries and campaign rules.",
+        "trace": {
+          "source_key": "workflow_scope",
+          "source_round": 4
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "requirements",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "137be52a3e449f36",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "fit_criterion": "",
+        "id": "functional-requirement-2",
+        "linked_step_ids": [],
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "quality_attribute": "",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "functional-requirement-2",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "requirement_kind": "functional",
+        "semantic_id": "functional-requirement-2",
+        "statement": "The platform must integrate with payment confirmation and downstream reporting sources.",
+        "trace": {
+          "source_key": "integrations",
+          "source_round": 3
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "requirements",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "6d25cd70cc309bd6",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "fit_criterion": "",
+        "id": "non_functional-requirement-1",
+        "linked_step_ids": [],
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "quality_attribute": "",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "non_functional-requirement-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "requirement_kind": "non_functional",
+        "semantic_id": "non_functional-requirement-1",
+        "statement": "The system must protect member and reward transactions with appropriate security controls.",
+        "trace": {
+          "source_key": "constraints",
+          "source_round": 2
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "requirements",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "3c50cc9fdf143ffc",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "fit_criterion": "",
+        "id": "non_functional-requirement-2",
+        "linked_step_ids": [],
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "quality_attribute": "",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "non_functional-requirement-2",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "requirement_kind": "non_functional",
+        "semantic_id": "non_functional-requirement-2",
+        "statement": "The member-facing experience must remain usable on common digital channels.",
+        "trace": {
+          "source_key": "constraints",
+          "source_round": 2
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "requirements",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "123d736840c12b01",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "fit_criterion": "",
+        "id": "non_functional-requirement-3",
+        "linked_step_ids": [],
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "quality_attribute": "",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "non_functional-requirement-3",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "requirement_kind": "non_functional",
+        "semantic_id": "non_functional-requirement-3",
+        "statement": "The platform must support integrations with external systems such as payment confirmation and reporting sources.",
+        "trace": {
+          "source_key": "constraints",
+          "source_round": 2
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "requirements",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "91b01cf0f9df4489",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "fit_criterion": "",
+        "id": "non_functional-requirement-4",
+        "linked_step_ids": [],
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "quality_attribute": "",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "non_functional-requirement-4",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "requirement_kind": "non_functional",
+        "semantic_id": "non_functional-requirement-4",
+        "statement": "The system must allow customers to enroll in the loyalty program digitally.",
+        "trace": {
+          "source_key": "non_functional_requirements",
+          "source_round": 4
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "requirements",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "c869b78025ab245a",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "fit_criterion": "",
+        "id": "non_functional-requirement-5",
+        "linked_step_ids": [],
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "quality_attribute": "",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "non_functional-requirement-5",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "requirement_kind": "non_functional",
+        "semantic_id": "non_functional-requirement-5",
+        "statement": "The system must show point balance and available rewards to eligible members.",
+        "trace": {
+          "source_key": "non_functional_requirements",
+          "source_round": 4
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "requirements",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "5f03cdaaa89ad4e1",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "fit_criterion": "",
+        "id": "non_functional-requirement-6",
+        "linked_step_ids": [],
+        "linked_use_case_ids": [
+          "redeem-reward"
+        ],
+        "model_layer": "analysis",
+        "quality_attribute": "",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "non_functional-requirement-6",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "requirement_kind": "non_functional",
+        "semantic_id": "non_functional-requirement-6",
+        "statement": "The system must allow members to redeem rewards when eligibility conditions are satisfied.",
+        "trace": {
+          "source_key": "non_functional_requirements",
+          "source_round": 4
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "requirements",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "925c5506da0bb97a",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "fit_criterion": "",
+        "id": "non_functional-requirement-7",
+        "linked_step_ids": [],
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "quality_attribute": "",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "non_functional-requirement-7",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "requirement_kind": "non_functional",
+        "semantic_id": "non_functional-requirement-7",
+        "statement": "The system must provide reporting on redemptions and campaign performance.",
+        "trace": {
+          "source_key": "non_functional_requirements",
+          "source_round": 4
+        }
+      }
+    ],
+    "risk_ids": [
+      "risk-payment-confirmation-dependency",
+      "risk-reward-configuration-errors",
+      "risk-reporting-latency"
+    ],
+    "risk_objects": [
+      {
+        "change_metadata": {
+          "change_source": "round_12",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "959edee70758d343",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "informative",
+        "description": "Payment confirmation dependency",
+        "id": "risk-payment-confirmation-dependency",
+        "mitigation": "add retry and reconciliation flow",
+        "model_layer": "analysis",
+        "name": "Payment confirmation dependency",
+        "priority": "high",
+        "semantic_id": "risk-payment-confirmation-dependency",
+        "status": "open",
+        "trace": {
+          "source_key": "risks",
+          "source_round": 12
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_12",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "d4eb70816cb7a815",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "informative",
+        "description": "Reward configuration errors",
+        "id": "risk-reward-configuration-errors",
+        "mitigation": "validate publish flow and guard rules",
+        "model_layer": "analysis",
+        "name": "Reward configuration errors",
+        "priority": "medium",
+        "semantic_id": "risk-reward-configuration-errors",
+        "status": "open",
+        "trace": {
+          "source_key": "risks",
+          "source_round": 12
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_12",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "48493fb41f5362d7",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "informative",
+        "description": "Reporting latency",
+        "id": "risk-reporting-latency",
+        "mitigation": "monitor analytics pipeline freshness",
+        "model_layer": "analysis",
+        "name": "Reporting latency",
+        "priority": "medium",
+        "semantic_id": "risk-reporting-latency",
+        "status": "open",
+        "trace": {
+          "source_key": "risks",
+          "source_round": 12
+        }
+      }
+    ],
+    "scenario_ids": [
+      "scenario-reward-inventory-exhausted",
+      "scenario-missing-payment-confirmation",
+      "scenario-invalid-catalog-change",
+      "scenario-reporting-delay"
+    ],
+    "scenario_objects": [
+      {
+        "activity_notes": [],
+        "change_metadata": {
+          "change_source": "round_13",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "f0edac8165649917",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "flow_of_events": [
+          "Customer selects a reward.",
+          "System checks reward availability.",
+          "System reports that inventory is exhausted."
+        ],
+        "id": "scenario-reward-inventory-exhausted",
+        "model_layer": "analysis",
+        "name": "Reward Inventory Exhausted",
+        "other_artifact_refs": [],
+        "other_requirement_ids": [],
+        "participating_analysis_object_ids": [],
+        "priority": "high",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "scenarios",
+          "id": "scenario-reward-inventory-exhausted",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "scenario-reward-inventory-exhausted",
+        "sequence_notes": [],
+        "status": "open",
+        "summary": "Redemption fails because no reward inventory remains.",
+        "trace": {
+          "source_key": "scenarios",
+          "source_round": 13
+        },
+        "use_case_id": "redeem-reward",
+        "use_case_name": "Redeem Reward"
+      },
+      {
+        "activity_notes": [],
+        "change_metadata": {
+          "change_source": "round_13",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "1467185c4aeb36b1",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "flow_of_events": [
+          "Customer selects a reward.",
+          "System requests payment confirmation.",
+          "System blocks fulfillment until confirmation arrives."
+        ],
+        "id": "scenario-missing-payment-confirmation",
+        "model_layer": "analysis",
+        "name": "Missing Payment Confirmation",
+        "other_artifact_refs": [],
+        "other_requirement_ids": [],
+        "participating_analysis_object_ids": [],
+        "priority": "medium",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "scenarios",
+          "id": "scenario-missing-payment-confirmation",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "scenario-missing-payment-confirmation",
+        "sequence_notes": [],
+        "status": "open",
+        "summary": "Redemption pauses until dependent payment confirmation arrives.",
+        "trace": {
+          "source_key": "scenarios",
+          "source_round": 13
+        },
+        "use_case_id": "redeem-reward",
+        "use_case_name": "Redeem Reward"
+      },
+      {
+        "activity_notes": [],
+        "change_metadata": {
+          "change_source": "round_13",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "08157c043930c28b",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "flow_of_events": [
+          "Operations Manager updates reward configuration.",
+          "System validates the change.",
+          "System rejects the invalid change."
+        ],
+        "id": "scenario-invalid-catalog-change",
+        "model_layer": "analysis",
+        "name": "Invalid Catalog Change",
+        "other_artifact_refs": [],
+        "other_requirement_ids": [],
+        "participating_analysis_object_ids": [],
+        "priority": "medium",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "scenarios",
+          "id": "scenario-invalid-catalog-change",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "scenario-invalid-catalog-change",
+        "sequence_notes": [],
+        "status": "open",
+        "summary": "Publication is rejected because the new reward configuration would break an active offer.",
+        "trace": {
+          "source_key": "scenarios",
+          "source_round": 13
+        },
+        "use_case_id": "manage-reward-catalog",
+        "use_case_name": "Manage Reward Catalog"
+      },
+      {
+        "activity_notes": [],
+        "change_metadata": {
+          "change_source": "round_13",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "1e8c371b106e161c",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "flow_of_events": [
+          "Operations Manager opens the analytics dashboard.",
+          "System detects delayed reporting data.",
+          "System shows a partial-data warning."
+        ],
+        "id": "scenario-reporting-delay",
+        "model_layer": "analysis",
+        "name": "Reporting Delay",
+        "other_artifact_refs": [],
+        "other_requirement_ids": [],
+        "participating_analysis_object_ids": [],
+        "priority": "low",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "scenarios",
+          "id": "scenario-reporting-delay",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "scenario-reporting-delay",
+        "sequence_notes": [],
+        "status": "open",
+        "summary": "Analytics view is partial because a reporting source is delayed.",
+        "trace": {
+          "source_key": "scenarios",
+          "source_round": 13
+        },
+        "use_case_id": "review-redemption-analytics",
+        "use_case_name": "Review Redemption Analytics"
+      }
+    ],
+    "state_entity_ids": [
+      "state-entity-redemption",
+      "state-entity-reward-catalog-entry"
+    ],
+    "state_entity_objects": [
+      {
+        "change_metadata": {
+          "change_source": "round_6",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "43f1a133415a38bb",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "",
+        "entity_type": "stateful_entity",
+        "id": "state-entity-redemption",
+        "model_layer": "analysis",
+        "name": "Redemption",
+        "semantic_id": "state-entity-redemption",
+        "states": [
+          "Requested",
+          "Validated",
+          "Fulfilled",
+          "Rejected"
+        ],
+        "trace": {
+          "source_key": "state_entities",
+          "source_round": 6
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_6",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "c145d5a38fe40ca1",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "",
+        "entity_type": "stateful_entity",
+        "id": "state-entity-reward-catalog-entry",
+        "model_layer": "analysis",
+        "name": "Reward Catalog Entry",
+        "semantic_id": "state-entity-reward-catalog-entry",
+        "states": [
+          "Draft",
+          "Published",
+          "Retired"
+        ],
+        "trace": {
+          "source_key": "state_entities",
+          "source_round": 6
+        }
+      }
+    ],
+    "state_invariant_ids": [
+      "state-invariant-1",
+      "state-invariant-2"
+    ],
+    "state_invariant_objects": [
+      {
+        "change_metadata": {
+          "change_source": "derived_state_invariants",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "1001f94a08fd8f05",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "A Redemption must not be fulfilled unless reward eligibility and available points are confirmed.",
+        "id": "state-invariant-1",
+        "model_layer": "analysis",
+        "name": "Rule 1",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "state_invariants",
+          "id": "state-invariant-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "state-invariant-1",
+        "source_business_rule_id": "business-rule-1",
+        "state_entity_ids": [
+          "state-entity-redemption"
+        ],
+        "trace": {
+          "source_key": "business_rules",
+          "source_round": 5
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_state_invariants",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "da255172f2fcc35e",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "A Reward Catalog Entry must be validated before it becomes Published.",
+        "id": "state-invariant-2",
+        "model_layer": "analysis",
+        "name": "Rule 2",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "state_invariants",
+          "id": "state-invariant-2",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "state-invariant-2",
+        "source_business_rule_id": "business-rule-2",
+        "state_entity_ids": [
+          "state-entity-reward-catalog-entry"
+        ],
+        "trace": {
+          "source_key": "business_rules",
+          "source_round": 5
+        }
+      }
+    ],
+    "state_transition_ids": [
+      "state-transition-1",
+      "state-transition-2",
+      "state-transition-3",
+      "state-transition-4",
+      "state-transition-5"
+    ],
+    "state_transition_objects": [
+      {
+        "change_metadata": {
+          "change_source": "round_6",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "d5953bdf2d9317ff",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint": "",
+        "content_semantics": "normative",
+        "description": "Redemption: Requested -> Validated -> Fulfilled",
+        "from_state": "Requested",
+        "id": "state-transition-1",
+        "is_exception_flow": false,
+        "is_terminal_transition": false,
+        "model_layer": "analysis",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "state_transitions",
+          "id": "state-transition-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "state-transition-1",
+        "state_entity_id": "state-entity-redemption",
+        "state_entity_name": "Redemption",
+        "to_state": "Validated",
+        "trace": {
+          "source_key": "states_and_transitions",
+          "source_round": 6
+        },
+        "trigger": ""
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_6",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "11aeec55110ebd28",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint": "",
+        "content_semantics": "normative",
+        "description": "Redemption: Requested -> Validated -> Fulfilled",
+        "from_state": "Validated",
+        "id": "state-transition-2",
+        "is_exception_flow": false,
+        "is_terminal_transition": true,
+        "model_layer": "analysis",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "state_transitions",
+          "id": "state-transition-2",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "state-transition-2",
+        "state_entity_id": "state-entity-redemption",
+        "state_entity_name": "Redemption",
+        "to_state": "Fulfilled",
+        "trace": {
+          "source_key": "states_and_transitions",
+          "source_round": 6
+        },
+        "trigger": ""
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_6",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "e46f9325295e1da2",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint": "",
+        "content_semantics": "normative",
+        "description": "Redemption: Requested -> Rejected",
+        "from_state": "Requested",
+        "id": "state-transition-3",
+        "is_exception_flow": true,
+        "is_terminal_transition": true,
+        "model_layer": "analysis",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "state_transitions",
+          "id": "state-transition-3",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "state-transition-3",
+        "state_entity_id": "state-entity-redemption",
+        "state_entity_name": "Redemption",
+        "to_state": "Rejected",
+        "trace": {
+          "source_key": "states_and_transitions",
+          "source_round": 6
+        },
+        "trigger": ""
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_6",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "25b25e4f3f2e7e93",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint": "",
+        "content_semantics": "normative",
+        "description": "Reward Catalog Entry: Draft -> Published -> Retired",
+        "from_state": "Draft",
+        "id": "state-transition-4",
+        "is_exception_flow": false,
+        "is_terminal_transition": false,
+        "model_layer": "analysis",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "state_transitions",
+          "id": "state-transition-4",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "state-transition-4",
+        "state_entity_id": "state-entity-reward-catalog-entry",
+        "state_entity_name": "Reward Catalog Entry",
+        "to_state": "Published",
+        "trace": {
+          "source_key": "states_and_transitions",
+          "source_round": 6
+        },
+        "trigger": ""
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_6",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "321f360989484fde",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint": "",
+        "content_semantics": "normative",
+        "description": "Reward Catalog Entry: Draft -> Published -> Retired",
+        "from_state": "Published",
+        "id": "state-transition-5",
+        "is_exception_flow": false,
+        "is_terminal_transition": false,
+        "model_layer": "analysis",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "state_transitions",
+          "id": "state-transition-5",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "state-transition-5",
+        "state_entity_id": "state-entity-reward-catalog-entry",
+        "state_entity_name": "Reward Catalog Entry",
+        "to_state": "Retired",
+        "trace": {
+          "source_key": "states_and_transitions",
+          "source_round": 6
+        },
+        "trigger": ""
+      }
+    ],
+    "trigger_ids": [
+      "trigger-1",
+      "trigger-2"
+    ],
+    "trigger_objects": [
+      {
+        "approval_required": false,
+        "change_metadata": {
+          "change_source": "round_6",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "e538e9a9d69eae52",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint_type": "event",
+        "content_semantics": "normative",
+        "description": "Payment confirmation triggers redemption fulfillment",
+        "event_name": "Payment confirmation",
+        "exceptional_behavior": false,
+        "id": "trigger-1",
+        "model_layer": "analysis",
+        "outcome": "redemption fulfillment",
+        "semantic_id": "trigger-1",
+        "trace": {
+          "source_key": "triggers_and_approvals",
+          "source_round": 6
+        }
+      },
+      {
+        "approval_required": true,
+        "change_metadata": {
+          "change_source": "round_6",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "1f509a6eabb650c0",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint_type": "approval",
+        "content_semantics": "normative",
+        "description": "Catalog validation approval is required before a reward becomes Published",
+        "event_name": "",
+        "exceptional_behavior": false,
+        "id": "trigger-2",
+        "model_layer": "analysis",
+        "outcome": "",
+        "semantic_id": "trigger-2",
+        "trace": {
+          "source_key": "triggers_and_approvals",
+          "source_round": 6
+        }
+      }
+    ],
+    "use_case_ids": [
+      "enroll-member",
+      "browse-rewards",
+      "redeem-reward",
+      "manage-reward-catalog",
+      "review-redemption-analytics"
+    ],
+    "use_case_step_ids": [
+      "enroll-member-step-1",
+      "enroll-member-step-2",
+      "enroll-member-step-3",
+      "enroll-member-extension-1",
+      "browse-rewards-step-1",
+      "browse-rewards-step-2",
+      "browse-rewards-step-3",
+      "browse-rewards-extension-1",
+      "redeem-reward-step-1",
+      "redeem-reward-step-2",
+      "redeem-reward-step-3",
+      "redeem-reward-step-4",
+      "redeem-reward-extension-1",
+      "redeem-reward-extension-2",
+      "redeem-reward-extension-3",
+      "manage-reward-catalog-step-1",
+      "manage-reward-catalog-step-2",
+      "manage-reward-catalog-step-3",
+      "manage-reward-catalog-extension-1",
+      "review-redemption-analytics-step-1",
+      "review-redemption-analytics-step-2",
+      "review-redemption-analytics-extension-1"
+    ],
+    "use_case_step_objects": [
+      {
+        "change_metadata": {
+          "change_source": "derived_use_case_steps",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "e7ec46c41fe9cf12",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "id": "enroll-member-step-1",
+        "model_layer": "analysis",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_case_steps",
+          "id": "enroll-member-step-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "enroll-member-step-1",
+        "step_index": 1,
+        "step_kind": "main_success",
+        "text": "Customer opens the loyalty enrollment flow.",
+        "trace": {
+          "source_key": "use_cases",
+          "source_round": 3
+        },
+        "use_case_id": "enroll-member",
+        "use_case_name": "Enroll Member"
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_use_case_steps",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "8c937b53f0ae3e91",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "id": "enroll-member-step-2",
+        "model_layer": "analysis",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_case_steps",
+          "id": "enroll-member-step-2",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "enroll-member-step-2",
+        "step_index": 2,
+        "step_kind": "main_success",
+        "text": "Customer provides the required details and consents.",
+        "trace": {
+          "source_key": "use_cases",
+          "source_round": 3
+        },
+        "use_case_id": "enroll-member",
+        "use_case_name": "Enroll Member"
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_use_case_steps",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "13ee1230b8fb95f9",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "id": "enroll-member-step-3",
+        "model_layer": "analysis",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_case_steps",
+          "id": "enroll-member-step-3",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "enroll-member-step-3",
+        "step_index": 3,
+        "step_kind": "main_success",
+        "text": "System validates the submission and creates the member account.",
+        "trace": {
+          "source_key": "use_cases",
+          "source_round": 3
+        },
+        "use_case_id": "enroll-member",
+        "use_case_name": "Enroll Member"
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_use_case_steps",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "5084306fb28e98a8",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "id": "enroll-member-extension-1",
+        "model_layer": "analysis",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_case_steps",
+          "id": "enroll-member-extension-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "enroll-member-extension-1",
+        "step_index": 1,
+        "step_kind": "extension",
+        "text": "Enrollment is blocked when required consent is missing.",
+        "trace": {
+          "source_key": "use_cases",
+          "source_round": 3
+        },
+        "use_case_id": "enroll-member",
+        "use_case_name": "Enroll Member"
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_use_case_steps",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "895b68cbcc6073f9",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "id": "browse-rewards-step-1",
+        "model_layer": "analysis",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_case_steps",
+          "id": "browse-rewards-step-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "browse-rewards-step-1",
+        "step_index": 1,
+        "step_kind": "main_success",
+        "text": "Customer opens the rewards catalog.",
+        "trace": {
+          "source_key": "use_cases",
+          "source_round": 3
+        },
+        "use_case_id": "browse-rewards",
+        "use_case_name": "Browse Rewards"
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_use_case_steps",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "dd86222bb48004ab",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "id": "browse-rewards-step-2",
+        "model_layer": "analysis",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_case_steps",
+          "id": "browse-rewards-step-2",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "browse-rewards-step-2",
+        "step_index": 2,
+        "step_kind": "main_success",
+        "text": "System displays available rewards and points balance.",
+        "trace": {
+          "source_key": "use_cases",
+          "source_round": 3
+        },
+        "use_case_id": "browse-rewards",
+        "use_case_name": "Browse Rewards"
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_use_case_steps",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "96b05cd90d750571",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "id": "browse-rewards-step-3",
+        "model_layer": "analysis",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_case_steps",
+          "id": "browse-rewards-step-3",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "browse-rewards-step-3",
+        "step_index": 3,
+        "step_kind": "main_success",
+        "text": "Customer filters or sorts the catalog.",
+        "trace": {
+          "source_key": "use_cases",
+          "source_round": 3
+        },
+        "use_case_id": "browse-rewards",
+        "use_case_name": "Browse Rewards"
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_use_case_steps",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "ef38d2cd32f6264d",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "id": "browse-rewards-extension-1",
+        "model_layer": "analysis",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_case_steps",
+          "id": "browse-rewards-extension-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "browse-rewards-extension-1",
+        "step_index": 1,
+        "step_kind": "extension",
+        "text": "Catalog view degrades if an integration is temporarily unavailable.",
+        "trace": {
+          "source_key": "use_cases",
+          "source_round": 3
+        },
+        "use_case_id": "browse-rewards",
+        "use_case_name": "Browse Rewards"
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_use_case_steps",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "dcf9844b30ea0150",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "id": "redeem-reward-step-1",
+        "model_layer": "analysis",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_case_steps",
+          "id": "redeem-reward-step-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "redeem-reward-step-1",
+        "step_index": 1,
+        "step_kind": "main_success",
+        "text": "Customer selects a reward.",
+        "trace": {
+          "source_key": "use_cases",
+          "source_round": 3
+        },
+        "use_case_id": "redeem-reward",
+        "use_case_name": "Redeem Reward"
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_use_case_steps",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "c92276c94c67212a",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "id": "redeem-reward-step-2",
+        "model_layer": "analysis",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_case_steps",
+          "id": "redeem-reward-step-2",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "redeem-reward-step-2",
+        "step_index": 2,
+        "step_kind": "main_success",
+        "text": "System validates reward eligibility and available points.",
+        "trace": {
+          "source_key": "use_cases",
+          "source_round": 3
+        },
+        "use_case_id": "redeem-reward",
+        "use_case_name": "Redeem Reward"
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_use_case_steps",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "1c4797621e3c0bc5",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "id": "redeem-reward-step-3",
+        "model_layer": "analysis",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_case_steps",
+          "id": "redeem-reward-step-3",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "redeem-reward-step-3",
+        "step_index": 3,
+        "step_kind": "main_success",
+        "text": "System reserves the reward and updates the member balance.",
+        "trace": {
+          "source_key": "use_cases",
+          "source_round": 3
+        },
+        "use_case_id": "redeem-reward",
+        "use_case_name": "Redeem Reward"
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_use_case_steps",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "6b2b2b1e56451842",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "id": "redeem-reward-step-4",
+        "model_layer": "analysis",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_case_steps",
+          "id": "redeem-reward-step-4",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "redeem-reward-step-4",
+        "step_index": 4,
+        "step_kind": "main_success",
+        "text": "System confirms redemption to the customer.",
+        "trace": {
+          "source_key": "use_cases",
+          "source_round": 3
+        },
+        "use_case_id": "redeem-reward",
+        "use_case_name": "Redeem Reward"
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_use_case_steps",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "187482a4d085efc5",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "id": "redeem-reward-extension-1",
+        "model_layer": "analysis",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_case_steps",
+          "id": "redeem-reward-extension-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "redeem-reward-extension-1",
+        "step_index": 1,
+        "step_kind": "extension",
+        "text": "Reward inventory is exhausted before completion.",
+        "trace": {
+          "source_key": "use_cases",
+          "source_round": 3
+        },
+        "use_case_id": "redeem-reward",
+        "use_case_name": "Redeem Reward"
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_use_case_steps",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "00dfc60e4b370401",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "id": "redeem-reward-extension-2",
+        "model_layer": "analysis",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_case_steps",
+          "id": "redeem-reward-extension-2",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "redeem-reward-extension-2",
+        "step_index": 2,
+        "step_kind": "extension",
+        "text": "Customer does not have enough points.",
+        "trace": {
+          "source_key": "use_cases",
+          "source_round": 3
+        },
+        "use_case_id": "redeem-reward",
+        "use_case_name": "Redeem Reward"
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_use_case_steps",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "f97975616da77c4d",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "id": "redeem-reward-extension-3",
+        "model_layer": "analysis",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_case_steps",
+          "id": "redeem-reward-extension-3",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "redeem-reward-extension-3",
+        "step_index": 3,
+        "step_kind": "extension",
+        "text": "Payment confirmation is missing for a reward that depends on purchase completion.",
+        "trace": {
+          "source_key": "use_cases",
+          "source_round": 3
+        },
+        "use_case_id": "redeem-reward",
+        "use_case_name": "Redeem Reward"
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_use_case_steps",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "3018683e51bb8375",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "id": "manage-reward-catalog-step-1",
+        "model_layer": "analysis",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_case_steps",
+          "id": "manage-reward-catalog-step-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "manage-reward-catalog-step-1",
+        "step_index": 1,
+        "step_kind": "main_success",
+        "text": "Operations Manager opens catalog administration.",
+        "trace": {
+          "source_key": "use_cases",
+          "source_round": 3
+        },
+        "use_case_id": "manage-reward-catalog",
+        "use_case_name": "Manage Reward Catalog"
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_use_case_steps",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "0c9fe51d87cb9b58",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "id": "manage-reward-catalog-step-2",
+        "model_layer": "analysis",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_case_steps",
+          "id": "manage-reward-catalog-step-2",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "manage-reward-catalog-step-2",
+        "step_index": 2,
+        "step_kind": "main_success",
+        "text": "Operations Manager updates reward configuration.",
+        "trace": {
+          "source_key": "use_cases",
+          "source_round": 3
+        },
+        "use_case_id": "manage-reward-catalog",
+        "use_case_name": "Manage Reward Catalog"
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_use_case_steps",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "7dc4a38b3ca526b1",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "id": "manage-reward-catalog-step-3",
+        "model_layer": "analysis",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_case_steps",
+          "id": "manage-reward-catalog-step-3",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "manage-reward-catalog-step-3",
+        "step_index": 3,
+        "step_kind": "main_success",
+        "text": "System validates and publishes the change.",
+        "trace": {
+          "source_key": "use_cases",
+          "source_round": 3
+        },
+        "use_case_id": "manage-reward-catalog",
+        "use_case_name": "Manage Reward Catalog"
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_use_case_steps",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "52b5017dbd2c3ecf",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "id": "manage-reward-catalog-extension-1",
+        "model_layer": "analysis",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_case_steps",
+          "id": "manage-reward-catalog-extension-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "manage-reward-catalog-extension-1",
+        "step_index": 1,
+        "step_kind": "extension",
+        "text": "A change is rejected because it would make an active reward invalid.",
+        "trace": {
+          "source_key": "use_cases",
+          "source_round": 3
+        },
+        "use_case_id": "manage-reward-catalog",
+        "use_case_name": "Manage Reward Catalog"
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_use_case_steps",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "2ad74b487836732e",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "id": "review-redemption-analytics-step-1",
+        "model_layer": "analysis",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_case_steps",
+          "id": "review-redemption-analytics-step-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "review-redemption-analytics-step-1",
+        "step_index": 1,
+        "step_kind": "main_success",
+        "text": "Operations Manager opens the analytics dashboard.",
+        "trace": {
+          "source_key": "use_cases",
+          "source_round": 3
+        },
+        "use_case_id": "review-redemption-analytics",
+        "use_case_name": "Review Redemption Analytics"
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_use_case_steps",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "c20a2d3b710b92b7",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "id": "review-redemption-analytics-step-2",
+        "model_layer": "analysis",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_case_steps",
+          "id": "review-redemption-analytics-step-2",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "review-redemption-analytics-step-2",
+        "step_index": 2,
+        "step_kind": "main_success",
+        "text": "System shows redemption and campaign metrics.",
+        "trace": {
+          "source_key": "use_cases",
+          "source_round": 3
+        },
+        "use_case_id": "review-redemption-analytics",
+        "use_case_name": "Review Redemption Analytics"
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_use_case_steps",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "32969fc50ee511ae",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "id": "review-redemption-analytics-extension-1",
+        "model_layer": "analysis",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_case_steps",
+          "id": "review-redemption-analytics-extension-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "review-redemption-analytics-extension-1",
+        "step_index": 1,
+        "step_kind": "extension",
+        "text": "A reporting data source is delayed.",
+        "trace": {
+          "source_key": "use_cases",
+          "source_round": 3
+        },
+        "use_case_id": "review-redemption-analytics",
+        "use_case_name": "Review Redemption Analytics"
+      }
+    ],
+    "use_cases": [
+      {
+        "change_metadata": {
+          "change_source": "round_3",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "e3815fbbb87f8b5d",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "complexity": "simple",
+        "complexity_trace": {
+          "source_key": "use_case_complexity",
+          "source_round": 9
+        },
+        "content_semantics": "normative",
+        "extension_points": [],
+        "extensions": [
+          "Enrollment is blocked when required consent is missing."
+        ],
+        "goal": "Enroll Member",
+        "id": "enroll-member",
+        "main_success_scenario": [
+          "Customer opens the loyalty enrollment flow.",
+          "Customer provides the required details and consents.",
+          "System validates the submission and creates the member account."
+        ],
+        "model_layer": "analysis",
+        "name": "Enroll Member",
+        "other_artifact_refs": [],
+        "other_requirement_ids": [],
+        "participating_analysis_object_ids": [
+          "entity-member"
+        ],
+        "postconditions": [
+          "Member account exists and is active"
+        ],
+        "preconditions": [
+          "Customer is not already enrolled"
+        ],
+        "primary_actor": "Unspecified",
+        "primary_actor_id": "",
+        "priority": "high",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_cases",
+          "id": "enroll-member",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "scenario_ids": [],
+        "semantic_id": "enroll-member",
+        "status": "confirmed",
+        "subordinate_use_case_ids": [],
+        "supporting_actor_ids": [],
+        "trace": {
+          "source_key": "use_cases",
+          "source_round": 3
+        },
+        "trigger": "",
+        "ui_notes": [
+          "Member-facing responsive enrollment form with consent capture and validation messaging."
+        ],
+        "used_use_case_ids": []
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_3",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "88feb125b5f936b0",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "complexity": "average",
+        "complexity_trace": {
+          "source_key": "use_case_complexity",
+          "source_round": 9
+        },
+        "content_semantics": "normative",
+        "extension_points": [],
+        "extensions": [
+          "Catalog view degrades if an integration is temporarily unavailable."
+        ],
+        "goal": "Browse Rewards",
+        "id": "browse-rewards",
+        "main_success_scenario": [
+          "Customer opens the rewards catalog.",
+          "System displays available rewards and points balance.",
+          "Customer filters or sorts the catalog."
+        ],
+        "model_layer": "analysis",
+        "name": "Browse Rewards",
+        "other_artifact_refs": [],
+        "other_requirement_ids": [],
+        "participating_analysis_object_ids": [
+          "entity-reward"
+        ],
+        "postconditions": [
+          "Eligible rewards and point balance are visible"
+        ],
+        "preconditions": [
+          "Member is enrolled"
+        ],
+        "primary_actor": "Unspecified",
+        "primary_actor_id": "",
+        "priority": "high",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_cases",
+          "id": "browse-rewards",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "scenario_ids": [],
+        "semantic_id": "browse-rewards",
+        "status": "confirmed",
+        "subordinate_use_case_ids": [],
+        "supporting_actor_ids": [],
+        "trace": {
+          "source_key": "use_cases",
+          "source_round": 3
+        },
+        "trigger": "",
+        "ui_notes": [
+          "Reward catalog view with filters, points balance summary, and eligibility indicators."
+        ],
+        "used_use_case_ids": []
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_3",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "ff5a198c0a1a3706",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "complexity": "complex",
+        "complexity_trace": {
+          "source_key": "use_case_complexity",
+          "source_round": 9
+        },
+        "content_semantics": "normative",
+        "extension_points": [],
+        "extensions": [
+          "Reward inventory is exhausted before completion.",
+          "Customer does not have enough points.",
+          "Payment confirmation is missing for a reward that depends on purchase completion."
+        ],
+        "goal": "Redeem Reward",
+        "id": "redeem-reward",
+        "main_success_scenario": [
+          "Customer selects a reward.",
+          "System validates reward eligibility and available points.",
+          "System reserves the reward and updates the member balance.",
+          "System confirms redemption to the customer."
+        ],
+        "model_layer": "analysis",
+        "name": "Redeem Reward",
+        "other_artifact_refs": [],
+        "other_requirement_ids": [
+          "non_functional-requirement-6"
+        ],
+        "participating_analysis_object_ids": [
+          "entity-member",
+          "entity-reward",
+          "entity-redemption",
+          "state-entity-redemption"
+        ],
+        "postconditions": [
+          "Redemption is recorded and balance is updated"
+        ],
+        "preconditions": [
+          "Member is enrolled",
+          "Reward is available"
+        ],
+        "primary_actor": "Unspecified",
+        "primary_actor_id": "",
+        "priority": "high",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_cases",
+          "id": "redeem-reward",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "scenario_ids": [
+          "scenario-reward-inventory-exhausted",
+          "scenario-missing-payment-confirmation"
+        ],
+        "semantic_id": "redeem-reward",
+        "status": "confirmed",
+        "subordinate_use_case_ids": [],
+        "supporting_actor_ids": [],
+        "trace": {
+          "source_key": "use_cases",
+          "source_round": 3
+        },
+        "trigger": "",
+        "ui_notes": [
+          "Reward detail and redemption confirmation flow with explicit failure states."
+        ],
+        "used_use_case_ids": []
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_3",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "7b9ec30b01092bc0",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "complexity": "average",
+        "complexity_trace": {
+          "source_key": "use_case_complexity",
+          "source_round": 9
+        },
+        "content_semantics": "normative",
+        "extension_points": [],
+        "extensions": [
+          "A change is rejected because it would make an active reward invalid."
+        ],
+        "goal": "Manage Reward Catalog",
+        "id": "manage-reward-catalog",
+        "main_success_scenario": [
+          "Operations Manager opens catalog administration.",
+          "Operations Manager updates reward configuration.",
+          "System validates and publishes the change."
+        ],
+        "model_layer": "analysis",
+        "name": "Manage Reward Catalog",
+        "other_artifact_refs": [],
+        "other_requirement_ids": [],
+        "participating_analysis_object_ids": [
+          "entity-reward"
+        ],
+        "postconditions": [
+          "Reward catalog change is published"
+        ],
+        "preconditions": [
+          "Operations Manager is authenticated"
+        ],
+        "primary_actor": "Unspecified",
+        "primary_actor_id": "",
+        "priority": "medium",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_cases",
+          "id": "manage-reward-catalog",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "scenario_ids": [
+          "scenario-invalid-catalog-change"
+        ],
+        "semantic_id": "manage-reward-catalog",
+        "status": "confirmed",
+        "subordinate_use_case_ids": [],
+        "supporting_actor_ids": [],
+        "trace": {
+          "source_key": "use_cases",
+          "source_round": 3
+        },
+        "trigger": "",
+        "ui_notes": [
+          "Back-office catalog editor with validation messages before publish."
+        ],
+        "used_use_case_ids": []
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_3",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "3504f84a0df0905e",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "complexity": "simple",
+        "complexity_trace": {
+          "source_key": "use_case_complexity",
+          "source_round": 9
+        },
+        "content_semantics": "normative",
+        "extension_points": [],
+        "extensions": [
+          "A reporting data source is delayed."
+        ],
+        "goal": "Review Redemption Analytics",
+        "id": "review-redemption-analytics",
+        "main_success_scenario": [
+          "Operations Manager opens the analytics dashboard.",
+          "System shows redemption and campaign metrics."
+        ],
+        "model_layer": "analysis",
+        "name": "Review Redemption Analytics",
+        "other_artifact_refs": [],
+        "other_requirement_ids": [],
+        "participating_analysis_object_ids": [
+          "entity-campaign",
+          "entity-redemption",
+          "state-entity-redemption"
+        ],
+        "postconditions": [
+          "Operations Manager can inspect campaign and redemption metrics"
+        ],
+        "preconditions": [
+          "Reporting data is available"
+        ],
+        "primary_actor": "Unspecified",
+        "primary_actor_id": "",
+        "priority": "medium",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_cases",
+          "id": "review-redemption-analytics",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "scenario_ids": [
+          "scenario-reporting-delay"
+        ],
+        "semantic_id": "review-redemption-analytics",
+        "status": "confirmed",
+        "subordinate_use_case_ids": [],
+        "supporting_actor_ids": [],
+        "trace": {
+          "source_key": "use_cases",
+          "source_round": 3
+        },
+        "trigger": "",
+        "ui_notes": [
+          "Operational dashboard summarizing redemptions, campaigns, and freshness warnings."
+        ],
+        "used_use_case_ids": []
+      }
+    ]
+  },
+  "architecture_view": {
+    "component_objects": [
+      {
+        "change_metadata": {
+          "change_source": "round_7",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "485e0e9ff431ce7c",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "component_kind": "component",
+        "content_semantics": "informative",
+        "id": "component-member-app",
+        "model_layer": "design",
+        "name": "Member App",
+        "responsibility": "",
+        "runtime_environment": "",
+        "semantic_id": "component-member-app",
+        "trace": {
+          "source_key": "components_and_services",
+          "source_round": 7
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_7",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "380953097eae22f1",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "component_kind": "api",
+        "content_semantics": "informative",
+        "id": "component-loyalty-api",
+        "model_layer": "design",
+        "name": "Loyalty API",
+        "responsibility": "",
+        "runtime_environment": "",
+        "semantic_id": "component-loyalty-api",
+        "trace": {
+          "source_key": "components_and_services",
+          "source_round": 7
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_7",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "7edbfa3a396b9716",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "component_kind": "component",
+        "content_semantics": "informative",
+        "id": "component-operations-console",
+        "model_layer": "design",
+        "name": "Operations Console",
+        "responsibility": "",
+        "runtime_environment": "",
+        "semantic_id": "component-operations-console",
+        "trace": {
+          "source_key": "components_and_services",
+          "source_round": 7
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_7",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "825204eaa1cc1e79",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "component_kind": "service",
+        "content_semantics": "informative",
+        "id": "component-analytics-service",
+        "model_layer": "design",
+        "name": "Analytics Service",
+        "responsibility": "",
+        "runtime_environment": "",
+        "semantic_id": "component-analytics-service",
+        "trace": {
+          "source_key": "components_and_services",
+          "source_round": 7
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_7",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "59fe92cc65024873",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "component_kind": "component",
+        "content_semantics": "informative",
+        "id": "component-payment-gateway-adapter",
+        "model_layer": "design",
+        "name": "Payment Gateway Adapter",
+        "responsibility": "",
+        "runtime_environment": "",
+        "semantic_id": "component-payment-gateway-adapter",
+        "trace": {
+          "source_key": "components_and_services",
+          "source_round": 7
+        }
+      }
+    ],
+    "components_and_services": [
+      "Member App",
+      "Loyalty API",
+      "Operations Console",
+      "Analytics Service",
+      "Payment Gateway Adapter"
+    ],
+    "interface_objects": [
+      {
+        "change_metadata": {
+          "change_source": "round_7",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "a3984a295ae19859",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "informative",
+        "description": "Member App calls Loyalty API",
+        "id": "interface-1",
+        "interaction_verb": "calls",
+        "model_layer": "design",
+        "protocol": "",
+        "semantic_id": "interface-1",
+        "source_component_id": "component-member-app",
+        "source_component_name": "Member App",
+        "target_component_id": "component-loyalty-api",
+        "target_component_name": "Loyalty API",
+        "trace": {
+          "source_key": "interfaces_and_integrations",
+          "source_round": 7
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_7",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "e0ecb350f7ee466a",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "informative",
+        "description": "Operations Console calls Loyalty API",
+        "id": "interface-2",
+        "interaction_verb": "calls",
+        "model_layer": "design",
+        "protocol": "",
+        "semantic_id": "interface-2",
+        "source_component_id": "component-operations-console",
+        "source_component_name": "Operations Console",
+        "target_component_id": "component-loyalty-api",
+        "target_component_name": "Loyalty API",
+        "trace": {
+          "source_key": "interfaces_and_integrations",
+          "source_round": 7
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_7",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "baf47c736888625f",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "informative",
+        "description": "Loyalty API calls Payment Gateway Adapter",
+        "id": "interface-3",
+        "interaction_verb": "calls",
+        "model_layer": "design",
+        "protocol": "",
+        "semantic_id": "interface-3",
+        "source_component_id": "component-loyalty-api",
+        "source_component_name": "Loyalty API",
+        "target_component_id": "component-payment-gateway-adapter",
+        "target_component_name": "Payment Gateway Adapter",
+        "trace": {
+          "source_key": "interfaces_and_integrations",
+          "source_round": 7
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_7",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "fcd26a3322838b1a",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "informative",
+        "description": "Loyalty API sends Analytics Service",
+        "id": "interface-4",
+        "interaction_verb": "sends",
+        "model_layer": "design",
+        "protocol": "",
+        "semantic_id": "interface-4",
+        "source_component_id": "component-loyalty-api",
+        "source_component_name": "Loyalty API",
+        "target_component_id": "component-analytics-service",
+        "target_component_name": "Analytics Service",
+        "trace": {
+          "source_key": "interfaces_and_integrations",
+          "source_round": 7
+        }
+      }
+    ],
+    "interfaces_and_integrations": [
+      "Member App calls Loyalty API",
+      "Operations Console calls Loyalty API",
+      "Loyalty API calls Payment Gateway Adapter",
+      "Loyalty API sends Analytics Service"
+    ],
+    "runtime_boundaries": [
+      "Member-facing apps and operations console run separately from the core API",
+      "Payment Gateway Adapter crosses an external boundary"
+    ],
+    "runtime_boundary_objects": [
+      {
+        "boundary_type": "runtime_separation",
+        "change_metadata": {
+          "change_source": "round_7",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "fb259936168e3113",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "informative",
+        "deployment_nodes": [],
+        "description": "Member-facing apps and operations console run separately from the core API",
+        "id": "runtime-boundary-1",
+        "model_layer": "design",
+        "name": "Runtime Boundary 1",
+        "semantic_id": "runtime-boundary-1",
+        "trace": {
+          "source_key": "runtime_boundaries",
+          "source_round": 7
+        }
+      },
+      {
+        "boundary_type": "",
+        "change_metadata": {
+          "change_source": "round_7",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "3760f53ac22faa26",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "informative",
+        "deployment_nodes": [],
+        "description": "Payment Gateway Adapter crosses an external boundary",
+        "id": "runtime-boundary-2",
+        "model_layer": "design",
+        "name": "Runtime Boundary 2",
+        "semantic_id": "runtime-boundary-2",
+        "trace": {
+          "source_key": "runtime_boundaries",
+          "source_round": 7
+        }
+      }
+    ]
+  },
+  "assumptions": [],
   "business_goals": [
     "Increase repeat customer engagement through a unified loyalty experience.",
     "Reduce the operational time required to launch or adjust reward campaigns.",
     "Create a reliable source of truth for loyalty performance reporting."
   ],
+  "design_view": {
+    "component_ids": [
+      "component-member-app",
+      "component-loyalty-api",
+      "component-operations-console",
+      "component-analytics-service",
+      "component-payment-gateway-adapter"
+    ],
+    "component_objects": [
+      {
+        "change_metadata": {
+          "change_source": "round_7",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "485e0e9ff431ce7c",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "component_kind": "component",
+        "content_semantics": "informative",
+        "id": "component-member-app",
+        "model_layer": "design",
+        "name": "Member App",
+        "responsibility": "",
+        "runtime_environment": "",
+        "semantic_id": "component-member-app",
+        "trace": {
+          "source_key": "components_and_services",
+          "source_round": 7
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_7",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "380953097eae22f1",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "component_kind": "api",
+        "content_semantics": "informative",
+        "id": "component-loyalty-api",
+        "model_layer": "design",
+        "name": "Loyalty API",
+        "responsibility": "",
+        "runtime_environment": "",
+        "semantic_id": "component-loyalty-api",
+        "trace": {
+          "source_key": "components_and_services",
+          "source_round": 7
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_7",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "7edbfa3a396b9716",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "component_kind": "component",
+        "content_semantics": "informative",
+        "id": "component-operations-console",
+        "model_layer": "design",
+        "name": "Operations Console",
+        "responsibility": "",
+        "runtime_environment": "",
+        "semantic_id": "component-operations-console",
+        "trace": {
+          "source_key": "components_and_services",
+          "source_round": 7
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_7",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "825204eaa1cc1e79",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "component_kind": "service",
+        "content_semantics": "informative",
+        "id": "component-analytics-service",
+        "model_layer": "design",
+        "name": "Analytics Service",
+        "responsibility": "",
+        "runtime_environment": "",
+        "semantic_id": "component-analytics-service",
+        "trace": {
+          "source_key": "components_and_services",
+          "source_round": 7
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_7",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "59fe92cc65024873",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "component_kind": "component",
+        "content_semantics": "informative",
+        "id": "component-payment-gateway-adapter",
+        "model_layer": "design",
+        "name": "Payment Gateway Adapter",
+        "responsibility": "",
+        "runtime_environment": "",
+        "semantic_id": "component-payment-gateway-adapter",
+        "trace": {
+          "source_key": "components_and_services",
+          "source_round": 7
+        }
+      }
+    ],
+    "interface_ids": [
+      "interface-1",
+      "interface-2",
+      "interface-3",
+      "interface-4"
+    ],
+    "interface_objects": [
+      {
+        "change_metadata": {
+          "change_source": "round_7",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "a3984a295ae19859",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "informative",
+        "description": "Member App calls Loyalty API",
+        "id": "interface-1",
+        "interaction_verb": "calls",
+        "model_layer": "design",
+        "protocol": "",
+        "semantic_id": "interface-1",
+        "source_component_id": "component-member-app",
+        "source_component_name": "Member App",
+        "target_component_id": "component-loyalty-api",
+        "target_component_name": "Loyalty API",
+        "trace": {
+          "source_key": "interfaces_and_integrations",
+          "source_round": 7
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_7",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "e0ecb350f7ee466a",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "informative",
+        "description": "Operations Console calls Loyalty API",
+        "id": "interface-2",
+        "interaction_verb": "calls",
+        "model_layer": "design",
+        "protocol": "",
+        "semantic_id": "interface-2",
+        "source_component_id": "component-operations-console",
+        "source_component_name": "Operations Console",
+        "target_component_id": "component-loyalty-api",
+        "target_component_name": "Loyalty API",
+        "trace": {
+          "source_key": "interfaces_and_integrations",
+          "source_round": 7
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_7",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "baf47c736888625f",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "informative",
+        "description": "Loyalty API calls Payment Gateway Adapter",
+        "id": "interface-3",
+        "interaction_verb": "calls",
+        "model_layer": "design",
+        "protocol": "",
+        "semantic_id": "interface-3",
+        "source_component_id": "component-loyalty-api",
+        "source_component_name": "Loyalty API",
+        "target_component_id": "component-payment-gateway-adapter",
+        "target_component_name": "Payment Gateway Adapter",
+        "trace": {
+          "source_key": "interfaces_and_integrations",
+          "source_round": 7
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_7",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "fcd26a3322838b1a",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "informative",
+        "description": "Loyalty API sends Analytics Service",
+        "id": "interface-4",
+        "interaction_verb": "sends",
+        "model_layer": "design",
+        "protocol": "",
+        "semantic_id": "interface-4",
+        "source_component_id": "component-loyalty-api",
+        "source_component_name": "Loyalty API",
+        "target_component_id": "component-analytics-service",
+        "target_component_name": "Analytics Service",
+        "trace": {
+          "source_key": "interfaces_and_integrations",
+          "source_round": 7
+        }
+      }
+    ],
+    "runtime_boundary_ids": [
+      "runtime-boundary-1",
+      "runtime-boundary-2"
+    ],
+    "runtime_boundary_objects": [
+      {
+        "boundary_type": "runtime_separation",
+        "change_metadata": {
+          "change_source": "round_7",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "fb259936168e3113",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "informative",
+        "deployment_nodes": [],
+        "description": "Member-facing apps and operations console run separately from the core API",
+        "id": "runtime-boundary-1",
+        "model_layer": "design",
+        "name": "Runtime Boundary 1",
+        "semantic_id": "runtime-boundary-1",
+        "trace": {
+          "source_key": "runtime_boundaries",
+          "source_round": 7
+        }
+      },
+      {
+        "boundary_type": "",
+        "change_metadata": {
+          "change_source": "round_7",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "3760f53ac22faa26",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "informative",
+        "deployment_nodes": [],
+        "description": "Payment Gateway Adapter crosses an external boundary",
+        "id": "runtime-boundary-2",
+        "model_layer": "design",
+        "name": "Runtime Boundary 2",
+        "semantic_id": "runtime-boundary-2",
+        "trace": {
+          "source_key": "runtime_boundaries",
+          "source_round": 7
+        }
+      }
+    ]
+  },
+  "element_readiness": {
+    "by_family": {
+      "acceptance_constraints": [
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-requirement-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-requirement-2",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-requirement-3",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-requirement-4",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-requirement-5",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-requirement-6",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-requirement-7",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-success-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-success-2",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-success-3",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        }
+      ],
+      "ambiguities": [],
+      "domain_invariants": [
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "domain_invariants",
+          "id": "domain-invariant-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "domain_invariants",
+          "id": "domain-invariant-2",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "domain_invariants",
+          "id": "domain-invariant-3",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        }
+      ],
+      "forbidden_transitions": [
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "forbidden_transitions",
+          "id": "forbidden-transition-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        }
+      ],
+      "guard_conditions": [
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "guard_conditions",
+          "id": "guard-condition-1",
+          "missing_fields": [
+            "related_transition_ids"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "guard_conditions",
+          "id": "guard-condition-2",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        }
+      ],
+      "requirements": [
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "functional-requirement-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "functional-requirement-2",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "non_functional-requirement-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "non_functional-requirement-2",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "non_functional-requirement-3",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "non_functional-requirement-4",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "non_functional-requirement-5",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "non_functional-requirement-6",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "non_functional-requirement-7",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        }
+      ],
+      "scenarios": [
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "scenarios",
+          "id": "scenario-reward-inventory-exhausted",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "scenarios",
+          "id": "scenario-missing-payment-confirmation",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "scenarios",
+          "id": "scenario-invalid-catalog-change",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "scenarios",
+          "id": "scenario-reporting-delay",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        }
+      ],
+      "state_invariants": [
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "state_invariants",
+          "id": "state-invariant-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "state_invariants",
+          "id": "state-invariant-2",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        }
+      ],
+      "state_transitions": [
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "state_transitions",
+          "id": "state-transition-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "state_transitions",
+          "id": "state-transition-2",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "state_transitions",
+          "id": "state-transition-3",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "state_transitions",
+          "id": "state-transition-4",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "state_transitions",
+          "id": "state-transition-5",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        }
+      ],
+      "use_case_steps": [
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_case_steps",
+          "id": "enroll-member-step-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_case_steps",
+          "id": "enroll-member-step-2",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_case_steps",
+          "id": "enroll-member-step-3",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_case_steps",
+          "id": "enroll-member-extension-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_case_steps",
+          "id": "browse-rewards-step-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_case_steps",
+          "id": "browse-rewards-step-2",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_case_steps",
+          "id": "browse-rewards-step-3",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_case_steps",
+          "id": "browse-rewards-extension-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_case_steps",
+          "id": "redeem-reward-step-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_case_steps",
+          "id": "redeem-reward-step-2",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_case_steps",
+          "id": "redeem-reward-step-3",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_case_steps",
+          "id": "redeem-reward-step-4",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_case_steps",
+          "id": "redeem-reward-extension-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_case_steps",
+          "id": "redeem-reward-extension-2",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_case_steps",
+          "id": "redeem-reward-extension-3",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_case_steps",
+          "id": "manage-reward-catalog-step-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_case_steps",
+          "id": "manage-reward-catalog-step-2",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_case_steps",
+          "id": "manage-reward-catalog-step-3",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_case_steps",
+          "id": "manage-reward-catalog-extension-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_case_steps",
+          "id": "review-redemption-analytics-step-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_case_steps",
+          "id": "review-redemption-analytics-step-2",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_case_steps",
+          "id": "review-redemption-analytics-extension-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        }
+      ],
+      "use_cases": [
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_cases",
+          "id": "enroll-member",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_cases",
+          "id": "browse-rewards",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_cases",
+          "id": "redeem-reward",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_cases",
+          "id": "manage-reward-catalog",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "use_cases",
+          "id": "review-redemption-analytics",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        }
+      ]
+    },
+    "summary": {
+      "blocked_normative_ids": [
+        "guard-condition-1"
+      ],
+      "informative_ids": [],
+      "partial_normative_ids": [],
+      "ready_normative_ids": [
+        "functional-requirement-1",
+        "functional-requirement-2",
+        "non_functional-requirement-1",
+        "non_functional-requirement-2",
+        "non_functional-requirement-3",
+        "non_functional-requirement-4",
+        "non_functional-requirement-5",
+        "non_functional-requirement-6",
+        "non_functional-requirement-7",
+        "acceptance-constraint-requirement-1",
+        "acceptance-constraint-requirement-2",
+        "acceptance-constraint-requirement-3",
+        "acceptance-constraint-requirement-4",
+        "acceptance-constraint-requirement-5",
+        "acceptance-constraint-requirement-6",
+        "acceptance-constraint-requirement-7",
+        "acceptance-constraint-success-1",
+        "acceptance-constraint-success-2",
+        "acceptance-constraint-success-3",
+        "enroll-member",
+        "browse-rewards",
+        "redeem-reward",
+        "manage-reward-catalog",
+        "review-redemption-analytics",
+        "scenario-reward-inventory-exhausted",
+        "scenario-missing-payment-confirmation",
+        "scenario-invalid-catalog-change",
+        "scenario-reporting-delay",
+        "enroll-member-step-1",
+        "enroll-member-step-2",
+        "enroll-member-step-3",
+        "enroll-member-extension-1",
+        "browse-rewards-step-1",
+        "browse-rewards-step-2",
+        "browse-rewards-step-3",
+        "browse-rewards-extension-1",
+        "redeem-reward-step-1",
+        "redeem-reward-step-2",
+        "redeem-reward-step-3",
+        "redeem-reward-step-4",
+        "redeem-reward-extension-1",
+        "redeem-reward-extension-2",
+        "redeem-reward-extension-3",
+        "manage-reward-catalog-step-1",
+        "manage-reward-catalog-step-2",
+        "manage-reward-catalog-step-3",
+        "manage-reward-catalog-extension-1",
+        "review-redemption-analytics-step-1",
+        "review-redemption-analytics-step-2",
+        "review-redemption-analytics-extension-1",
+        "state-transition-1",
+        "state-transition-2",
+        "state-transition-3",
+        "state-transition-4",
+        "state-transition-5",
+        "domain-invariant-1",
+        "domain-invariant-2",
+        "domain-invariant-3",
+        "state-invariant-1",
+        "state-invariant-2",
+        "guard-condition-2",
+        "forbidden-transition-1"
+      ]
+    }
+  },
   "future_placeholders": {
     "formal_specification": [],
     "uml": []
   },
-  "open_questions": [
-    "Should partner merchants be modeled as separate actors in V1?",
-    "What reporting latency is acceptable for operational analytics?"
+  "interaction_view": {
+    "message_ids": [
+      "interaction-message-1",
+      "interaction-message-2",
+      "interaction-message-3",
+      "interaction-message-4"
+    ],
+    "message_objects": [
+      {
+        "change_metadata": {
+          "change_source": "derived_interaction_view",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "d81ef89599054303",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "description": "Member App calls Loyalty API",
+        "id": "interaction-message-1",
+        "interaction_verb": "calls",
+        "model_layer": "design",
+        "semantic_id": "interaction-message-1",
+        "source_id": "component-member-app",
+        "source_name": "Member App",
+        "target_id": "component-loyalty-api",
+        "target_name": "Loyalty API",
+        "trace": {
+          "source_key": "interfaces_and_integrations",
+          "source_round": 7
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_interaction_view",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "b9c14dee92d31afe",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "description": "Operations Console calls Loyalty API",
+        "id": "interaction-message-2",
+        "interaction_verb": "calls",
+        "model_layer": "design",
+        "semantic_id": "interaction-message-2",
+        "source_id": "component-operations-console",
+        "source_name": "Operations Console",
+        "target_id": "component-loyalty-api",
+        "target_name": "Loyalty API",
+        "trace": {
+          "source_key": "interfaces_and_integrations",
+          "source_round": 7
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_interaction_view",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "1c5a2beab2b1083f",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "description": "Loyalty API calls Payment Gateway Adapter",
+        "id": "interaction-message-3",
+        "interaction_verb": "calls",
+        "model_layer": "design",
+        "semantic_id": "interaction-message-3",
+        "source_id": "component-loyalty-api",
+        "source_name": "Loyalty API",
+        "target_id": "component-payment-gateway-adapter",
+        "target_name": "Payment Gateway Adapter",
+        "trace": {
+          "source_key": "interfaces_and_integrations",
+          "source_round": 7
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_interaction_view",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "7d39ed8491c50cd0",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "description": "Loyalty API sends Analytics Service",
+        "id": "interaction-message-4",
+        "interaction_verb": "sends",
+        "model_layer": "design",
+        "semantic_id": "interaction-message-4",
+        "source_id": "component-loyalty-api",
+        "source_name": "Loyalty API",
+        "target_id": "component-analytics-service",
+        "target_name": "Analytics Service",
+        "trace": {
+          "source_key": "interfaces_and_integrations",
+          "source_round": 7
+        }
+      }
+    ],
+    "realization_ids": [
+      "interaction-realization-1",
+      "interaction-realization-2",
+      "interaction-realization-3",
+      "interaction-realization-4",
+      "interaction-realization-5"
+    ],
+    "realization_objects": [
+      {
+        "change_metadata": {
+          "change_source": "derived_interaction_view",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "2afd4f714cbb6387",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "id": "interaction-realization-1",
+        "model_layer": "analysis",
+        "participant_ids": [],
+        "participant_names": [],
+        "semantic_id": "interaction-realization-1",
+        "step_objects": [
+          {
+            "change_metadata": {
+              "change_source": "derived_interaction_view",
+              "last_changed_at": "",
+              "regenerated_from_version": "",
+              "semantic_hash": "a476ea2b7331f506",
+              "semantic_version": 1,
+              "supersedes": []
+            },
+            "id": "enroll-member-realization-step-1",
+            "model_layer": "analysis",
+            "semantic_id": "enroll-member-realization-step-1",
+            "step_index": 1,
+            "text": "Customer opens the loyalty enrollment flow.",
+            "trace": {
+              "source_key": "use_cases",
+              "source_round": 3
+            },
+            "use_case_id": "enroll-member",
+            "use_case_name": "Enroll Member"
+          },
+          {
+            "change_metadata": {
+              "change_source": "derived_interaction_view",
+              "last_changed_at": "",
+              "regenerated_from_version": "",
+              "semantic_hash": "8578be3ef7656aeb",
+              "semantic_version": 1,
+              "supersedes": []
+            },
+            "id": "enroll-member-realization-step-2",
+            "model_layer": "analysis",
+            "semantic_id": "enroll-member-realization-step-2",
+            "step_index": 2,
+            "text": "Customer provides the required details and consents.",
+            "trace": {
+              "source_key": "use_cases",
+              "source_round": 3
+            },
+            "use_case_id": "enroll-member",
+            "use_case_name": "Enroll Member"
+          },
+          {
+            "change_metadata": {
+              "change_source": "derived_interaction_view",
+              "last_changed_at": "",
+              "regenerated_from_version": "",
+              "semantic_hash": "e5039ce4685174d5",
+              "semantic_version": 1,
+              "supersedes": []
+            },
+            "id": "enroll-member-realization-step-3",
+            "model_layer": "analysis",
+            "semantic_id": "enroll-member-realization-step-3",
+            "step_index": 3,
+            "text": "System validates the submission and creates the member account.",
+            "trace": {
+              "source_key": "use_cases",
+              "source_round": 3
+            },
+            "use_case_id": "enroll-member",
+            "use_case_name": "Enroll Member"
+          }
+        ],
+        "steps": [
+          "Customer opens the loyalty enrollment flow.",
+          "Customer provides the required details and consents.",
+          "System validates the submission and creates the member account."
+        ],
+        "trace": {
+          "source_key": "use_cases",
+          "source_round": 3
+        },
+        "use_case_id": "enroll-member",
+        "use_case_name": "Enroll Member"
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_interaction_view",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "03bda7f663ea5513",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "id": "interaction-realization-2",
+        "model_layer": "analysis",
+        "participant_ids": [],
+        "participant_names": [],
+        "semantic_id": "interaction-realization-2",
+        "step_objects": [
+          {
+            "change_metadata": {
+              "change_source": "derived_interaction_view",
+              "last_changed_at": "",
+              "regenerated_from_version": "",
+              "semantic_hash": "d276f7926a871b5d",
+              "semantic_version": 1,
+              "supersedes": []
+            },
+            "id": "browse-rewards-realization-step-1",
+            "model_layer": "analysis",
+            "semantic_id": "browse-rewards-realization-step-1",
+            "step_index": 1,
+            "text": "Customer opens the rewards catalog.",
+            "trace": {
+              "source_key": "use_cases",
+              "source_round": 3
+            },
+            "use_case_id": "browse-rewards",
+            "use_case_name": "Browse Rewards"
+          },
+          {
+            "change_metadata": {
+              "change_source": "derived_interaction_view",
+              "last_changed_at": "",
+              "regenerated_from_version": "",
+              "semantic_hash": "4bfc8e781caaaaaa",
+              "semantic_version": 1,
+              "supersedes": []
+            },
+            "id": "browse-rewards-realization-step-2",
+            "model_layer": "analysis",
+            "semantic_id": "browse-rewards-realization-step-2",
+            "step_index": 2,
+            "text": "System displays available rewards and points balance.",
+            "trace": {
+              "source_key": "use_cases",
+              "source_round": 3
+            },
+            "use_case_id": "browse-rewards",
+            "use_case_name": "Browse Rewards"
+          },
+          {
+            "change_metadata": {
+              "change_source": "derived_interaction_view",
+              "last_changed_at": "",
+              "regenerated_from_version": "",
+              "semantic_hash": "9a3abab5ef2fdd9e",
+              "semantic_version": 1,
+              "supersedes": []
+            },
+            "id": "browse-rewards-realization-step-3",
+            "model_layer": "analysis",
+            "semantic_id": "browse-rewards-realization-step-3",
+            "step_index": 3,
+            "text": "Customer filters or sorts the catalog.",
+            "trace": {
+              "source_key": "use_cases",
+              "source_round": 3
+            },
+            "use_case_id": "browse-rewards",
+            "use_case_name": "Browse Rewards"
+          }
+        ],
+        "steps": [
+          "Customer opens the rewards catalog.",
+          "System displays available rewards and points balance.",
+          "Customer filters or sorts the catalog."
+        ],
+        "trace": {
+          "source_key": "use_cases",
+          "source_round": 3
+        },
+        "use_case_id": "browse-rewards",
+        "use_case_name": "Browse Rewards"
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_interaction_view",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "6e6e35c313c02a6c",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "id": "interaction-realization-3",
+        "model_layer": "analysis",
+        "participant_ids": [],
+        "participant_names": [],
+        "semantic_id": "interaction-realization-3",
+        "step_objects": [
+          {
+            "change_metadata": {
+              "change_source": "derived_interaction_view",
+              "last_changed_at": "",
+              "regenerated_from_version": "",
+              "semantic_hash": "6956a25fa7ea1821",
+              "semantic_version": 1,
+              "supersedes": []
+            },
+            "id": "redeem-reward-realization-step-1",
+            "model_layer": "analysis",
+            "semantic_id": "redeem-reward-realization-step-1",
+            "step_index": 1,
+            "text": "Customer selects a reward.",
+            "trace": {
+              "source_key": "use_cases",
+              "source_round": 3
+            },
+            "use_case_id": "redeem-reward",
+            "use_case_name": "Redeem Reward"
+          },
+          {
+            "change_metadata": {
+              "change_source": "derived_interaction_view",
+              "last_changed_at": "",
+              "regenerated_from_version": "",
+              "semantic_hash": "6f9db55aadddb956",
+              "semantic_version": 1,
+              "supersedes": []
+            },
+            "id": "redeem-reward-realization-step-2",
+            "model_layer": "analysis",
+            "semantic_id": "redeem-reward-realization-step-2",
+            "step_index": 2,
+            "text": "System validates reward eligibility and available points.",
+            "trace": {
+              "source_key": "use_cases",
+              "source_round": 3
+            },
+            "use_case_id": "redeem-reward",
+            "use_case_name": "Redeem Reward"
+          },
+          {
+            "change_metadata": {
+              "change_source": "derived_interaction_view",
+              "last_changed_at": "",
+              "regenerated_from_version": "",
+              "semantic_hash": "38155a4ea69a69f9",
+              "semantic_version": 1,
+              "supersedes": []
+            },
+            "id": "redeem-reward-realization-step-3",
+            "model_layer": "analysis",
+            "semantic_id": "redeem-reward-realization-step-3",
+            "step_index": 3,
+            "text": "System reserves the reward and updates the member balance.",
+            "trace": {
+              "source_key": "use_cases",
+              "source_round": 3
+            },
+            "use_case_id": "redeem-reward",
+            "use_case_name": "Redeem Reward"
+          },
+          {
+            "change_metadata": {
+              "change_source": "derived_interaction_view",
+              "last_changed_at": "",
+              "regenerated_from_version": "",
+              "semantic_hash": "f7ef8f9d66c3e33b",
+              "semantic_version": 1,
+              "supersedes": []
+            },
+            "id": "redeem-reward-realization-step-4",
+            "model_layer": "analysis",
+            "semantic_id": "redeem-reward-realization-step-4",
+            "step_index": 4,
+            "text": "System confirms redemption to the customer.",
+            "trace": {
+              "source_key": "use_cases",
+              "source_round": 3
+            },
+            "use_case_id": "redeem-reward",
+            "use_case_name": "Redeem Reward"
+          }
+        ],
+        "steps": [
+          "Customer selects a reward.",
+          "System validates reward eligibility and available points.",
+          "System reserves the reward and updates the member balance.",
+          "System confirms redemption to the customer."
+        ],
+        "trace": {
+          "source_key": "use_cases",
+          "source_round": 3
+        },
+        "use_case_id": "redeem-reward",
+        "use_case_name": "Redeem Reward"
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_interaction_view",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "2e012933135718dd",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "id": "interaction-realization-4",
+        "model_layer": "analysis",
+        "participant_ids": [],
+        "participant_names": [],
+        "semantic_id": "interaction-realization-4",
+        "step_objects": [
+          {
+            "change_metadata": {
+              "change_source": "derived_interaction_view",
+              "last_changed_at": "",
+              "regenerated_from_version": "",
+              "semantic_hash": "8c5d4ad7848bec46",
+              "semantic_version": 1,
+              "supersedes": []
+            },
+            "id": "manage-reward-catalog-realization-step-1",
+            "model_layer": "analysis",
+            "semantic_id": "manage-reward-catalog-realization-step-1",
+            "step_index": 1,
+            "text": "Operations Manager opens catalog administration.",
+            "trace": {
+              "source_key": "use_cases",
+              "source_round": 3
+            },
+            "use_case_id": "manage-reward-catalog",
+            "use_case_name": "Manage Reward Catalog"
+          },
+          {
+            "change_metadata": {
+              "change_source": "derived_interaction_view",
+              "last_changed_at": "",
+              "regenerated_from_version": "",
+              "semantic_hash": "5c23321a56f915a0",
+              "semantic_version": 1,
+              "supersedes": []
+            },
+            "id": "manage-reward-catalog-realization-step-2",
+            "model_layer": "analysis",
+            "semantic_id": "manage-reward-catalog-realization-step-2",
+            "step_index": 2,
+            "text": "Operations Manager updates reward configuration.",
+            "trace": {
+              "source_key": "use_cases",
+              "source_round": 3
+            },
+            "use_case_id": "manage-reward-catalog",
+            "use_case_name": "Manage Reward Catalog"
+          },
+          {
+            "change_metadata": {
+              "change_source": "derived_interaction_view",
+              "last_changed_at": "",
+              "regenerated_from_version": "",
+              "semantic_hash": "7e9ad93c2c580cd3",
+              "semantic_version": 1,
+              "supersedes": []
+            },
+            "id": "manage-reward-catalog-realization-step-3",
+            "model_layer": "analysis",
+            "semantic_id": "manage-reward-catalog-realization-step-3",
+            "step_index": 3,
+            "text": "System validates and publishes the change.",
+            "trace": {
+              "source_key": "use_cases",
+              "source_round": 3
+            },
+            "use_case_id": "manage-reward-catalog",
+            "use_case_name": "Manage Reward Catalog"
+          }
+        ],
+        "steps": [
+          "Operations Manager opens catalog administration.",
+          "Operations Manager updates reward configuration.",
+          "System validates and publishes the change."
+        ],
+        "trace": {
+          "source_key": "use_cases",
+          "source_round": 3
+        },
+        "use_case_id": "manage-reward-catalog",
+        "use_case_name": "Manage Reward Catalog"
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_interaction_view",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "12255a520e6ed1e3",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "id": "interaction-realization-5",
+        "model_layer": "analysis",
+        "participant_ids": [],
+        "participant_names": [],
+        "semantic_id": "interaction-realization-5",
+        "step_objects": [
+          {
+            "change_metadata": {
+              "change_source": "derived_interaction_view",
+              "last_changed_at": "",
+              "regenerated_from_version": "",
+              "semantic_hash": "47f7dc328e26b24d",
+              "semantic_version": 1,
+              "supersedes": []
+            },
+            "id": "review-redemption-analytics-realization-step-1",
+            "model_layer": "analysis",
+            "semantic_id": "review-redemption-analytics-realization-step-1",
+            "step_index": 1,
+            "text": "Operations Manager opens the analytics dashboard.",
+            "trace": {
+              "source_key": "use_cases",
+              "source_round": 3
+            },
+            "use_case_id": "review-redemption-analytics",
+            "use_case_name": "Review Redemption Analytics"
+          },
+          {
+            "change_metadata": {
+              "change_source": "derived_interaction_view",
+              "last_changed_at": "",
+              "regenerated_from_version": "",
+              "semantic_hash": "d712935e22e0f624",
+              "semantic_version": 1,
+              "supersedes": []
+            },
+            "id": "review-redemption-analytics-realization-step-2",
+            "model_layer": "analysis",
+            "semantic_id": "review-redemption-analytics-realization-step-2",
+            "step_index": 2,
+            "text": "System shows redemption and campaign metrics.",
+            "trace": {
+              "source_key": "use_cases",
+              "source_round": 3
+            },
+            "use_case_id": "review-redemption-analytics",
+            "use_case_name": "Review Redemption Analytics"
+          }
+        ],
+        "steps": [
+          "Operations Manager opens the analytics dashboard.",
+          "System shows redemption and campaign metrics."
+        ],
+        "trace": {
+          "source_key": "use_cases",
+          "source_round": 3
+        },
+        "use_case_id": "review-redemption-analytics",
+        "use_case_name": "Review Redemption Analytics"
+      }
+    ]
+  },
+  "logical_view": {
+    "business_rule_objects": [
+      {
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "31ed3a5922b7f6f7",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "id": "business-rule-1",
+        "model_layer": "analysis",
+        "name": "Rule 1",
+        "rule_text": "A Redemption must not be fulfilled unless reward eligibility and available points are confirmed.",
+        "scope": "A Redemption",
+        "semantic_id": "business-rule-1",
+        "trace": {
+          "source_key": "business_rules",
+          "source_round": 5
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "c647a6ca1c45f1eb",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "id": "business-rule-2",
+        "model_layer": "analysis",
+        "name": "Rule 2",
+        "rule_text": "A Reward Catalog Entry must be validated before it becomes Published.",
+        "scope": "A Reward Catalog Entry",
+        "semantic_id": "business-rule-2",
+        "trace": {
+          "source_key": "business_rules",
+          "source_round": 5
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "0a51c9b642e8f7bb",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "id": "business-rule-3",
+        "model_layer": "analysis",
+        "name": "Rule 3",
+        "rule_text": "A Member must provide the required details and consents before enrollment completes.",
+        "scope": "A Member",
+        "semantic_id": "business-rule-3",
+        "trace": {
+          "source_key": "business_rules",
+          "source_round": 5
+        }
+      }
+    ],
+    "business_rules": [
+      "A Redemption must not be fulfilled unless reward eligibility and available points are confirmed.",
+      "A Reward Catalog Entry must be validated before it becomes Published.",
+      "A Member must provide the required details and consents before enrollment completes."
+    ],
+    "domain_entities": [
+      "Member",
+      "Reward",
+      "Reward Catalog Entry",
+      "Campaign",
+      "Redemption",
+      "Payment Confirmation",
+      "Analytics Report"
+    ],
+    "domain_entity_objects": [
+      {
+        "attributes": [],
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "88db15323024bb83",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "",
+        "entity_type": "domain_entity",
+        "id": "entity-member",
+        "model_layer": "analysis",
+        "name": "Member",
+        "responsibilities": [],
+        "semantic_id": "entity-member",
+        "trace": {
+          "source_key": "domain_entities",
+          "source_round": 5
+        }
+      },
+      {
+        "attributes": [],
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "c77a1b736f14366c",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "",
+        "entity_type": "domain_entity",
+        "id": "entity-reward",
+        "model_layer": "analysis",
+        "name": "Reward",
+        "responsibilities": [],
+        "semantic_id": "entity-reward",
+        "trace": {
+          "source_key": "domain_entities",
+          "source_round": 5
+        }
+      },
+      {
+        "attributes": [],
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "2df4a67e03f7f9a6",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "",
+        "entity_type": "domain_entity",
+        "id": "entity-reward-catalog-entry",
+        "model_layer": "analysis",
+        "name": "Reward Catalog Entry",
+        "responsibilities": [],
+        "semantic_id": "entity-reward-catalog-entry",
+        "trace": {
+          "source_key": "domain_entities",
+          "source_round": 5
+        }
+      },
+      {
+        "attributes": [],
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "6201c0d87098e9ce",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "",
+        "entity_type": "domain_entity",
+        "id": "entity-campaign",
+        "model_layer": "analysis",
+        "name": "Campaign",
+        "responsibilities": [],
+        "semantic_id": "entity-campaign",
+        "trace": {
+          "source_key": "domain_entities",
+          "source_round": 5
+        }
+      },
+      {
+        "attributes": [],
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "00eaa33d6b332bcb",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "",
+        "entity_type": "domain_entity",
+        "id": "entity-redemption",
+        "model_layer": "analysis",
+        "name": "Redemption",
+        "responsibilities": [],
+        "semantic_id": "entity-redemption",
+        "trace": {
+          "source_key": "domain_entities",
+          "source_round": 5
+        }
+      },
+      {
+        "attributes": [],
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "636404d9ab89daba",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "",
+        "entity_type": "domain_entity",
+        "id": "entity-payment-confirmation",
+        "model_layer": "analysis",
+        "name": "Payment Confirmation",
+        "responsibilities": [],
+        "semantic_id": "entity-payment-confirmation",
+        "trace": {
+          "source_key": "domain_entities",
+          "source_round": 5
+        }
+      },
+      {
+        "attributes": [],
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "2dae1906e4d468a1",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "",
+        "entity_type": "domain_entity",
+        "id": "entity-analytics-report",
+        "model_layer": "analysis",
+        "name": "Analytics Report",
+        "responsibilities": [],
+        "semantic_id": "entity-analytics-report",
+        "trace": {
+          "source_key": "domain_entities",
+          "source_round": 5
+        }
+      }
+    ],
+    "domain_invariant_objects": [
+      {
+        "change_metadata": {
+          "change_source": "derived_domain_invariants",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "9bdd873c55f95c20",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "A Redemption must not be fulfilled unless reward eligibility and available points are confirmed.",
+        "id": "domain-invariant-1",
+        "model_layer": "analysis",
+        "name": "Rule 1",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "domain_invariants",
+          "id": "domain-invariant-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "scope_entity_ids": [
+          "entity-reward",
+          "entity-redemption"
+        ],
+        "semantic_id": "domain-invariant-1",
+        "source_business_rule_id": "business-rule-1",
+        "trace": {
+          "source_key": "business_rules",
+          "source_round": 5
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_domain_invariants",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "a637b3e22f50cdd4",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "A Reward Catalog Entry must be validated before it becomes Published.",
+        "id": "domain-invariant-2",
+        "model_layer": "analysis",
+        "name": "Rule 2",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "domain_invariants",
+          "id": "domain-invariant-2",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "scope_entity_ids": [
+          "entity-reward",
+          "entity-reward-catalog-entry"
+        ],
+        "semantic_id": "domain-invariant-2",
+        "source_business_rule_id": "business-rule-2",
+        "trace": {
+          "source_key": "business_rules",
+          "source_round": 5
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_domain_invariants",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "c2cf041e428bfa76",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "A Member must provide the required details and consents before enrollment completes.",
+        "id": "domain-invariant-3",
+        "model_layer": "analysis",
+        "name": "Rule 3",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "domain_invariants",
+          "id": "domain-invariant-3",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "scope_entity_ids": [
+          "entity-member"
+        ],
+        "semantic_id": "domain-invariant-3",
+        "source_business_rule_id": "business-rule-3",
+        "trace": {
+          "source_key": "business_rules",
+          "source_round": 5
+        }
+      }
+    ],
+    "domain_invariants": [
+      "A Redemption must not be fulfilled unless reward eligibility and available points are confirmed.",
+      "A Reward Catalog Entry must be validated before it becomes Published.",
+      "A Member must provide the required details and consents before enrollment completes."
+    ],
+    "relationship_objects": [
+      {
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "53cea002c83a9170",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "A Member has many Redemptions",
+        "id": "relationship-1",
+        "model_layer": "analysis",
+        "relationship_type": "has_many",
+        "semantic_id": "relationship-1",
+        "source_entity_id": "entity-member",
+        "source_multiplicity": "1",
+        "source_name": "A Member",
+        "source_role_name": "redemptions",
+        "target_entity_id": "entity-redemption",
+        "target_multiplicity": "*",
+        "target_name": "Redemptions",
+        "target_role_name": "a_member",
+        "trace": {
+          "source_key": "relationships",
+          "source_round": 5
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "a9a577dfd3c66013",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "A Reward Catalog Entry has one Reward",
+        "id": "relationship-2",
+        "model_layer": "analysis",
+        "relationship_type": "",
+        "semantic_id": "relationship-2",
+        "source_entity_id": "",
+        "source_multiplicity": "",
+        "source_name": "",
+        "source_role_name": "",
+        "target_entity_id": "",
+        "target_multiplicity": "",
+        "target_name": "",
+        "target_role_name": "",
+        "trace": {
+          "source_key": "relationships",
+          "source_round": 5
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "a1a2ce18eb6193fc",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "A Campaign has many Reward Catalog Entries",
+        "id": "relationship-3",
+        "model_layer": "analysis",
+        "relationship_type": "has_many",
+        "semantic_id": "relationship-3",
+        "source_entity_id": "entity-campaign",
+        "source_multiplicity": "1",
+        "source_name": "A Campaign",
+        "source_role_name": "reward_catalog_entries",
+        "target_entity_id": "entity-reward-catalog-entry",
+        "target_multiplicity": "*",
+        "target_name": "Reward Catalog Entries",
+        "target_role_name": "a_campaign",
+        "trace": {
+          "source_key": "relationships",
+          "source_round": 5
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "8042da34054a4968",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "A Redemption has one Payment Confirmation",
+        "id": "relationship-4",
+        "model_layer": "analysis",
+        "relationship_type": "",
+        "semantic_id": "relationship-4",
+        "source_entity_id": "",
+        "source_multiplicity": "",
+        "source_name": "",
+        "source_role_name": "",
+        "target_entity_id": "",
+        "target_multiplicity": "",
+        "target_name": "",
+        "target_role_name": "",
+        "trace": {
+          "source_key": "relationships",
+          "source_round": 5
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_5",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "d221c438f9391632",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "An Analytics Report has many Redemptions",
+        "id": "relationship-5",
+        "model_layer": "analysis",
+        "relationship_type": "has_many",
+        "semantic_id": "relationship-5",
+        "source_entity_id": "entity-analytics-report",
+        "source_multiplicity": "1",
+        "source_name": "An Analytics Report",
+        "source_role_name": "redemptions",
+        "target_entity_id": "entity-redemption",
+        "target_multiplicity": "*",
+        "target_name": "Redemptions",
+        "target_role_name": "an_analytics_report",
+        "trace": {
+          "source_key": "relationships",
+          "source_round": 5
+        }
+      }
+    ],
+    "relationships": [
+      "A Member has many Redemptions",
+      "A Reward Catalog Entry has one Reward",
+      "A Campaign has many Reward Catalog Entries",
+      "A Redemption has one Payment Confirmation",
+      "An Analytics Report has many Redemptions"
+    ]
+  },
+  "metadata_fields": [
+    "Member identifier",
+    "Consent status",
+    "Point balance",
+    "Reward eligibility rules",
+    "Reward inventory",
+    "Campaign dates",
+    "Payment confirmation reference"
   ],
+  "model_metadata": {
+    "change_metadata": {
+      "change_source": "normalize_replay_to_model",
+      "last_changed_at": "",
+      "regenerated_from_version": "",
+      "semantic_hash": "f53b334e86e54b91",
+      "semantic_version": 1,
+      "supersedes": []
+    },
+    "schema_version": 1,
+    "semantic_id": "rupify-model"
+  },
+  "open_questions": [],
+  "process_view": {
+    "forbidden_transition_objects": [
+      {
+        "change_metadata": {
+          "change_source": "derived_forbidden_transitions",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "793aa682141bec56",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "A Redemption must not be fulfilled unless reward eligibility and available points are confirmed.",
+        "from_state": "",
+        "id": "forbidden-transition-1",
+        "model_layer": "analysis",
+        "name": "Forbidden Transition 1",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "forbidden_transitions",
+          "id": "forbidden-transition-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "related_transition_id": "",
+        "semantic_id": "forbidden-transition-1",
+        "source_business_rule_id": "business-rule-1",
+        "state_entity_id": "",
+        "to_state": "",
+        "trace": {
+          "source_key": "business_rules",
+          "source_round": 5
+        }
+      }
+    ],
+    "forbidden_transitions": [
+      "A Redemption must not be fulfilled unless reward eligibility and available points are confirmed."
+    ],
+    "guard_condition_objects": [
+      {
+        "change_metadata": {
+          "change_source": "derived_guard_conditions",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "5af79f330a184976",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "condition_text": "Payment confirmation triggers redemption fulfillment",
+        "content_semantics": "normative",
+        "description": "Payment confirmation triggers redemption fulfillment",
+        "id": "guard-condition-1",
+        "model_layer": "analysis",
+        "name": "Payment confirmation",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "guard_conditions",
+          "id": "guard-condition-1",
+          "missing_fields": [
+            "related_transition_ids"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
+        },
+        "related_transition_ids": [],
+        "semantic_id": "guard-condition-1",
+        "source_trigger_id": "trigger-1",
+        "state_entity_ids": [
+          "state-entity-redemption"
+        ],
+        "trace": {
+          "source_key": "triggers_and_approvals",
+          "source_round": 6
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_guard_conditions",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "8c5e2e061f6f6c0b",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "condition_text": "Catalog validation approval is required before a reward becomes Published",
+        "content_semantics": "normative",
+        "description": "Catalog validation approval is required before a reward becomes Published",
+        "id": "guard-condition-2",
+        "model_layer": "analysis",
+        "name": "Guard Condition 2",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "guard_conditions",
+          "id": "guard-condition-2",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "related_transition_ids": [
+          "state-transition-1",
+          "state-transition-2",
+          "state-transition-3",
+          "state-transition-4",
+          "state-transition-5"
+        ],
+        "semantic_id": "guard-condition-2",
+        "source_trigger_id": "trigger-2",
+        "state_entity_ids": [],
+        "trace": {
+          "source_key": "triggers_and_approvals",
+          "source_round": 6
+        }
+      }
+    ],
+    "guard_conditions": [
+      "Payment confirmation triggers redemption fulfillment",
+      "Catalog validation approval is required before a reward becomes Published"
+    ],
+    "state_entities": [
+      "Redemption",
+      "Reward Catalog Entry"
+    ],
+    "state_entity_objects": [
+      {
+        "change_metadata": {
+          "change_source": "round_6",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "43f1a133415a38bb",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "",
+        "entity_type": "stateful_entity",
+        "id": "state-entity-redemption",
+        "model_layer": "analysis",
+        "name": "Redemption",
+        "semantic_id": "state-entity-redemption",
+        "states": [
+          "Requested",
+          "Validated",
+          "Fulfilled",
+          "Rejected"
+        ],
+        "trace": {
+          "source_key": "state_entities",
+          "source_round": 6
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_6",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "c145d5a38fe40ca1",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "",
+        "entity_type": "stateful_entity",
+        "id": "state-entity-reward-catalog-entry",
+        "model_layer": "analysis",
+        "name": "Reward Catalog Entry",
+        "semantic_id": "state-entity-reward-catalog-entry",
+        "states": [
+          "Draft",
+          "Published",
+          "Retired"
+        ],
+        "trace": {
+          "source_key": "state_entities",
+          "source_round": 6
+        }
+      }
+    ],
+    "state_invariant_objects": [
+      {
+        "change_metadata": {
+          "change_source": "derived_state_invariants",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "1001f94a08fd8f05",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "A Redemption must not be fulfilled unless reward eligibility and available points are confirmed.",
+        "id": "state-invariant-1",
+        "model_layer": "analysis",
+        "name": "Rule 1",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "state_invariants",
+          "id": "state-invariant-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "state-invariant-1",
+        "source_business_rule_id": "business-rule-1",
+        "state_entity_ids": [
+          "state-entity-redemption"
+        ],
+        "trace": {
+          "source_key": "business_rules",
+          "source_round": 5
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_state_invariants",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "da255172f2fcc35e",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "description": "A Reward Catalog Entry must be validated before it becomes Published.",
+        "id": "state-invariant-2",
+        "model_layer": "analysis",
+        "name": "Rule 2",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "state_invariants",
+          "id": "state-invariant-2",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "state-invariant-2",
+        "source_business_rule_id": "business-rule-2",
+        "state_entity_ids": [
+          "state-entity-reward-catalog-entry"
+        ],
+        "trace": {
+          "source_key": "business_rules",
+          "source_round": 5
+        }
+      }
+    ],
+    "state_invariants": [
+      "A Redemption must not be fulfilled unless reward eligibility and available points are confirmed.",
+      "A Reward Catalog Entry must be validated before it becomes Published."
+    ],
+    "state_transition_objects": [
+      {
+        "change_metadata": {
+          "change_source": "round_6",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "d5953bdf2d9317ff",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint": "",
+        "content_semantics": "normative",
+        "description": "Redemption: Requested -> Validated -> Fulfilled",
+        "from_state": "Requested",
+        "id": "state-transition-1",
+        "is_exception_flow": false,
+        "is_terminal_transition": false,
+        "model_layer": "analysis",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "state_transitions",
+          "id": "state-transition-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "state-transition-1",
+        "state_entity_id": "state-entity-redemption",
+        "state_entity_name": "Redemption",
+        "to_state": "Validated",
+        "trace": {
+          "source_key": "states_and_transitions",
+          "source_round": 6
+        },
+        "trigger": ""
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_6",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "11aeec55110ebd28",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint": "",
+        "content_semantics": "normative",
+        "description": "Redemption: Requested -> Validated -> Fulfilled",
+        "from_state": "Validated",
+        "id": "state-transition-2",
+        "is_exception_flow": false,
+        "is_terminal_transition": true,
+        "model_layer": "analysis",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "state_transitions",
+          "id": "state-transition-2",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "state-transition-2",
+        "state_entity_id": "state-entity-redemption",
+        "state_entity_name": "Redemption",
+        "to_state": "Fulfilled",
+        "trace": {
+          "source_key": "states_and_transitions",
+          "source_round": 6
+        },
+        "trigger": ""
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_6",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "e46f9325295e1da2",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint": "",
+        "content_semantics": "normative",
+        "description": "Redemption: Requested -> Rejected",
+        "from_state": "Requested",
+        "id": "state-transition-3",
+        "is_exception_flow": true,
+        "is_terminal_transition": true,
+        "model_layer": "analysis",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "state_transitions",
+          "id": "state-transition-3",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "state-transition-3",
+        "state_entity_id": "state-entity-redemption",
+        "state_entity_name": "Redemption",
+        "to_state": "Rejected",
+        "trace": {
+          "source_key": "states_and_transitions",
+          "source_round": 6
+        },
+        "trigger": ""
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_6",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "25b25e4f3f2e7e93",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint": "",
+        "content_semantics": "normative",
+        "description": "Reward Catalog Entry: Draft -> Published -> Retired",
+        "from_state": "Draft",
+        "id": "state-transition-4",
+        "is_exception_flow": false,
+        "is_terminal_transition": false,
+        "model_layer": "analysis",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "state_transitions",
+          "id": "state-transition-4",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "state-transition-4",
+        "state_entity_id": "state-entity-reward-catalog-entry",
+        "state_entity_name": "Reward Catalog Entry",
+        "to_state": "Published",
+        "trace": {
+          "source_key": "states_and_transitions",
+          "source_round": 6
+        },
+        "trigger": ""
+      },
+      {
+        "change_metadata": {
+          "change_source": "round_6",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "321f360989484fde",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint": "",
+        "content_semantics": "normative",
+        "description": "Reward Catalog Entry: Draft -> Published -> Retired",
+        "from_state": "Published",
+        "id": "state-transition-5",
+        "is_exception_flow": false,
+        "is_terminal_transition": false,
+        "model_layer": "analysis",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "state_transitions",
+          "id": "state-transition-5",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "state-transition-5",
+        "state_entity_id": "state-entity-reward-catalog-entry",
+        "state_entity_name": "Reward Catalog Entry",
+        "to_state": "Retired",
+        "trace": {
+          "source_key": "states_and_transitions",
+          "source_round": 6
+        },
+        "trigger": ""
+      }
+    ],
+    "states_and_transitions": [
+      "Redemption: Requested -> Validated -> Fulfilled",
+      "Redemption: Requested -> Validated -> Fulfilled",
+      "Redemption: Requested -> Rejected",
+      "Reward Catalog Entry: Draft -> Published -> Retired",
+      "Reward Catalog Entry: Draft -> Published -> Retired"
+    ],
+    "trigger_objects": [
+      {
+        "approval_required": false,
+        "change_metadata": {
+          "change_source": "round_6",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "e538e9a9d69eae52",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint_type": "event",
+        "content_semantics": "normative",
+        "description": "Payment confirmation triggers redemption fulfillment",
+        "event_name": "Payment confirmation",
+        "exceptional_behavior": false,
+        "id": "trigger-1",
+        "model_layer": "analysis",
+        "outcome": "redemption fulfillment",
+        "semantic_id": "trigger-1",
+        "trace": {
+          "source_key": "triggers_and_approvals",
+          "source_round": 6
+        }
+      },
+      {
+        "approval_required": true,
+        "change_metadata": {
+          "change_source": "round_6",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "1f509a6eabb650c0",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint_type": "approval",
+        "content_semantics": "normative",
+        "description": "Catalog validation approval is required before a reward becomes Published",
+        "event_name": "",
+        "exceptional_behavior": false,
+        "id": "trigger-2",
+        "model_layer": "analysis",
+        "outcome": "",
+        "semantic_id": "trigger-2",
+        "trace": {
+          "source_key": "triggers_and_approvals",
+          "source_round": 6
+        }
+      }
+    ],
+    "triggers_and_approvals": [
+      "Payment confirmation triggers redemption fulfillment",
+      "Catalog validation approval is required before a reward becomes Published"
+    ]
+  },
   "project": {
-    "domain": "Retail",
+    "domain": "Unspecified",
     "name": "Loyalty Platform",
     "problem_statement": "Legacy loyalty operations are fragmented across channels and teams, causing inconsistent member experience and slow campaign execution.",
     "system_scope": "A member loyalty platform for enrollment, rewards browsing, redemption, and operational reporting."
   },
   "requirements": {
-    "functional": [
+    "acceptance_constraint_objects": [
+      {
+        "change_metadata": {
+          "change_source": "derived_acceptance_constraints",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "94812897dc06184b",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint_kind": "non_functional_requirement",
+        "content_semantics": "normative",
+        "description": "The system must protect member and reward transactions with appropriate security controls.",
+        "id": "acceptance-constraint-requirement-1",
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "name": "Acceptance Constraint 1",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-requirement-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "acceptance-constraint-requirement-1",
+        "source_requirement_id": "non_functional-requirement-1",
+        "trace": {
+          "source_key": "constraints",
+          "source_round": 2
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_acceptance_constraints",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "9dc0f244dacd87c2",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint_kind": "non_functional_requirement",
+        "content_semantics": "normative",
+        "description": "The member-facing experience must remain usable on common digital channels.",
+        "id": "acceptance-constraint-requirement-2",
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "name": "Acceptance Constraint 2",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-requirement-2",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "acceptance-constraint-requirement-2",
+        "source_requirement_id": "non_functional-requirement-2",
+        "trace": {
+          "source_key": "constraints",
+          "source_round": 2
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_acceptance_constraints",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "2ff2dee2880ffd8d",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint_kind": "non_functional_requirement",
+        "content_semantics": "normative",
+        "description": "The platform must support integrations with external systems such as payment confirmation and reporting sources.",
+        "id": "acceptance-constraint-requirement-3",
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "name": "Acceptance Constraint 3",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-requirement-3",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "acceptance-constraint-requirement-3",
+        "source_requirement_id": "non_functional-requirement-3",
+        "trace": {
+          "source_key": "constraints",
+          "source_round": 2
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_acceptance_constraints",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "257c1792f5ca8674",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint_kind": "non_functional_requirement",
+        "content_semantics": "normative",
+        "description": "The system must allow customers to enroll in the loyalty program digitally.",
+        "id": "acceptance-constraint-requirement-4",
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "name": "Acceptance Constraint 4",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-requirement-4",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "acceptance-constraint-requirement-4",
+        "source_requirement_id": "non_functional-requirement-4",
+        "trace": {
+          "source_key": "non_functional_requirements",
+          "source_round": 4
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_acceptance_constraints",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "bd76e87bf7d763f7",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint_kind": "non_functional_requirement",
+        "content_semantics": "normative",
+        "description": "The system must show point balance and available rewards to eligible members.",
+        "id": "acceptance-constraint-requirement-5",
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "name": "Acceptance Constraint 5",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-requirement-5",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "acceptance-constraint-requirement-5",
+        "source_requirement_id": "non_functional-requirement-5",
+        "trace": {
+          "source_key": "non_functional_requirements",
+          "source_round": 4
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_acceptance_constraints",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "a705e18f2183b881",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint_kind": "non_functional_requirement",
+        "content_semantics": "normative",
+        "description": "The system must allow members to redeem rewards when eligibility conditions are satisfied.",
+        "id": "acceptance-constraint-requirement-6",
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "name": "Acceptance Constraint 6",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-requirement-6",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "acceptance-constraint-requirement-6",
+        "source_requirement_id": "non_functional-requirement-6",
+        "trace": {
+          "source_key": "non_functional_requirements",
+          "source_round": 4
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_acceptance_constraints",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "b4be53384966216f",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint_kind": "non_functional_requirement",
+        "content_semantics": "normative",
+        "description": "The system must provide reporting on redemptions and campaign performance.",
+        "id": "acceptance-constraint-requirement-7",
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "name": "Acceptance Constraint 7",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-requirement-7",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "acceptance-constraint-requirement-7",
+        "source_requirement_id": "non_functional-requirement-7",
+        "trace": {
+          "source_key": "non_functional_requirements",
+          "source_round": 4
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_acceptance_constraints",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "50e151c1183f5872",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint_kind": "success_criterion",
+        "content_semantics": "normative",
+        "description": "Members can enroll and redeem rewards through one coherent digital journey.",
+        "id": "acceptance-constraint-success-1",
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "name": "Success Criterion 1",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-success-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "acceptance-constraint-success-1",
+        "source_requirement_id": "",
+        "trace": {
+          "source_key": "success_criteria",
+          "source_round": 2
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_acceptance_constraints",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "2abb9a2aa9983c0a",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint_kind": "success_criterion",
+        "content_semantics": "normative",
+        "description": "Operations managers can update the reward catalog without engineering support for routine changes.",
+        "id": "acceptance-constraint-success-2",
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "name": "Success Criterion 2",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-success-2",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "acceptance-constraint-success-2",
+        "source_requirement_id": "",
+        "trace": {
+          "source_key": "success_criteria",
+          "source_round": 2
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "derived_acceptance_constraints",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "489ea823b5173325",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "constraint_kind": "success_criterion",
+        "content_semantics": "normative",
+        "description": "The business can review redemption and campaign performance in one reporting workflow.",
+        "id": "acceptance-constraint-success-3",
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "name": "Success Criterion 3",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "acceptance_constraints",
+          "id": "acceptance-constraint-success-3",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "semantic_id": "acceptance-constraint-success-3",
+        "source_requirement_id": "",
+        "trace": {
+          "source_key": "success_criteria",
+          "source_round": 2
+        }
+      }
+    ],
+    "acceptance_constraints": [
+      "The system must protect member and reward transactions with appropriate security controls.",
+      "The member-facing experience must remain usable on common digital channels.",
+      "The platform must support integrations with external systems such as payment confirmation and reporting sources.",
       "The system must allow customers to enroll in the loyalty program digitally.",
       "The system must show point balance and available rewards to eligible members.",
       "The system must allow members to redeem rewards when eligibility conditions are satisfied.",
+      "The system must provide reporting on redemptions and campaign performance.",
+      "Members can enroll and redeem rewards through one coherent digital journey.",
+      "Operations managers can update the reward catalog without engineering support for routine changes.",
+      "The business can review redemption and campaign performance in one reporting workflow."
+    ],
+    "functional": [
       "The system must allow operations managers to maintain reward catalog entries and campaign rules.",
-      "The system must provide reporting on redemptions and campaign performance."
+      "The platform must integrate with payment confirmation and downstream reporting sources."
+    ],
+    "functional_objects": [
+      {
+        "change_metadata": {
+          "change_source": "requirements",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "50ca3d7990de2576",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "fit_criterion": "",
+        "id": "functional-requirement-1",
+        "linked_step_ids": [],
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "quality_attribute": "",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "functional-requirement-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "requirement_kind": "functional",
+        "semantic_id": "functional-requirement-1",
+        "statement": "The system must allow operations managers to maintain reward catalog entries and campaign rules.",
+        "trace": {
+          "source_key": "workflow_scope",
+          "source_round": 4
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "requirements",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "137be52a3e449f36",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "fit_criterion": "",
+        "id": "functional-requirement-2",
+        "linked_step_ids": [],
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "quality_attribute": "",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "functional-requirement-2",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "requirement_kind": "functional",
+        "semantic_id": "functional-requirement-2",
+        "statement": "The platform must integrate with payment confirmation and downstream reporting sources.",
+        "trace": {
+          "source_key": "integrations",
+          "source_round": 3
+        }
+      }
     ],
     "non_functional": [
       "The system must protect member and reward transactions with appropriate security controls.",
       "The member-facing experience must remain usable on common digital channels.",
-      "The platform must support integrations with external systems such as payment confirmation and reporting sources."
+      "The platform must support integrations with external systems such as payment confirmation and reporting sources.",
+      "The system must allow customers to enroll in the loyalty program digitally.",
+      "The system must show point balance and available rewards to eligible members.",
+      "The system must allow members to redeem rewards when eligibility conditions are satisfied.",
+      "The system must provide reporting on redemptions and campaign performance."
+    ],
+    "non_functional_objects": [
+      {
+        "change_metadata": {
+          "change_source": "requirements",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "6d25cd70cc309bd6",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "fit_criterion": "",
+        "id": "non_functional-requirement-1",
+        "linked_step_ids": [],
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "quality_attribute": "",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "non_functional-requirement-1",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "requirement_kind": "non_functional",
+        "semantic_id": "non_functional-requirement-1",
+        "statement": "The system must protect member and reward transactions with appropriate security controls.",
+        "trace": {
+          "source_key": "constraints",
+          "source_round": 2
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "requirements",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "3c50cc9fdf143ffc",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "fit_criterion": "",
+        "id": "non_functional-requirement-2",
+        "linked_step_ids": [],
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "quality_attribute": "",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "non_functional-requirement-2",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "requirement_kind": "non_functional",
+        "semantic_id": "non_functional-requirement-2",
+        "statement": "The member-facing experience must remain usable on common digital channels.",
+        "trace": {
+          "source_key": "constraints",
+          "source_round": 2
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "requirements",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "123d736840c12b01",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "fit_criterion": "",
+        "id": "non_functional-requirement-3",
+        "linked_step_ids": [],
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "quality_attribute": "",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "non_functional-requirement-3",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "requirement_kind": "non_functional",
+        "semantic_id": "non_functional-requirement-3",
+        "statement": "The platform must support integrations with external systems such as payment confirmation and reporting sources.",
+        "trace": {
+          "source_key": "constraints",
+          "source_round": 2
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "requirements",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "91b01cf0f9df4489",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "fit_criterion": "",
+        "id": "non_functional-requirement-4",
+        "linked_step_ids": [],
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "quality_attribute": "",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "non_functional-requirement-4",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "requirement_kind": "non_functional",
+        "semantic_id": "non_functional-requirement-4",
+        "statement": "The system must allow customers to enroll in the loyalty program digitally.",
+        "trace": {
+          "source_key": "non_functional_requirements",
+          "source_round": 4
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "requirements",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "c869b78025ab245a",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "fit_criterion": "",
+        "id": "non_functional-requirement-5",
+        "linked_step_ids": [],
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "quality_attribute": "",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "non_functional-requirement-5",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "requirement_kind": "non_functional",
+        "semantic_id": "non_functional-requirement-5",
+        "statement": "The system must show point balance and available rewards to eligible members.",
+        "trace": {
+          "source_key": "non_functional_requirements",
+          "source_round": 4
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "requirements",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "5f03cdaaa89ad4e1",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "fit_criterion": "",
+        "id": "non_functional-requirement-6",
+        "linked_step_ids": [],
+        "linked_use_case_ids": [
+          "redeem-reward"
+        ],
+        "model_layer": "analysis",
+        "quality_attribute": "",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "non_functional-requirement-6",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "requirement_kind": "non_functional",
+        "semantic_id": "non_functional-requirement-6",
+        "statement": "The system must allow members to redeem rewards when eligibility conditions are satisfied.",
+        "trace": {
+          "source_key": "non_functional_requirements",
+          "source_round": 4
+        }
+      },
+      {
+        "change_metadata": {
+          "change_source": "requirements",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "925c5506da0bb97a",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "content_semantics": "normative",
+        "fit_criterion": "",
+        "id": "non_functional-requirement-7",
+        "linked_step_ids": [],
+        "linked_use_case_ids": [],
+        "model_layer": "analysis",
+        "quality_attribute": "",
+        "readiness": {
+          "blocking_ambiguity_ids": [],
+          "content_semantics": "normative",
+          "family": "requirements",
+          "id": "non_functional-requirement-7",
+          "missing_fields": [],
+          "normative_ready": true,
+          "status": "ready"
+        },
+        "requirement_kind": "non_functional",
+        "semantic_id": "non_functional-requirement-7",
+        "statement": "The system must provide reporting on redemptions and campaign performance.",
+        "trace": {
+          "source_key": "non_functional_requirements",
+          "source_round": 4
+        }
+      }
     ]
   },
+  "risks": [
+    {
+      "change_metadata": {
+        "change_source": "round_12",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "959edee70758d343",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "informative",
+      "description": "Payment confirmation dependency",
+      "id": "risk-payment-confirmation-dependency",
+      "mitigation": "add retry and reconciliation flow",
+      "model_layer": "analysis",
+      "name": "Payment confirmation dependency",
+      "priority": "high",
+      "semantic_id": "risk-payment-confirmation-dependency",
+      "status": "open",
+      "trace": {
+        "source_key": "risks",
+        "source_round": 12
+      }
+    },
+    {
+      "change_metadata": {
+        "change_source": "round_12",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "d4eb70816cb7a815",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "informative",
+      "description": "Reward configuration errors",
+      "id": "risk-reward-configuration-errors",
+      "mitigation": "validate publish flow and guard rules",
+      "model_layer": "analysis",
+      "name": "Reward configuration errors",
+      "priority": "medium",
+      "semantic_id": "risk-reward-configuration-errors",
+      "status": "open",
+      "trace": {
+        "source_key": "risks",
+        "source_round": 12
+      }
+    },
+    {
+      "change_metadata": {
+        "change_source": "round_12",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "48493fb41f5362d7",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "informative",
+      "description": "Reporting latency",
+      "id": "risk-reporting-latency",
+      "mitigation": "monitor analytics pipeline freshness",
+      "model_layer": "analysis",
+      "name": "Reporting latency",
+      "priority": "medium",
+      "semantic_id": "risk-reporting-latency",
+      "status": "open",
+      "trace": {
+        "source_key": "risks",
+        "source_round": 12
+      }
+    }
+  ],
+  "scenarios": [
+    {
+      "activity_notes": [],
+      "change_metadata": {
+        "change_source": "round_13",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "f0edac8165649917",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "flow_of_events": [
+        "Customer selects a reward.",
+        "System checks reward availability.",
+        "System reports that inventory is exhausted."
+      ],
+      "id": "scenario-reward-inventory-exhausted",
+      "model_layer": "analysis",
+      "name": "Reward Inventory Exhausted",
+      "other_artifact_refs": [],
+      "other_requirement_ids": [],
+      "participating_analysis_object_ids": [],
+      "priority": "high",
+      "readiness": {
+        "blocking_ambiguity_ids": [],
+        "content_semantics": "normative",
+        "family": "scenarios",
+        "id": "scenario-reward-inventory-exhausted",
+        "missing_fields": [],
+        "normative_ready": true,
+        "status": "ready"
+      },
+      "semantic_id": "scenario-reward-inventory-exhausted",
+      "sequence_notes": [],
+      "status": "open",
+      "summary": "Redemption fails because no reward inventory remains.",
+      "trace": {
+        "source_key": "scenarios",
+        "source_round": 13
+      },
+      "use_case_id": "redeem-reward",
+      "use_case_name": "Redeem Reward"
+    },
+    {
+      "activity_notes": [],
+      "change_metadata": {
+        "change_source": "round_13",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "1467185c4aeb36b1",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "flow_of_events": [
+        "Customer selects a reward.",
+        "System requests payment confirmation.",
+        "System blocks fulfillment until confirmation arrives."
+      ],
+      "id": "scenario-missing-payment-confirmation",
+      "model_layer": "analysis",
+      "name": "Missing Payment Confirmation",
+      "other_artifact_refs": [],
+      "other_requirement_ids": [],
+      "participating_analysis_object_ids": [],
+      "priority": "medium",
+      "readiness": {
+        "blocking_ambiguity_ids": [],
+        "content_semantics": "normative",
+        "family": "scenarios",
+        "id": "scenario-missing-payment-confirmation",
+        "missing_fields": [],
+        "normative_ready": true,
+        "status": "ready"
+      },
+      "semantic_id": "scenario-missing-payment-confirmation",
+      "sequence_notes": [],
+      "status": "open",
+      "summary": "Redemption pauses until dependent payment confirmation arrives.",
+      "trace": {
+        "source_key": "scenarios",
+        "source_round": 13
+      },
+      "use_case_id": "redeem-reward",
+      "use_case_name": "Redeem Reward"
+    },
+    {
+      "activity_notes": [],
+      "change_metadata": {
+        "change_source": "round_13",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "08157c043930c28b",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "flow_of_events": [
+        "Operations Manager updates reward configuration.",
+        "System validates the change.",
+        "System rejects the invalid change."
+      ],
+      "id": "scenario-invalid-catalog-change",
+      "model_layer": "analysis",
+      "name": "Invalid Catalog Change",
+      "other_artifact_refs": [],
+      "other_requirement_ids": [],
+      "participating_analysis_object_ids": [],
+      "priority": "medium",
+      "readiness": {
+        "blocking_ambiguity_ids": [],
+        "content_semantics": "normative",
+        "family": "scenarios",
+        "id": "scenario-invalid-catalog-change",
+        "missing_fields": [],
+        "normative_ready": true,
+        "status": "ready"
+      },
+      "semantic_id": "scenario-invalid-catalog-change",
+      "sequence_notes": [],
+      "status": "open",
+      "summary": "Publication is rejected because the new reward configuration would break an active offer.",
+      "trace": {
+        "source_key": "scenarios",
+        "source_round": 13
+      },
+      "use_case_id": "manage-reward-catalog",
+      "use_case_name": "Manage Reward Catalog"
+    },
+    {
+      "activity_notes": [],
+      "change_metadata": {
+        "change_source": "round_13",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "1e8c371b106e161c",
+        "semantic_version": 1,
+        "supersedes": []
+      },
+      "content_semantics": "normative",
+      "flow_of_events": [
+        "Operations Manager opens the analytics dashboard.",
+        "System detects delayed reporting data.",
+        "System shows a partial-data warning."
+      ],
+      "id": "scenario-reporting-delay",
+      "model_layer": "analysis",
+      "name": "Reporting Delay",
+      "other_artifact_refs": [],
+      "other_requirement_ids": [],
+      "participating_analysis_object_ids": [],
+      "priority": "low",
+      "readiness": {
+        "blocking_ambiguity_ids": [],
+        "content_semantics": "normative",
+        "family": "scenarios",
+        "id": "scenario-reporting-delay",
+        "missing_fields": [],
+        "normative_ready": true,
+        "status": "ready"
+      },
+      "semantic_id": "scenario-reporting-delay",
+      "sequence_notes": [],
+      "status": "open",
+      "summary": "Analytics view is partial because a reporting source is delayed.",
+      "trace": {
+        "source_key": "scenarios",
+        "source_round": 13
+      },
+      "use_case_id": "review-redemption-analytics",
+      "use_case_name": "Review Redemption Analytics"
+    }
+  ],
   "success_criteria": [
     "Members can enroll and redeem rewards through one coherent digital journey.",
     "Operations managers can update the reward catalog without engineering support for routine changes.",
     "The business can review redemption and campaign performance in one reporting workflow."
   ],
+  "traceability": {
+    "acceptance_constraint_to_requirement": [
+      {
+        "basis": "acceptance constraint is derived from canonical requirement",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "f499408c812a5b1f",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "acceptance-constraint-requirement-1",
+        "id": "trace-acceptance-constraint-requirement-1",
+        "link_type": "acceptance_constraint_to_requirement",
+        "semantic_id": "trace-acceptance-constraint-requirement-1",
+        "to_id": "non_functional-requirement-1"
+      },
+      {
+        "basis": "acceptance constraint is derived from canonical requirement",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "2a8f30551fd123cf",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "acceptance-constraint-requirement-2",
+        "id": "trace-acceptance-constraint-requirement-2",
+        "link_type": "acceptance_constraint_to_requirement",
+        "semantic_id": "trace-acceptance-constraint-requirement-2",
+        "to_id": "non_functional-requirement-2"
+      },
+      {
+        "basis": "acceptance constraint is derived from canonical requirement",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "1042f169ffa0dfac",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "acceptance-constraint-requirement-3",
+        "id": "trace-acceptance-constraint-requirement-3",
+        "link_type": "acceptance_constraint_to_requirement",
+        "semantic_id": "trace-acceptance-constraint-requirement-3",
+        "to_id": "non_functional-requirement-3"
+      },
+      {
+        "basis": "acceptance constraint is derived from canonical requirement",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "c159e8e6b122d0a5",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "acceptance-constraint-requirement-4",
+        "id": "trace-acceptance-constraint-requirement-4",
+        "link_type": "acceptance_constraint_to_requirement",
+        "semantic_id": "trace-acceptance-constraint-requirement-4",
+        "to_id": "non_functional-requirement-4"
+      },
+      {
+        "basis": "acceptance constraint is derived from canonical requirement",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "7093ee6afe35b701",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "acceptance-constraint-requirement-5",
+        "id": "trace-acceptance-constraint-requirement-5",
+        "link_type": "acceptance_constraint_to_requirement",
+        "semantic_id": "trace-acceptance-constraint-requirement-5",
+        "to_id": "non_functional-requirement-5"
+      },
+      {
+        "basis": "acceptance constraint is derived from canonical requirement",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "d21a0052e99e9f96",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "acceptance-constraint-requirement-6",
+        "id": "trace-acceptance-constraint-requirement-6",
+        "link_type": "acceptance_constraint_to_requirement",
+        "semantic_id": "trace-acceptance-constraint-requirement-6",
+        "to_id": "non_functional-requirement-6"
+      },
+      {
+        "basis": "acceptance constraint is derived from canonical requirement",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "925ad8c492270e3b",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "acceptance-constraint-requirement-7",
+        "id": "trace-acceptance-constraint-requirement-7",
+        "link_type": "acceptance_constraint_to_requirement",
+        "semantic_id": "trace-acceptance-constraint-requirement-7",
+        "to_id": "non_functional-requirement-7"
+      }
+    ],
+    "ambiguity_to_element": [],
+    "analysis_to_design": [
+      {
+        "basis": "design component name references analysis object name",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "cfc827de3bcb0695",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "entity-member",
+        "id": "trace-analysis-design-1",
+        "link_type": "analysis_to_design",
+        "semantic_id": "trace-analysis-design-1",
+        "to_id": "component-member-app"
+      }
+    ],
+    "artifact_lineage": [
+      {
+        "artifact_section": "risk factors",
+        "basis": "canonical risk factors object renders into system-document.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "6e46bfebcf530db4",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "risk-payment-confirmation-dependency",
+        "id": "trace-artifact-system-document-risk-factors-risk-payment-confirmation-dependency",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-system-document-risk-factors-risk-payment-confirmation-dependency",
+        "to_artifact": "system-document.md"
+      },
+      {
+        "artifact_section": "risk factors",
+        "basis": "canonical risk factors object renders into system-document.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "04e8c96dbefa590c",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "risk-reward-configuration-errors",
+        "id": "trace-artifact-system-document-risk-factors-risk-reward-configuration-errors",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-system-document-risk-factors-risk-reward-configuration-errors",
+        "to_artifact": "system-document.md"
+      },
+      {
+        "artifact_section": "risk factors",
+        "basis": "canonical risk factors object renders into system-document.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "62f3c4291f6e74b8",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "risk-reporting-latency",
+        "id": "trace-artifact-system-document-risk-factors-risk-reporting-latency",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-system-document-risk-factors-risk-reporting-latency",
+        "to_artifact": "system-document.md"
+      },
+      {
+        "artifact_section": "system-level use cases",
+        "basis": "canonical system-level use cases object renders into system-document.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "55052802958f7158",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "enroll-member",
+        "id": "trace-artifact-system-document-system-level-use-cases-enroll-member",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-system-document-system-level-use-cases-enroll-member",
+        "to_artifact": "system-document.md"
+      },
+      {
+        "artifact_section": "system-level use cases",
+        "basis": "canonical system-level use cases object renders into system-document.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "33184aff67d70b17",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "browse-rewards",
+        "id": "trace-artifact-system-document-system-level-use-cases-browse-rewards",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-system-document-system-level-use-cases-browse-rewards",
+        "to_artifact": "system-document.md"
+      },
+      {
+        "artifact_section": "system-level use cases",
+        "basis": "canonical system-level use cases object renders into system-document.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "1ea0237fc96b5059",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "redeem-reward",
+        "id": "trace-artifact-system-document-system-level-use-cases-redeem-reward",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-system-document-system-level-use-cases-redeem-reward",
+        "to_artifact": "system-document.md"
+      },
+      {
+        "artifact_section": "system-level use cases",
+        "basis": "canonical system-level use cases object renders into system-document.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "df35c4ca38515a93",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "manage-reward-catalog",
+        "id": "trace-artifact-system-document-system-level-use-cases-manage-reward-catalog",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-system-document-system-level-use-cases-manage-reward-catalog",
+        "to_artifact": "system-document.md"
+      },
+      {
+        "artifact_section": "system-level use cases",
+        "basis": "canonical system-level use cases object renders into system-document.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "7f7ccd0b92b1e57a",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "review-redemption-analytics",
+        "id": "trace-artifact-system-document-system-level-use-cases-review-redemption-analytics",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-system-document-system-level-use-cases-review-redemption-analytics",
+        "to_artifact": "system-document.md"
+      },
+      {
+        "artifact_section": "architecture overview",
+        "basis": "canonical architecture overview object renders into system-document.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "1b9fb24dc405ffbc",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "component-member-app",
+        "id": "trace-artifact-system-document-architecture-overview-component-member-app",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-system-document-architecture-overview-component-member-app",
+        "to_artifact": "system-document.md"
+      },
+      {
+        "artifact_section": "architecture overview",
+        "basis": "canonical architecture overview object renders into system-document.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "f3ef9d85c34fba70",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "component-loyalty-api",
+        "id": "trace-artifact-system-document-architecture-overview-component-loyalty-api",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-system-document-architecture-overview-component-loyalty-api",
+        "to_artifact": "system-document.md"
+      },
+      {
+        "artifact_section": "architecture overview",
+        "basis": "canonical architecture overview object renders into system-document.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "b2ea526f66c7c4ed",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "component-operations-console",
+        "id": "trace-artifact-system-document-architecture-overview-component-operations-console",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-system-document-architecture-overview-component-operations-console",
+        "to_artifact": "system-document.md"
+      },
+      {
+        "artifact_section": "architecture overview",
+        "basis": "canonical architecture overview object renders into system-document.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "c38fad4d9335c9a1",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "component-analytics-service",
+        "id": "trace-artifact-system-document-architecture-overview-component-analytics-service",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-system-document-architecture-overview-component-analytics-service",
+        "to_artifact": "system-document.md"
+      },
+      {
+        "artifact_section": "architecture overview",
+        "basis": "canonical architecture overview object renders into system-document.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "59e7c77ec4879db4",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "component-payment-gateway-adapter",
+        "id": "trace-artifact-system-document-architecture-overview-component-payment-gateway-adapter",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-system-document-architecture-overview-component-payment-gateway-adapter",
+        "to_artifact": "system-document.md"
+      },
+      {
+        "artifact_section": "interfaces and integrations",
+        "basis": "canonical interfaces and integrations object renders into system-document.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "91eece8d26d5ed9b",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "interface-1",
+        "id": "trace-artifact-system-document-interfaces-and-integrations-interface-1",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-system-document-interfaces-and-integrations-interface-1",
+        "to_artifact": "system-document.md"
+      },
+      {
+        "artifact_section": "interfaces and integrations",
+        "basis": "canonical interfaces and integrations object renders into system-document.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "3f042eff6cee48d3",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "interface-2",
+        "id": "trace-artifact-system-document-interfaces-and-integrations-interface-2",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-system-document-interfaces-and-integrations-interface-2",
+        "to_artifact": "system-document.md"
+      },
+      {
+        "artifact_section": "interfaces and integrations",
+        "basis": "canonical interfaces and integrations object renders into system-document.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "722e6e57b38642dc",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "interface-3",
+        "id": "trace-artifact-system-document-interfaces-and-integrations-interface-3",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-system-document-interfaces-and-integrations-interface-3",
+        "to_artifact": "system-document.md"
+      },
+      {
+        "artifact_section": "interfaces and integrations",
+        "basis": "canonical interfaces and integrations object renders into system-document.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "70a9c9c226d9b9b2",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "interface-4",
+        "id": "trace-artifact-system-document-interfaces-and-integrations-interface-4",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-system-document-interfaces-and-integrations-interface-4",
+        "to_artifact": "system-document.md"
+      },
+      {
+        "artifact_section": "runtime boundaries",
+        "basis": "canonical runtime boundaries object renders into system-document.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "fdf54dd2f5e1e22b",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "runtime-boundary-1",
+        "id": "trace-artifact-system-document-runtime-boundaries-runtime-boundary-1",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-system-document-runtime-boundaries-runtime-boundary-1",
+        "to_artifact": "system-document.md"
+      },
+      {
+        "artifact_section": "runtime boundaries",
+        "basis": "canonical runtime boundaries object renders into system-document.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "6cfa760423dde8f8",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "runtime-boundary-2",
+        "id": "trace-artifact-system-document-runtime-boundaries-runtime-boundary-2",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-system-document-runtime-boundaries-runtime-boundary-2",
+        "to_artifact": "system-document.md"
+      },
+      {
+        "artifact_section": "functional requirements",
+        "basis": "canonical functional requirements object renders into requirements-spec.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "fec25440bb6afe79",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "functional-requirement-1",
+        "id": "trace-artifact-requirements-spec-functional-requirements-functional-requirement-1",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-requirements-spec-functional-requirements-functional-requirement-1",
+        "to_artifact": "requirements-spec.md"
+      },
+      {
+        "artifact_section": "functional requirements",
+        "basis": "canonical functional requirements object renders into requirements-spec.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "49f0e4b5d57e2433",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "functional-requirement-2",
+        "id": "trace-artifact-requirements-spec-functional-requirements-functional-requirement-2",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-requirements-spec-functional-requirements-functional-requirement-2",
+        "to_artifact": "requirements-spec.md"
+      },
+      {
+        "artifact_section": "functional requirements",
+        "basis": "canonical functional requirements object renders into requirements-spec.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "366d3df1f215edf6",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "non_functional-requirement-1",
+        "id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-1",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-1",
+        "to_artifact": "requirements-spec.md"
+      },
+      {
+        "artifact_section": "functional requirements",
+        "basis": "canonical functional requirements object renders into requirements-spec.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "553fc29268eb54af",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "non_functional-requirement-2",
+        "id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-2",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-2",
+        "to_artifact": "requirements-spec.md"
+      },
+      {
+        "artifact_section": "functional requirements",
+        "basis": "canonical functional requirements object renders into requirements-spec.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "45842652ab1a37ac",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "non_functional-requirement-3",
+        "id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-3",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-3",
+        "to_artifact": "requirements-spec.md"
+      },
+      {
+        "artifact_section": "functional requirements",
+        "basis": "canonical functional requirements object renders into requirements-spec.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "deffbd4b51a070ad",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "non_functional-requirement-4",
+        "id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-4",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-4",
+        "to_artifact": "requirements-spec.md"
+      },
+      {
+        "artifact_section": "functional requirements",
+        "basis": "canonical functional requirements object renders into requirements-spec.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "5d7714100200c16f",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "non_functional-requirement-5",
+        "id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-5",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-5",
+        "to_artifact": "requirements-spec.md"
+      },
+      {
+        "artifact_section": "functional requirements",
+        "basis": "canonical functional requirements object renders into requirements-spec.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "f3c17e6b06f0c694",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "non_functional-requirement-6",
+        "id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-6",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-6",
+        "to_artifact": "requirements-spec.md"
+      },
+      {
+        "artifact_section": "functional requirements",
+        "basis": "canonical functional requirements object renders into requirements-spec.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "515decfb51f1bc20",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "non_functional-requirement-7",
+        "id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-7",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-requirements-spec-functional-requirements-non_functional-requirement-7",
+        "to_artifact": "requirements-spec.md"
+      },
+      {
+        "artifact_section": "acceptance constraints",
+        "basis": "canonical acceptance constraints object renders into requirements-spec.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "b9a087737158f727",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "acceptance-constraint-requirement-1",
+        "id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-1",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-1",
+        "to_artifact": "requirements-spec.md"
+      },
+      {
+        "artifact_section": "acceptance constraints",
+        "basis": "canonical acceptance constraints object renders into requirements-spec.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "b2270d7e957c58fa",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "acceptance-constraint-requirement-2",
+        "id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-2",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-2",
+        "to_artifact": "requirements-spec.md"
+      },
+      {
+        "artifact_section": "acceptance constraints",
+        "basis": "canonical acceptance constraints object renders into requirements-spec.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "8180562a372ad219",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "acceptance-constraint-requirement-3",
+        "id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-3",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-3",
+        "to_artifact": "requirements-spec.md"
+      },
+      {
+        "artifact_section": "acceptance constraints",
+        "basis": "canonical acceptance constraints object renders into requirements-spec.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "46ebf22f963fa28d",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "acceptance-constraint-requirement-4",
+        "id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-4",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-4",
+        "to_artifact": "requirements-spec.md"
+      },
+      {
+        "artifact_section": "acceptance constraints",
+        "basis": "canonical acceptance constraints object renders into requirements-spec.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "9434a1c4a8ceb824",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "acceptance-constraint-requirement-5",
+        "id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-5",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-5",
+        "to_artifact": "requirements-spec.md"
+      },
+      {
+        "artifact_section": "acceptance constraints",
+        "basis": "canonical acceptance constraints object renders into requirements-spec.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "d855358cded4ea44",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "acceptance-constraint-requirement-6",
+        "id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-6",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-6",
+        "to_artifact": "requirements-spec.md"
+      },
+      {
+        "artifact_section": "acceptance constraints",
+        "basis": "canonical acceptance constraints object renders into requirements-spec.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "ea6de4221e2055e8",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "acceptance-constraint-requirement-7",
+        "id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-7",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-requirement-7",
+        "to_artifact": "requirements-spec.md"
+      },
+      {
+        "artifact_section": "acceptance constraints",
+        "basis": "canonical acceptance constraints object renders into requirements-spec.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "9a069ddc773b3326",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "acceptance-constraint-success-1",
+        "id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-success-1",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-success-1",
+        "to_artifact": "requirements-spec.md"
+      },
+      {
+        "artifact_section": "acceptance constraints",
+        "basis": "canonical acceptance constraints object renders into requirements-spec.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "b4f52e328a66f8b5",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "acceptance-constraint-success-2",
+        "id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-success-2",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-success-2",
+        "to_artifact": "requirements-spec.md"
+      },
+      {
+        "artifact_section": "acceptance constraints",
+        "basis": "canonical acceptance constraints object renders into requirements-spec.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "6fc7c34127a50714",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "acceptance-constraint-success-3",
+        "id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-success-3",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-requirements-spec-acceptance-constraints-acceptance-constraint-success-3",
+        "to_artifact": "requirements-spec.md"
+      },
+      {
+        "artifact_section": "use cases",
+        "basis": "canonical use cases object renders into use-case-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "377e8a49e3eda19f",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "enroll-member",
+        "id": "trace-artifact-use-case-model-use-cases-enroll-member",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-use-case-model-use-cases-enroll-member",
+        "to_artifact": "use-case-model.md"
+      },
+      {
+        "artifact_section": "use cases",
+        "basis": "canonical use cases object renders into use-case-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "514f95ad0fca3cbd",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "browse-rewards",
+        "id": "trace-artifact-use-case-model-use-cases-browse-rewards",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-use-case-model-use-cases-browse-rewards",
+        "to_artifact": "use-case-model.md"
+      },
+      {
+        "artifact_section": "use cases",
+        "basis": "canonical use cases object renders into use-case-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "7b90b75db6633f28",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "redeem-reward",
+        "id": "trace-artifact-use-case-model-use-cases-redeem-reward",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-use-case-model-use-cases-redeem-reward",
+        "to_artifact": "use-case-model.md"
+      },
+      {
+        "artifact_section": "use cases",
+        "basis": "canonical use cases object renders into use-case-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "bad8490420fc1c58",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "manage-reward-catalog",
+        "id": "trace-artifact-use-case-model-use-cases-manage-reward-catalog",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-use-case-model-use-cases-manage-reward-catalog",
+        "to_artifact": "use-case-model.md"
+      },
+      {
+        "artifact_section": "use cases",
+        "basis": "canonical use cases object renders into use-case-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "5e968f92ec1f975c",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "review-redemption-analytics",
+        "id": "trace-artifact-use-case-model-use-cases-review-redemption-analytics",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-use-case-model-use-cases-review-redemption-analytics",
+        "to_artifact": "use-case-model.md"
+      },
+      {
+        "artifact_section": "use-case documents",
+        "basis": "canonical use-case documents object renders into use-case-documents.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "153925ccce33cb78",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "enroll-member",
+        "id": "trace-artifact-use-case-documents-use-case-documents-enroll-member",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-use-case-documents-use-case-documents-enroll-member",
+        "to_artifact": "use-case-documents.md"
+      },
+      {
+        "artifact_section": "use-case documents",
+        "basis": "canonical use-case documents object renders into use-case-documents.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "68f3ec23c9b542c5",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "browse-rewards",
+        "id": "trace-artifact-use-case-documents-use-case-documents-browse-rewards",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-use-case-documents-use-case-documents-browse-rewards",
+        "to_artifact": "use-case-documents.md"
+      },
+      {
+        "artifact_section": "use-case documents",
+        "basis": "canonical use-case documents object renders into use-case-documents.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "bff0fb6c9906df6a",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "redeem-reward",
+        "id": "trace-artifact-use-case-documents-use-case-documents-redeem-reward",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-use-case-documents-use-case-documents-redeem-reward",
+        "to_artifact": "use-case-documents.md"
+      },
+      {
+        "artifact_section": "use-case documents",
+        "basis": "canonical use-case documents object renders into use-case-documents.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "5921276218b129e7",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "manage-reward-catalog",
+        "id": "trace-artifact-use-case-documents-use-case-documents-manage-reward-catalog",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-use-case-documents-use-case-documents-manage-reward-catalog",
+        "to_artifact": "use-case-documents.md"
+      },
+      {
+        "artifact_section": "use-case documents",
+        "basis": "canonical use-case documents object renders into use-case-documents.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "4412e29544f26156",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "review-redemption-analytics",
+        "id": "trace-artifact-use-case-documents-use-case-documents-review-redemption-analytics",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-use-case-documents-use-case-documents-review-redemption-analytics",
+        "to_artifact": "use-case-documents.md"
+      },
+      {
+        "artifact_section": "scenario summaries",
+        "basis": "canonical scenario summaries object renders into use-case-documents.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "f2d962fe68b4788e",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "scenario-reward-inventory-exhausted",
+        "id": "trace-artifact-use-case-documents-scenario-summaries-scenario-reward-inventory-exhausted",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-use-case-documents-scenario-summaries-scenario-reward-inventory-exhausted",
+        "to_artifact": "use-case-documents.md"
+      },
+      {
+        "artifact_section": "scenario summaries",
+        "basis": "canonical scenario summaries object renders into use-case-documents.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "d05ee9a42ad5e5da",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "scenario-missing-payment-confirmation",
+        "id": "trace-artifact-use-case-documents-scenario-summaries-scenario-missing-payment-confirmation",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-use-case-documents-scenario-summaries-scenario-missing-payment-confirmation",
+        "to_artifact": "use-case-documents.md"
+      },
+      {
+        "artifact_section": "scenario summaries",
+        "basis": "canonical scenario summaries object renders into use-case-documents.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "9127a8b8141a378a",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "scenario-invalid-catalog-change",
+        "id": "trace-artifact-use-case-documents-scenario-summaries-scenario-invalid-catalog-change",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-use-case-documents-scenario-summaries-scenario-invalid-catalog-change",
+        "to_artifact": "use-case-documents.md"
+      },
+      {
+        "artifact_section": "scenario summaries",
+        "basis": "canonical scenario summaries object renders into use-case-documents.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "8ea8956cb20af4d9",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "scenario-reporting-delay",
+        "id": "trace-artifact-use-case-documents-scenario-summaries-scenario-reporting-delay",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-use-case-documents-scenario-summaries-scenario-reporting-delay",
+        "to_artifact": "use-case-documents.md"
+      },
+      {
+        "artifact_section": "scenario documents",
+        "basis": "canonical scenario documents object renders into scenario-documents.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "de4fc6eeb45a6f6a",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "scenario-reward-inventory-exhausted",
+        "id": "trace-artifact-scenario-documents-scenario-documents-scenario-reward-inventory-exhausted",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-scenario-documents-scenario-documents-scenario-reward-inventory-exhausted",
+        "to_artifact": "scenario-documents.md"
+      },
+      {
+        "artifact_section": "scenario documents",
+        "basis": "canonical scenario documents object renders into scenario-documents.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "1a18be66ca23decb",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "scenario-missing-payment-confirmation",
+        "id": "trace-artifact-scenario-documents-scenario-documents-scenario-missing-payment-confirmation",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-scenario-documents-scenario-documents-scenario-missing-payment-confirmation",
+        "to_artifact": "scenario-documents.md"
+      },
+      {
+        "artifact_section": "scenario documents",
+        "basis": "canonical scenario documents object renders into scenario-documents.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "12865275064988a6",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "scenario-invalid-catalog-change",
+        "id": "trace-artifact-scenario-documents-scenario-documents-scenario-invalid-catalog-change",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-scenario-documents-scenario-documents-scenario-invalid-catalog-change",
+        "to_artifact": "scenario-documents.md"
+      },
+      {
+        "artifact_section": "scenario documents",
+        "basis": "canonical scenario documents object renders into scenario-documents.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "fa0ad0ccb4ad2e5e",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "scenario-reporting-delay",
+        "id": "trace-artifact-scenario-documents-scenario-documents-scenario-reporting-delay",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-scenario-documents-scenario-documents-scenario-reporting-delay",
+        "to_artifact": "scenario-documents.md"
+      },
+      {
+        "artifact_section": "domain entities",
+        "basis": "canonical domain entities object renders into domain-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "5715c34f1dfa4e05",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "entity-member",
+        "id": "trace-artifact-domain-model-domain-entities-entity-member",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-domain-model-domain-entities-entity-member",
+        "to_artifact": "domain-model.md"
+      },
+      {
+        "artifact_section": "domain entities",
+        "basis": "canonical domain entities object renders into domain-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "f79f540905c9e20f",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "entity-reward",
+        "id": "trace-artifact-domain-model-domain-entities-entity-reward",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-domain-model-domain-entities-entity-reward",
+        "to_artifact": "domain-model.md"
+      },
+      {
+        "artifact_section": "domain entities",
+        "basis": "canonical domain entities object renders into domain-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "cfd432da03fdb5ab",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "entity-reward-catalog-entry",
+        "id": "trace-artifact-domain-model-domain-entities-entity-reward-catalog-entry",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-domain-model-domain-entities-entity-reward-catalog-entry",
+        "to_artifact": "domain-model.md"
+      },
+      {
+        "artifact_section": "domain entities",
+        "basis": "canonical domain entities object renders into domain-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "44286f94447c6a66",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "entity-campaign",
+        "id": "trace-artifact-domain-model-domain-entities-entity-campaign",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-domain-model-domain-entities-entity-campaign",
+        "to_artifact": "domain-model.md"
+      },
+      {
+        "artifact_section": "domain entities",
+        "basis": "canonical domain entities object renders into domain-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "570b377125ed0a71",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "entity-redemption",
+        "id": "trace-artifact-domain-model-domain-entities-entity-redemption",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-domain-model-domain-entities-entity-redemption",
+        "to_artifact": "domain-model.md"
+      },
+      {
+        "artifact_section": "domain entities",
+        "basis": "canonical domain entities object renders into domain-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "7a5039186ff20b9e",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "entity-payment-confirmation",
+        "id": "trace-artifact-domain-model-domain-entities-entity-payment-confirmation",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-domain-model-domain-entities-entity-payment-confirmation",
+        "to_artifact": "domain-model.md"
+      },
+      {
+        "artifact_section": "domain entities",
+        "basis": "canonical domain entities object renders into domain-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "9fe9db5e8ebe0a9d",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "entity-analytics-report",
+        "id": "trace-artifact-domain-model-domain-entities-entity-analytics-report",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-domain-model-domain-entities-entity-analytics-report",
+        "to_artifact": "domain-model.md"
+      },
+      {
+        "artifact_section": "relationships",
+        "basis": "canonical relationships object renders into domain-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "3f9d110e45e868b3",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "relationship-1",
+        "id": "trace-artifact-domain-model-relationships-relationship-1",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-domain-model-relationships-relationship-1",
+        "to_artifact": "domain-model.md"
+      },
+      {
+        "artifact_section": "relationships",
+        "basis": "canonical relationships object renders into domain-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "82d26cc72fe3d665",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "relationship-2",
+        "id": "trace-artifact-domain-model-relationships-relationship-2",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-domain-model-relationships-relationship-2",
+        "to_artifact": "domain-model.md"
+      },
+      {
+        "artifact_section": "relationships",
+        "basis": "canonical relationships object renders into domain-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "aed3828f4d7ff3e1",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "relationship-3",
+        "id": "trace-artifact-domain-model-relationships-relationship-3",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-domain-model-relationships-relationship-3",
+        "to_artifact": "domain-model.md"
+      },
+      {
+        "artifact_section": "relationships",
+        "basis": "canonical relationships object renders into domain-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "f87566d9edb20283",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "relationship-4",
+        "id": "trace-artifact-domain-model-relationships-relationship-4",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-domain-model-relationships-relationship-4",
+        "to_artifact": "domain-model.md"
+      },
+      {
+        "artifact_section": "relationships",
+        "basis": "canonical relationships object renders into domain-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "aa3eb4ffa7b6066e",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "relationship-5",
+        "id": "trace-artifact-domain-model-relationships-relationship-5",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-domain-model-relationships-relationship-5",
+        "to_artifact": "domain-model.md"
+      },
+      {
+        "artifact_section": "business rules",
+        "basis": "canonical business rules object renders into domain-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "78dc7ea16d834a20",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "business-rule-1",
+        "id": "trace-artifact-domain-model-business-rules-business-rule-1",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-domain-model-business-rules-business-rule-1",
+        "to_artifact": "domain-model.md"
+      },
+      {
+        "artifact_section": "business rules",
+        "basis": "canonical business rules object renders into domain-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "e6182870d05b9f7a",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "business-rule-2",
+        "id": "trace-artifact-domain-model-business-rules-business-rule-2",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-domain-model-business-rules-business-rule-2",
+        "to_artifact": "domain-model.md"
+      },
+      {
+        "artifact_section": "business rules",
+        "basis": "canonical business rules object renders into domain-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "db08e5f8695442da",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "business-rule-3",
+        "id": "trace-artifact-domain-model-business-rules-business-rule-3",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-domain-model-business-rules-business-rule-3",
+        "to_artifact": "domain-model.md"
+      },
+      {
+        "artifact_section": "domain invariants",
+        "basis": "canonical domain invariants object renders into domain-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "a90aa119fd188cdf",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "domain-invariant-1",
+        "id": "trace-artifact-domain-model-domain-invariants-domain-invariant-1",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-domain-model-domain-invariants-domain-invariant-1",
+        "to_artifact": "domain-model.md"
+      },
+      {
+        "artifact_section": "domain invariants",
+        "basis": "canonical domain invariants object renders into domain-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "c954802ff4fd4b50",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "domain-invariant-2",
+        "id": "trace-artifact-domain-model-domain-invariants-domain-invariant-2",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-domain-model-domain-invariants-domain-invariant-2",
+        "to_artifact": "domain-model.md"
+      },
+      {
+        "artifact_section": "domain invariants",
+        "basis": "canonical domain invariants object renders into domain-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "122fe94f2ccfd8f9",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "domain-invariant-3",
+        "id": "trace-artifact-domain-model-domain-invariants-domain-invariant-3",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-domain-model-domain-invariants-domain-invariant-3",
+        "to_artifact": "domain-model.md"
+      },
+      {
+        "artifact_section": "use-case realizations",
+        "basis": "canonical use-case realizations object renders into interaction-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "c1b6823d2aeeb87a",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "interaction-realization-1",
+        "id": "trace-artifact-interaction-model-use-case-realizations-interaction-realization-1",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-interaction-model-use-case-realizations-interaction-realization-1",
+        "to_artifact": "interaction-model.md"
+      },
+      {
+        "artifact_section": "use-case realizations",
+        "basis": "canonical use-case realizations object renders into interaction-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "ff275c3ef6eda3ed",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "interaction-realization-2",
+        "id": "trace-artifact-interaction-model-use-case-realizations-interaction-realization-2",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-interaction-model-use-case-realizations-interaction-realization-2",
+        "to_artifact": "interaction-model.md"
+      },
+      {
+        "artifact_section": "use-case realizations",
+        "basis": "canonical use-case realizations object renders into interaction-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "7e4fb0b4c67991c7",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "interaction-realization-3",
+        "id": "trace-artifact-interaction-model-use-case-realizations-interaction-realization-3",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-interaction-model-use-case-realizations-interaction-realization-3",
+        "to_artifact": "interaction-model.md"
+      },
+      {
+        "artifact_section": "use-case realizations",
+        "basis": "canonical use-case realizations object renders into interaction-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "19f77e4577165002",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "interaction-realization-4",
+        "id": "trace-artifact-interaction-model-use-case-realizations-interaction-realization-4",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-interaction-model-use-case-realizations-interaction-realization-4",
+        "to_artifact": "interaction-model.md"
+      },
+      {
+        "artifact_section": "use-case realizations",
+        "basis": "canonical use-case realizations object renders into interaction-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "c9a030230c311202",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "interaction-realization-5",
+        "id": "trace-artifact-interaction-model-use-case-realizations-interaction-realization-5",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-interaction-model-use-case-realizations-interaction-realization-5",
+        "to_artifact": "interaction-model.md"
+      },
+      {
+        "artifact_section": "message flows",
+        "basis": "canonical message flows object renders into interaction-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "0b3a7106bfe418b7",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "interaction-message-1",
+        "id": "trace-artifact-interaction-model-message-flows-interaction-message-1",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-interaction-model-message-flows-interaction-message-1",
+        "to_artifact": "interaction-model.md"
+      },
+      {
+        "artifact_section": "message flows",
+        "basis": "canonical message flows object renders into interaction-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "7b943cc11b7a8f88",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "interaction-message-2",
+        "id": "trace-artifact-interaction-model-message-flows-interaction-message-2",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-interaction-model-message-flows-interaction-message-2",
+        "to_artifact": "interaction-model.md"
+      },
+      {
+        "artifact_section": "message flows",
+        "basis": "canonical message flows object renders into interaction-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "99be2280bd0aec6f",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "interaction-message-3",
+        "id": "trace-artifact-interaction-model-message-flows-interaction-message-3",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-interaction-model-message-flows-interaction-message-3",
+        "to_artifact": "interaction-model.md"
+      },
+      {
+        "artifact_section": "message flows",
+        "basis": "canonical message flows object renders into interaction-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "e36cb245800b685b",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "interaction-message-4",
+        "id": "trace-artifact-interaction-model-message-flows-interaction-message-4",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-interaction-model-message-flows-interaction-message-4",
+        "to_artifact": "interaction-model.md"
+      },
+      {
+        "artifact_section": "components",
+        "basis": "canonical components object renders into deployment-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "8395e6e65900e4e9",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "component-member-app",
+        "id": "trace-artifact-deployment-model-components-component-member-app",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-deployment-model-components-component-member-app",
+        "to_artifact": "deployment-model.md"
+      },
+      {
+        "artifact_section": "components",
+        "basis": "canonical components object renders into deployment-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "ea4f2781a9abdbe3",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "component-loyalty-api",
+        "id": "trace-artifact-deployment-model-components-component-loyalty-api",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-deployment-model-components-component-loyalty-api",
+        "to_artifact": "deployment-model.md"
+      },
+      {
+        "artifact_section": "components",
+        "basis": "canonical components object renders into deployment-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "96f0faa3577c5958",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "component-operations-console",
+        "id": "trace-artifact-deployment-model-components-component-operations-console",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-deployment-model-components-component-operations-console",
+        "to_artifact": "deployment-model.md"
+      },
+      {
+        "artifact_section": "components",
+        "basis": "canonical components object renders into deployment-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "44de6c32dd3650b9",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "component-analytics-service",
+        "id": "trace-artifact-deployment-model-components-component-analytics-service",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-deployment-model-components-component-analytics-service",
+        "to_artifact": "deployment-model.md"
+      },
+      {
+        "artifact_section": "components",
+        "basis": "canonical components object renders into deployment-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "3f7e60f42de57872",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "component-payment-gateway-adapter",
+        "id": "trace-artifact-deployment-model-components-component-payment-gateway-adapter",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-deployment-model-components-component-payment-gateway-adapter",
+        "to_artifact": "deployment-model.md"
+      },
+      {
+        "artifact_section": "interfaces and integrations",
+        "basis": "canonical interfaces and integrations object renders into deployment-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "4185f4411a623540",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "interface-1",
+        "id": "trace-artifact-deployment-model-interfaces-and-integrations-interface-1",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-deployment-model-interfaces-and-integrations-interface-1",
+        "to_artifact": "deployment-model.md"
+      },
+      {
+        "artifact_section": "interfaces and integrations",
+        "basis": "canonical interfaces and integrations object renders into deployment-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "a17ccea49d467835",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "interface-2",
+        "id": "trace-artifact-deployment-model-interfaces-and-integrations-interface-2",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-deployment-model-interfaces-and-integrations-interface-2",
+        "to_artifact": "deployment-model.md"
+      },
+      {
+        "artifact_section": "interfaces and integrations",
+        "basis": "canonical interfaces and integrations object renders into deployment-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "719e067b7da57776",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "interface-3",
+        "id": "trace-artifact-deployment-model-interfaces-and-integrations-interface-3",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-deployment-model-interfaces-and-integrations-interface-3",
+        "to_artifact": "deployment-model.md"
+      },
+      {
+        "artifact_section": "interfaces and integrations",
+        "basis": "canonical interfaces and integrations object renders into deployment-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "d485ae144f6a5bcd",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "interface-4",
+        "id": "trace-artifact-deployment-model-interfaces-and-integrations-interface-4",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-deployment-model-interfaces-and-integrations-interface-4",
+        "to_artifact": "deployment-model.md"
+      },
+      {
+        "artifact_section": "runtime boundaries",
+        "basis": "canonical runtime boundaries object renders into deployment-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "be72109b76fcb841",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "runtime-boundary-1",
+        "id": "trace-artifact-deployment-model-runtime-boundaries-runtime-boundary-1",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-deployment-model-runtime-boundaries-runtime-boundary-1",
+        "to_artifact": "deployment-model.md"
+      },
+      {
+        "artifact_section": "runtime boundaries",
+        "basis": "canonical runtime boundaries object renders into deployment-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "5fc33d4f7c95f26d",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "runtime-boundary-2",
+        "id": "trace-artifact-deployment-model-runtime-boundaries-runtime-boundary-2",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-deployment-model-runtime-boundaries-runtime-boundary-2",
+        "to_artifact": "deployment-model.md"
+      },
+      {
+        "artifact_section": "state entities",
+        "basis": "canonical state entities object renders into state-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "01a71d64da8739d7",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "state-entity-redemption",
+        "id": "trace-artifact-state-model-state-entities-state-entity-redemption",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-state-model-state-entities-state-entity-redemption",
+        "to_artifact": "state-model.md"
+      },
+      {
+        "artifact_section": "state entities",
+        "basis": "canonical state entities object renders into state-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "5792f5ce12819ca0",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "state-entity-reward-catalog-entry",
+        "id": "trace-artifact-state-model-state-entities-state-entity-reward-catalog-entry",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-state-model-state-entities-state-entity-reward-catalog-entry",
+        "to_artifact": "state-model.md"
+      },
+      {
+        "artifact_section": "state transitions",
+        "basis": "canonical state transitions object renders into state-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "5e3bb5d335f535a0",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "state-transition-1",
+        "id": "trace-artifact-state-model-state-transitions-state-transition-1",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-state-model-state-transitions-state-transition-1",
+        "to_artifact": "state-model.md"
+      },
+      {
+        "artifact_section": "state transitions",
+        "basis": "canonical state transitions object renders into state-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "3c2aa5a1b7def9a0",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "state-transition-2",
+        "id": "trace-artifact-state-model-state-transitions-state-transition-2",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-state-model-state-transitions-state-transition-2",
+        "to_artifact": "state-model.md"
+      },
+      {
+        "artifact_section": "state transitions",
+        "basis": "canonical state transitions object renders into state-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "1af79bac5dae50d9",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "state-transition-3",
+        "id": "trace-artifact-state-model-state-transitions-state-transition-3",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-state-model-state-transitions-state-transition-3",
+        "to_artifact": "state-model.md"
+      },
+      {
+        "artifact_section": "state transitions",
+        "basis": "canonical state transitions object renders into state-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "facb3d54f01b3e57",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "state-transition-4",
+        "id": "trace-artifact-state-model-state-transitions-state-transition-4",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-state-model-state-transitions-state-transition-4",
+        "to_artifact": "state-model.md"
+      },
+      {
+        "artifact_section": "state transitions",
+        "basis": "canonical state transitions object renders into state-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "3d31fb335559e5d9",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "state-transition-5",
+        "id": "trace-artifact-state-model-state-transitions-state-transition-5",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-state-model-state-transitions-state-transition-5",
+        "to_artifact": "state-model.md"
+      },
+      {
+        "artifact_section": "triggers and approvals",
+        "basis": "canonical triggers and approvals object renders into state-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "c82280ef83063a38",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "trigger-1",
+        "id": "trace-artifact-state-model-triggers-and-approvals-trigger-1",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-state-model-triggers-and-approvals-trigger-1",
+        "to_artifact": "state-model.md"
+      },
+      {
+        "artifact_section": "triggers and approvals",
+        "basis": "canonical triggers and approvals object renders into state-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "826c99d687ec2f69",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "trigger-2",
+        "id": "trace-artifact-state-model-triggers-and-approvals-trigger-2",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-state-model-triggers-and-approvals-trigger-2",
+        "to_artifact": "state-model.md"
+      },
+      {
+        "artifact_section": "state invariants",
+        "basis": "canonical state invariants object renders into state-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "0fc9afd4b2b4d208",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "state-invariant-1",
+        "id": "trace-artifact-state-model-state-invariants-state-invariant-1",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-state-model-state-invariants-state-invariant-1",
+        "to_artifact": "state-model.md"
+      },
+      {
+        "artifact_section": "state invariants",
+        "basis": "canonical state invariants object renders into state-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "7ca8114c140d58c2",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "state-invariant-2",
+        "id": "trace-artifact-state-model-state-invariants-state-invariant-2",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-state-model-state-invariants-state-invariant-2",
+        "to_artifact": "state-model.md"
+      },
+      {
+        "artifact_section": "guard conditions",
+        "basis": "canonical guard conditions object renders into state-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "e6c1be629fc829cf",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "guard-condition-1",
+        "id": "trace-artifact-state-model-guard-conditions-guard-condition-1",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-state-model-guard-conditions-guard-condition-1",
+        "to_artifact": "state-model.md"
+      },
+      {
+        "artifact_section": "guard conditions",
+        "basis": "canonical guard conditions object renders into state-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "0135f82024c2d563",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "guard-condition-2",
+        "id": "trace-artifact-state-model-guard-conditions-guard-condition-2",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-state-model-guard-conditions-guard-condition-2",
+        "to_artifact": "state-model.md"
+      },
+      {
+        "artifact_section": "forbidden transitions",
+        "basis": "canonical forbidden transitions object renders into state-model.md",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "6bfa72e54c78fc26",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "forbidden-transition-1",
+        "id": "trace-artifact-state-model-forbidden-transitions-forbidden-transition-1",
+        "link_type": "artifact_lineage",
+        "semantic_id": "trace-artifact-state-model-forbidden-transitions-forbidden-transition-1",
+        "to_artifact": "state-model.md"
+      }
+    ],
+    "business_rule_to_transition": [
+      {
+        "basis": "business rule scope references state transition text",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "8330b21dc06c3215",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "business-rule-1",
+        "id": "trace-rule-transition-1",
+        "link_type": "business_rule_to_transition",
+        "semantic_id": "trace-rule-transition-1",
+        "to_id": "state-transition-1"
+      },
+      {
+        "basis": "business rule scope references state transition text",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "38ebf4886c4cbd8a",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "business-rule-1",
+        "id": "trace-rule-transition-2",
+        "link_type": "business_rule_to_transition",
+        "semantic_id": "trace-rule-transition-2",
+        "to_id": "state-transition-2"
+      },
+      {
+        "basis": "business rule scope references state transition text",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "2de406aa503c0e3c",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "business-rule-1",
+        "id": "trace-rule-transition-3",
+        "link_type": "business_rule_to_transition",
+        "semantic_id": "trace-rule-transition-3",
+        "to_id": "state-transition-3"
+      },
+      {
+        "basis": "business rule scope references state transition text",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "746a76a9ed5eebc0",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "business-rule-2",
+        "id": "trace-rule-transition-4",
+        "link_type": "business_rule_to_transition",
+        "semantic_id": "trace-rule-transition-4",
+        "to_id": "state-transition-4"
+      },
+      {
+        "basis": "business rule scope references state transition text",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "f54fae653699b4f1",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "business-rule-2",
+        "id": "trace-rule-transition-5",
+        "link_type": "business_rule_to_transition",
+        "semantic_id": "trace-rule-transition-5",
+        "to_id": "state-transition-5"
+      }
+    ],
+    "domain_invariant_to_entity": [
+      {
+        "basis": "domain invariant scope references domain entity",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "4c34571873064995",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "domain-invariant-1",
+        "id": "trace-domain-invariant-entity-1",
+        "link_type": "domain_invariant_to_entity",
+        "semantic_id": "trace-domain-invariant-entity-1",
+        "to_id": "entity-reward"
+      },
+      {
+        "basis": "domain invariant scope references domain entity",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "d5a48ebbb564f1b9",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "domain-invariant-1",
+        "id": "trace-domain-invariant-entity-2",
+        "link_type": "domain_invariant_to_entity",
+        "semantic_id": "trace-domain-invariant-entity-2",
+        "to_id": "entity-redemption"
+      },
+      {
+        "basis": "domain invariant scope references domain entity",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "e872c7c2a3472ad3",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "domain-invariant-2",
+        "id": "trace-domain-invariant-entity-3",
+        "link_type": "domain_invariant_to_entity",
+        "semantic_id": "trace-domain-invariant-entity-3",
+        "to_id": "entity-reward"
+      },
+      {
+        "basis": "domain invariant scope references domain entity",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "9847fab45fcd3007",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "domain-invariant-2",
+        "id": "trace-domain-invariant-entity-4",
+        "link_type": "domain_invariant_to_entity",
+        "semantic_id": "trace-domain-invariant-entity-4",
+        "to_id": "entity-reward-catalog-entry"
+      },
+      {
+        "basis": "domain invariant scope references domain entity",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "662fede529199607",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "domain-invariant-3",
+        "id": "trace-domain-invariant-entity-5",
+        "link_type": "domain_invariant_to_entity",
+        "semantic_id": "trace-domain-invariant-entity-5",
+        "to_id": "entity-member"
+      }
+    ],
+    "forbidden_transition_to_transition": [],
+    "guard_to_transition": [
+      {
+        "basis": "guard condition text references state transition",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "ffeaa64c1319eaec",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "guard-condition-2",
+        "id": "trace-guard-transition-1",
+        "link_type": "guard_to_transition",
+        "semantic_id": "trace-guard-transition-1",
+        "to_id": "state-transition-1"
+      },
+      {
+        "basis": "guard condition text references state transition",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "28200a1b6227b96a",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "guard-condition-2",
+        "id": "trace-guard-transition-2",
+        "link_type": "guard_to_transition",
+        "semantic_id": "trace-guard-transition-2",
+        "to_id": "state-transition-2"
+      },
+      {
+        "basis": "guard condition text references state transition",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "de6d1aebf218ed11",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "guard-condition-2",
+        "id": "trace-guard-transition-3",
+        "link_type": "guard_to_transition",
+        "semantic_id": "trace-guard-transition-3",
+        "to_id": "state-transition-3"
+      },
+      {
+        "basis": "guard condition text references state transition",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "6ade68ccb7e4ee66",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "guard-condition-2",
+        "id": "trace-guard-transition-4",
+        "link_type": "guard_to_transition",
+        "semantic_id": "trace-guard-transition-4",
+        "to_id": "state-transition-4"
+      },
+      {
+        "basis": "guard condition text references state transition",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "e959f2cc324ea0ec",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "guard-condition-2",
+        "id": "trace-guard-transition-5",
+        "link_type": "guard_to_transition",
+        "semantic_id": "trace-guard-transition-5",
+        "to_id": "state-transition-5"
+      }
+    ],
+    "requirement_to_step": [],
+    "requirement_to_use_case": [
+      {
+        "basis": "requirement statement references use-case name",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "2c984dd2ee5f4f3a",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "non_functional-requirement-6",
+        "id": "trace-req-uc-1",
+        "link_type": "requirement_to_use_case",
+        "semantic_id": "trace-req-uc-1",
+        "to_id": "redeem-reward"
+      }
+    ],
+    "state_invariant_to_state": [
+      {
+        "basis": "state invariant scope references state entity",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "766a8d44492d1f83",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "state-invariant-1",
+        "id": "trace-state-invariant-state-1",
+        "link_type": "state_invariant_to_state",
+        "semantic_id": "trace-state-invariant-state-1",
+        "to_id": "state-entity-redemption"
+      },
+      {
+        "basis": "state invariant scope references state entity",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "c1063178b053ccb7",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "state-invariant-2",
+        "id": "trace-state-invariant-state-2",
+        "link_type": "state_invariant_to_state",
+        "semantic_id": "trace-state-invariant-state-2",
+        "to_id": "state-entity-reward-catalog-entry"
+      }
+    ],
+    "step_to_interaction": [],
+    "step_to_transition": [],
+    "use_case_to_analysis": [
+      {
+        "basis": "use-case text references analysis object name",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "c134de4b34669066",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "enroll-member",
+        "id": "trace-uc-analysis-1",
+        "link_type": "use_case_to_analysis",
+        "semantic_id": "trace-uc-analysis-1",
+        "to_id": "entity-member"
+      },
+      {
+        "basis": "use-case text references analysis object name",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "0bc5570be1c4d457",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "browse-rewards",
+        "id": "trace-uc-analysis-2",
+        "link_type": "use_case_to_analysis",
+        "semantic_id": "trace-uc-analysis-2",
+        "to_id": "entity-reward"
+      },
+      {
+        "basis": "use-case text references analysis object name",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "c0b977e16e09bd25",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "redeem-reward",
+        "id": "trace-uc-analysis-3",
+        "link_type": "use_case_to_analysis",
+        "semantic_id": "trace-uc-analysis-3",
+        "to_id": "entity-member"
+      },
+      {
+        "basis": "use-case text references analysis object name",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "a29aced625d11c99",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "redeem-reward",
+        "id": "trace-uc-analysis-4",
+        "link_type": "use_case_to_analysis",
+        "semantic_id": "trace-uc-analysis-4",
+        "to_id": "entity-reward"
+      },
+      {
+        "basis": "use-case text references analysis object name",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "aecca953333a3ace",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "redeem-reward",
+        "id": "trace-uc-analysis-5",
+        "link_type": "use_case_to_analysis",
+        "semantic_id": "trace-uc-analysis-5",
+        "to_id": "entity-redemption"
+      },
+      {
+        "basis": "use-case text references analysis object name",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "b5d4f782f2aff706",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "redeem-reward",
+        "id": "trace-uc-analysis-6",
+        "link_type": "use_case_to_analysis",
+        "semantic_id": "trace-uc-analysis-6",
+        "to_id": "state-entity-redemption"
+      },
+      {
+        "basis": "use-case text references analysis object name",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "69563f29e908f0b3",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "manage-reward-catalog",
+        "id": "trace-uc-analysis-7",
+        "link_type": "use_case_to_analysis",
+        "semantic_id": "trace-uc-analysis-7",
+        "to_id": "entity-reward"
+      },
+      {
+        "basis": "use-case text references analysis object name",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "eaf0a3cdbb72e03b",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "review-redemption-analytics",
+        "id": "trace-uc-analysis-8",
+        "link_type": "use_case_to_analysis",
+        "semantic_id": "trace-uc-analysis-8",
+        "to_id": "entity-campaign"
+      },
+      {
+        "basis": "use-case text references analysis object name",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "ce8e9d6703423e26",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "review-redemption-analytics",
+        "id": "trace-uc-analysis-9",
+        "link_type": "use_case_to_analysis",
+        "semantic_id": "trace-uc-analysis-9",
+        "to_id": "entity-redemption"
+      },
+      {
+        "basis": "use-case text references analysis object name",
+        "change_metadata": {
+          "change_source": "derived_traceability",
+          "last_changed_at": "",
+          "regenerated_from_version": "",
+          "semantic_hash": "5febd6fdc31d15e8",
+          "semantic_version": 1,
+          "supersedes": []
+        },
+        "from_id": "review-redemption-analytics",
+        "id": "trace-uc-analysis-10",
+        "link_type": "use_case_to_analysis",
+        "semantic_id": "trace-uc-analysis-10",
+        "to_id": "state-entity-redemption"
+      }
+    ]
+  },
   "ucp": {
     "environmental_factors": {
       "application_experience": 3,
@@ -94,81 +9357,351 @@
   },
   "use_cases": [
     {
+      "change_metadata": {
+        "change_source": "round_3",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "e3815fbbb87f8b5d",
+        "semantic_version": 1,
+        "supersedes": []
+      },
       "complexity": "simple",
+      "complexity_trace": {
+        "source_key": "use_case_complexity",
+        "source_round": 9
+      },
+      "content_semantics": "normative",
+      "extension_points": [],
       "extensions": [
         "Enrollment is blocked when required consent is missing."
       ],
-      "goal": "Join the loyalty program and activate an account.",
-      "id": "uc-enroll",
+      "goal": "Enroll Member",
+      "id": "enroll-member",
       "main_success_scenario": [
         "Customer opens the loyalty enrollment flow.",
         "Customer provides the required details and consents.",
         "System validates the submission and creates the member account."
       ],
+      "model_layer": "analysis",
       "name": "Enroll Member",
-      "primary_actor": "Customer"
+      "other_artifact_refs": [],
+      "other_requirement_ids": [],
+      "participating_analysis_object_ids": [
+        "entity-member"
+      ],
+      "postconditions": [
+        "Member account exists and is active"
+      ],
+      "preconditions": [
+        "Customer is not already enrolled"
+      ],
+      "primary_actor": "Unspecified",
+      "primary_actor_id": "",
+      "priority": "high",
+      "readiness": {
+        "blocking_ambiguity_ids": [],
+        "content_semantics": "normative",
+        "family": "use_cases",
+        "id": "enroll-member",
+        "missing_fields": [],
+        "normative_ready": true,
+        "status": "ready"
+      },
+      "scenario_ids": [],
+      "semantic_id": "enroll-member",
+      "status": "confirmed",
+      "subordinate_use_case_ids": [],
+      "supporting_actor_ids": [],
+      "trace": {
+        "source_key": "use_cases",
+        "source_round": 3
+      },
+      "trigger": "",
+      "ui_notes": [
+        "Member-facing responsive enrollment form with consent capture and validation messaging."
+      ],
+      "used_use_case_ids": []
     },
     {
+      "change_metadata": {
+        "change_source": "round_3",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "88feb125b5f936b0",
+        "semantic_version": 1,
+        "supersedes": []
+      },
       "complexity": "average",
+      "complexity_trace": {
+        "source_key": "use_case_complexity",
+        "source_round": 9
+      },
+      "content_semantics": "normative",
+      "extension_points": [],
       "extensions": [
         "Catalog view degrades if an integration is temporarily unavailable."
       ],
-      "goal": "View eligible rewards and current point balance.",
-      "id": "uc-browse",
+      "goal": "Browse Rewards",
+      "id": "browse-rewards",
       "main_success_scenario": [
         "Customer opens the rewards catalog.",
         "System displays available rewards and points balance.",
         "Customer filters or sorts the catalog."
       ],
+      "model_layer": "analysis",
       "name": "Browse Rewards",
-      "primary_actor": "Customer"
+      "other_artifact_refs": [],
+      "other_requirement_ids": [],
+      "participating_analysis_object_ids": [
+        "entity-reward"
+      ],
+      "postconditions": [
+        "Eligible rewards and point balance are visible"
+      ],
+      "preconditions": [
+        "Member is enrolled"
+      ],
+      "primary_actor": "Unspecified",
+      "primary_actor_id": "",
+      "priority": "high",
+      "readiness": {
+        "blocking_ambiguity_ids": [],
+        "content_semantics": "normative",
+        "family": "use_cases",
+        "id": "browse-rewards",
+        "missing_fields": [],
+        "normative_ready": true,
+        "status": "ready"
+      },
+      "scenario_ids": [],
+      "semantic_id": "browse-rewards",
+      "status": "confirmed",
+      "subordinate_use_case_ids": [],
+      "supporting_actor_ids": [],
+      "trace": {
+        "source_key": "use_cases",
+        "source_round": 3
+      },
+      "trigger": "",
+      "ui_notes": [
+        "Reward catalog view with filters, points balance summary, and eligibility indicators."
+      ],
+      "used_use_case_ids": []
     },
     {
+      "change_metadata": {
+        "change_source": "round_3",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "ff5a198c0a1a3706",
+        "semantic_version": 1,
+        "supersedes": []
+      },
       "complexity": "complex",
+      "complexity_trace": {
+        "source_key": "use_case_complexity",
+        "source_round": 9
+      },
+      "content_semantics": "normative",
+      "extension_points": [],
       "extensions": [
         "Reward inventory is exhausted before completion.",
         "Customer does not have enough points.",
         "Payment confirmation is missing for a reward that depends on purchase completion."
       ],
-      "goal": "Redeem a selected reward against available loyalty points.",
-      "id": "uc-redeem",
+      "goal": "Redeem Reward",
+      "id": "redeem-reward",
       "main_success_scenario": [
         "Customer selects a reward.",
         "System validates reward eligibility and available points.",
         "System reserves the reward and updates the member balance.",
         "System confirms redemption to the customer."
       ],
+      "model_layer": "analysis",
       "name": "Redeem Reward",
-      "primary_actor": "Customer"
+      "other_artifact_refs": [],
+      "other_requirement_ids": [
+        "non_functional-requirement-6"
+      ],
+      "participating_analysis_object_ids": [
+        "entity-member",
+        "entity-reward",
+        "entity-redemption",
+        "state-entity-redemption"
+      ],
+      "postconditions": [
+        "Redemption is recorded and balance is updated"
+      ],
+      "preconditions": [
+        "Member is enrolled",
+        "Reward is available"
+      ],
+      "primary_actor": "Unspecified",
+      "primary_actor_id": "",
+      "priority": "high",
+      "readiness": {
+        "blocking_ambiguity_ids": [],
+        "content_semantics": "normative",
+        "family": "use_cases",
+        "id": "redeem-reward",
+        "missing_fields": [],
+        "normative_ready": true,
+        "status": "ready"
+      },
+      "scenario_ids": [
+        "scenario-reward-inventory-exhausted",
+        "scenario-missing-payment-confirmation"
+      ],
+      "semantic_id": "redeem-reward",
+      "status": "confirmed",
+      "subordinate_use_case_ids": [],
+      "supporting_actor_ids": [],
+      "trace": {
+        "source_key": "use_cases",
+        "source_round": 3
+      },
+      "trigger": "",
+      "ui_notes": [
+        "Reward detail and redemption confirmation flow with explicit failure states."
+      ],
+      "used_use_case_ids": []
     },
     {
+      "change_metadata": {
+        "change_source": "round_3",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "7b9ec30b01092bc0",
+        "semantic_version": 1,
+        "supersedes": []
+      },
       "complexity": "average",
+      "complexity_trace": {
+        "source_key": "use_case_complexity",
+        "source_round": 9
+      },
+      "content_semantics": "normative",
+      "extension_points": [],
       "extensions": [
         "A change is rejected because it would make an active reward invalid."
       ],
-      "goal": "Create or update reward catalog entries and campaign details.",
-      "id": "uc-catalog",
+      "goal": "Manage Reward Catalog",
+      "id": "manage-reward-catalog",
       "main_success_scenario": [
         "Operations Manager opens catalog administration.",
         "Operations Manager updates reward configuration.",
         "System validates and publishes the change."
       ],
+      "model_layer": "analysis",
       "name": "Manage Reward Catalog",
-      "primary_actor": "Operations Manager"
+      "other_artifact_refs": [],
+      "other_requirement_ids": [],
+      "participating_analysis_object_ids": [
+        "entity-reward"
+      ],
+      "postconditions": [
+        "Reward catalog change is published"
+      ],
+      "preconditions": [
+        "Operations Manager is authenticated"
+      ],
+      "primary_actor": "Unspecified",
+      "primary_actor_id": "",
+      "priority": "medium",
+      "readiness": {
+        "blocking_ambiguity_ids": [],
+        "content_semantics": "normative",
+        "family": "use_cases",
+        "id": "manage-reward-catalog",
+        "missing_fields": [],
+        "normative_ready": true,
+        "status": "ready"
+      },
+      "scenario_ids": [
+        "scenario-invalid-catalog-change"
+      ],
+      "semantic_id": "manage-reward-catalog",
+      "status": "confirmed",
+      "subordinate_use_case_ids": [],
+      "supporting_actor_ids": [],
+      "trace": {
+        "source_key": "use_cases",
+        "source_round": 3
+      },
+      "trigger": "",
+      "ui_notes": [
+        "Back-office catalog editor with validation messages before publish."
+      ],
+      "used_use_case_ids": []
     },
     {
+      "change_metadata": {
+        "change_source": "round_3",
+        "last_changed_at": "",
+        "regenerated_from_version": "",
+        "semantic_hash": "3504f84a0df0905e",
+        "semantic_version": 1,
+        "supersedes": []
+      },
       "complexity": "simple",
+      "complexity_trace": {
+        "source_key": "use_case_complexity",
+        "source_round": 9
+      },
+      "content_semantics": "normative",
+      "extension_points": [],
       "extensions": [
         "A reporting data source is delayed."
       ],
-      "goal": "Inspect reward redemption and campaign performance.",
-      "id": "uc-analytics",
+      "goal": "Review Redemption Analytics",
+      "id": "review-redemption-analytics",
       "main_success_scenario": [
         "Operations Manager opens the analytics dashboard.",
         "System shows redemption and campaign metrics."
       ],
+      "model_layer": "analysis",
       "name": "Review Redemption Analytics",
-      "primary_actor": "Operations Manager"
+      "other_artifact_refs": [],
+      "other_requirement_ids": [],
+      "participating_analysis_object_ids": [
+        "entity-campaign",
+        "entity-redemption",
+        "state-entity-redemption"
+      ],
+      "postconditions": [
+        "Operations Manager can inspect campaign and redemption metrics"
+      ],
+      "preconditions": [
+        "Reporting data is available"
+      ],
+      "primary_actor": "Unspecified",
+      "primary_actor_id": "",
+      "priority": "medium",
+      "readiness": {
+        "blocking_ambiguity_ids": [],
+        "content_semantics": "normative",
+        "family": "use_cases",
+        "id": "review-redemption-analytics",
+        "missing_fields": [],
+        "normative_ready": true,
+        "status": "ready"
+      },
+      "scenario_ids": [
+        "scenario-reporting-delay"
+      ],
+      "semantic_id": "review-redemption-analytics",
+      "status": "confirmed",
+      "subordinate_use_case_ids": [],
+      "supporting_actor_ids": [],
+      "trace": {
+        "source_key": "use_cases",
+        "source_round": 3
+      },
+      "trigger": "",
+      "ui_notes": [
+        "Operational dashboard summarizing redemptions, campaigns, and freshness warnings."
+      ],
+      "used_use_case_ids": []
     }
   ]
 }

--- a/examples/loyalty-platform-v2/model/rupify-model.json
+++ b/examples/loyalty-platform-v2/model/rupify-model.json
@@ -1,0 +1,174 @@
+{
+  "actors": [
+    {
+      "complexity": "complex",
+      "description": "A loyalty member using the digital experience to enroll, browse, and redeem rewards.",
+      "id": "customer",
+      "name": "Customer",
+      "type": "human"
+    },
+    {
+      "complexity": "average",
+      "description": "An internal operator responsible for campaigns, catalog changes, and reporting.",
+      "id": "ops-manager",
+      "name": "Operations Manager",
+      "type": "human"
+    },
+    {
+      "complexity": "simple",
+      "description": "An external system that confirms payment completion for eligible transactions.",
+      "id": "payment-gateway",
+      "name": "Payment Gateway",
+      "type": "system"
+    }
+  ],
+  "assumptions": [
+    "The first delivery increment focuses on a single market and one loyalty program configuration.",
+    "A single product team delivers the first release."
+  ],
+  "business_goals": [
+    "Increase repeat customer engagement through a unified loyalty experience.",
+    "Reduce the operational time required to launch or adjust reward campaigns.",
+    "Create a reliable source of truth for loyalty performance reporting."
+  ],
+  "future_placeholders": {
+    "formal_specification": [],
+    "uml": []
+  },
+  "open_questions": [
+    "Should partner merchants be modeled as separate actors in V1?",
+    "What reporting latency is acceptable for operational analytics?"
+  ],
+  "project": {
+    "domain": "Retail",
+    "name": "Loyalty Platform",
+    "problem_statement": "Legacy loyalty operations are fragmented across channels and teams, causing inconsistent member experience and slow campaign execution.",
+    "system_scope": "A member loyalty platform for enrollment, rewards browsing, redemption, and operational reporting."
+  },
+  "requirements": {
+    "functional": [
+      "The system must allow customers to enroll in the loyalty program digitally.",
+      "The system must show point balance and available rewards to eligible members.",
+      "The system must allow members to redeem rewards when eligibility conditions are satisfied.",
+      "The system must allow operations managers to maintain reward catalog entries and campaign rules.",
+      "The system must provide reporting on redemptions and campaign performance."
+    ],
+    "non_functional": [
+      "The system must protect member and reward transactions with appropriate security controls.",
+      "The member-facing experience must remain usable on common digital channels.",
+      "The platform must support integrations with external systems such as payment confirmation and reporting sources."
+    ]
+  },
+  "success_criteria": [
+    "Members can enroll and redeem rewards through one coherent digital journey.",
+    "Operations managers can update the reward catalog without engineering support for routine changes.",
+    "The business can review redemption and campaign performance in one reporting workflow."
+  ],
+  "ucp": {
+    "environmental_factors": {
+      "application_experience": 3,
+      "difficult_programming_language": 2,
+      "familiar_with_process": 4,
+      "lead_analyst_capability": 4,
+      "motivation": 5,
+      "object_oriented_experience": 3,
+      "part_time_staff": 1,
+      "stable_requirements": 3
+    },
+    "productivity_hours_per_ucp": 20,
+    "technical_factors": {
+      "complex_internal_processing": 3,
+      "concurrency": 2,
+      "distributed_system": 3,
+      "easy_to_change": 3,
+      "easy_to_install": 2,
+      "easy_to_use": 4,
+      "end_user_efficiency": 4,
+      "portability": 2,
+      "response_time": 3,
+      "reusable_code": 2,
+      "special_security": 5,
+      "special_user_training": 2,
+      "third_party_access": 4
+    }
+  },
+  "use_cases": [
+    {
+      "complexity": "simple",
+      "extensions": [
+        "Enrollment is blocked when required consent is missing."
+      ],
+      "goal": "Join the loyalty program and activate an account.",
+      "id": "uc-enroll",
+      "main_success_scenario": [
+        "Customer opens the loyalty enrollment flow.",
+        "Customer provides the required details and consents.",
+        "System validates the submission and creates the member account."
+      ],
+      "name": "Enroll Member",
+      "primary_actor": "Customer"
+    },
+    {
+      "complexity": "average",
+      "extensions": [
+        "Catalog view degrades if an integration is temporarily unavailable."
+      ],
+      "goal": "View eligible rewards and current point balance.",
+      "id": "uc-browse",
+      "main_success_scenario": [
+        "Customer opens the rewards catalog.",
+        "System displays available rewards and points balance.",
+        "Customer filters or sorts the catalog."
+      ],
+      "name": "Browse Rewards",
+      "primary_actor": "Customer"
+    },
+    {
+      "complexity": "complex",
+      "extensions": [
+        "Reward inventory is exhausted before completion.",
+        "Customer does not have enough points.",
+        "Payment confirmation is missing for a reward that depends on purchase completion."
+      ],
+      "goal": "Redeem a selected reward against available loyalty points.",
+      "id": "uc-redeem",
+      "main_success_scenario": [
+        "Customer selects a reward.",
+        "System validates reward eligibility and available points.",
+        "System reserves the reward and updates the member balance.",
+        "System confirms redemption to the customer."
+      ],
+      "name": "Redeem Reward",
+      "primary_actor": "Customer"
+    },
+    {
+      "complexity": "average",
+      "extensions": [
+        "A change is rejected because it would make an active reward invalid."
+      ],
+      "goal": "Create or update reward catalog entries and campaign details.",
+      "id": "uc-catalog",
+      "main_success_scenario": [
+        "Operations Manager opens catalog administration.",
+        "Operations Manager updates reward configuration.",
+        "System validates and publishes the change."
+      ],
+      "name": "Manage Reward Catalog",
+      "primary_actor": "Operations Manager"
+    },
+    {
+      "complexity": "simple",
+      "extensions": [
+        "A reporting data source is delayed."
+      ],
+      "goal": "Inspect reward redemption and campaign performance.",
+      "id": "uc-analytics",
+      "main_success_scenario": [
+        "Operations Manager opens the analytics dashboard.",
+        "System shows redemption and campaign metrics."
+      ],
+      "name": "Review Redemption Analytics",
+      "primary_actor": "Operations Manager"
+    }
+  ]
+}

--- a/tests/fixtures/loyalty_platform_session.json
+++ b/tests/fixtures/loyalty_platform_session.json
@@ -1,0 +1,311 @@
+{
+  "rounds": [
+    {
+      "round": 1,
+      "responses": [
+        {
+          "key": "idea",
+          "answer": "Loyalty Platform"
+        },
+        {
+          "key": "problem",
+          "answer": "Legacy loyalty operations are fragmented across channels and teams, causing inconsistent member experience and slow campaign execution."
+        },
+        {
+          "key": "users",
+          "answer": "Customers and Operations Managers."
+        },
+        {
+          "key": "in_scope",
+          "answer": "A member loyalty platform for enrollment, rewards browsing, redemption, and operational reporting."
+        },
+        {
+          "key": "out_of_scope",
+          "answer": "Partner settlement workflows and multi-country program administration."
+        }
+      ]
+    },
+    {
+      "round": 2,
+      "responses": [
+        {
+          "key": "outcomes",
+          "answer": [
+            "Increase repeat customer engagement through a unified loyalty experience.",
+            "Reduce the operational time required to launch or adjust reward campaigns.",
+            "Create a reliable source of truth for loyalty performance reporting."
+          ]
+        },
+        {
+          "key": "success_criteria",
+          "answer": [
+            "Members can enroll and redeem rewards through one coherent digital journey.",
+            "Operations managers can update the reward catalog without engineering support for routine changes.",
+            "The business can review redemption and campaign performance in one reporting workflow."
+          ]
+        },
+        {
+          "key": "required_data",
+          "answer": [
+            "Member profile and consent data",
+            "Point balances",
+            "Reward catalog configuration",
+            "Campaign rules",
+            "Redemption history"
+          ]
+        },
+        {
+          "key": "constraints",
+          "answer": [
+            "The system must protect member and reward transactions with appropriate security controls.",
+            "The member-facing experience must remain usable on common digital channels.",
+            "The platform must support integrations with external systems such as payment confirmation and reporting sources."
+          ]
+        }
+      ]
+    },
+    {
+      "round": 3,
+      "responses": [
+        {
+          "key": "actors",
+          "answer": [
+            "Customer",
+            "Operations Manager",
+            "Payment Gateway"
+          ]
+        },
+        {
+          "key": "use_cases",
+          "answer": [
+            "Enroll Member",
+            "Browse Rewards",
+            "Redeem Reward",
+            "Manage Reward Catalog",
+            "Review Redemption Analytics"
+          ]
+        },
+        {
+          "key": "integrations",
+          "answer": "The platform must integrate with payment confirmation and downstream reporting sources."
+        }
+      ]
+    },
+    {
+      "round": 4,
+      "responses": [
+        {
+          "key": "workflow_scope",
+          "answer": "The system must allow operations managers to maintain reward catalog entries and campaign rules."
+        },
+        {
+          "key": "metadata_fields",
+          "answer": [
+            "Member identifier",
+            "Consent status",
+            "Point balance",
+            "Reward eligibility rules",
+            "Reward inventory",
+            "Campaign dates",
+            "Payment confirmation reference"
+          ]
+        },
+        {
+          "key": "non_functional_requirements",
+          "answer": [
+            "The system must allow customers to enroll in the loyalty program digitally.",
+            "The system must show point balance and available rewards to eligible members.",
+            "The system must allow members to redeem rewards when eligibility conditions are satisfied.",
+            "The system must provide reporting on redemptions and campaign performance."
+          ]
+        }
+      ]
+    },
+    {
+      "round": 5,
+      "responses": [
+        {
+          "key": "domain_entities",
+          "answer": [
+            "Member",
+            "Reward",
+            "Reward Catalog Entry",
+            "Campaign",
+            "Redemption",
+            "Payment Confirmation",
+            "Analytics Report"
+          ]
+        },
+        {
+          "key": "relationships",
+          "answer": [
+            "A Member has many Redemptions",
+            "A Reward Catalog Entry has one Reward",
+            "A Campaign has many Reward Catalog Entries",
+            "A Redemption has one Payment Confirmation",
+            "An Analytics Report has many Redemptions"
+          ]
+        },
+        {
+          "key": "business_rules",
+          "answer": [
+            "A Redemption must not be fulfilled unless reward eligibility and available points are confirmed.",
+            "A Reward Catalog Entry must be validated before it becomes Published.",
+            "A Member must provide the required details and consents before enrollment completes."
+          ]
+        }
+      ]
+    },
+    {
+      "round": 6,
+      "responses": [
+        {
+          "key": "state_entities",
+          "answer": [
+            "Redemption",
+            "Reward Catalog Entry"
+          ]
+        },
+        {
+          "key": "states_and_transitions",
+          "answer": [
+            "Redemption: Requested -> Validated -> Fulfilled",
+            "Redemption: Requested -> Rejected",
+            "Reward Catalog Entry: Draft -> Published -> Retired"
+          ]
+        },
+        {
+          "key": "triggers_and_approvals",
+          "answer": [
+            "Payment confirmation triggers redemption fulfillment",
+            "Catalog validation approval is required before a reward becomes Published"
+          ]
+        }
+      ]
+    },
+    {
+      "round": 7,
+      "responses": [
+        {
+          "key": "components_and_services",
+          "answer": [
+            "Member App",
+            "Loyalty API",
+            "Operations Console",
+            "Analytics Service",
+            "Payment Gateway Adapter"
+          ]
+        },
+        {
+          "key": "interfaces_and_integrations",
+          "answer": [
+            "Member App calls Loyalty API",
+            "Operations Console calls Loyalty API",
+            "Loyalty API calls Payment Gateway Adapter",
+            "Loyalty API sends Analytics Service"
+          ]
+        },
+        {
+          "key": "runtime_boundaries",
+          "answer": [
+            "Member-facing apps and operations console run separately from the core API",
+            "Payment Gateway Adapter crosses an external boundary"
+          ]
+        }
+      ]
+    },
+    {
+      "round": 8,
+      "responses": [
+        {
+          "key": "actor_complexity",
+          "answer": [
+            "Customer: complex",
+            "Operations Manager: average",
+            "Payment Gateway: simple"
+          ]
+        }
+      ]
+    },
+    {
+      "round": 9,
+      "responses": [
+        {
+          "key": "use_case_complexity",
+          "answer": [
+            "Enroll Member: simple",
+            "Browse Rewards: average",
+            "Redeem Reward: complex",
+            "Manage Reward Catalog: average",
+            "Review Redemption Analytics: simple"
+          ]
+        }
+      ]
+    },
+    {
+      "round": 10,
+      "responses": [
+        {
+          "key": "technical",
+          "answer": "distributed system: 3\nresponse time: 3\nend-user efficiency: 4\ncomplex internal processing: 3\nreusability: 2\nease of installation: 2\nease of use: 4\nportability: 2\nease of change: 3\nconcurrency: 2\nsecurity: 5\nthird-party access: 4\nspecial user training: 2"
+        }
+      ]
+    },
+    {
+      "round": 11,
+      "responses": [
+        {
+          "key": "environmental",
+          "answer": "team familiarity: 4\napplication experience: 3\narchitecture experience: 3\nanalyst capability: 4\nmotivation: 5\nrequirements stability: 3\npart-time staffing: 1\nplatform difficulty: 2"
+        }
+      ]
+    },
+    {
+      "round": 12,
+      "responses": [
+        {
+          "key": "risks",
+          "answer": [
+            "Payment confirmation dependency | priority: high | status: open | mitigation: add retry and reconciliation flow",
+            "Reward configuration errors | priority: medium | status: open | mitigation: validate publish flow and guard rules",
+            "Reporting latency | priority: medium | status: open | mitigation: monitor analytics pipeline freshness"
+          ]
+        }
+      ]
+    },
+    {
+      "round": 13,
+      "responses": [
+        {
+          "key": "use_case_details",
+          "answer": [
+            "Enroll Member | priority: high | status: confirmed | preconditions: Customer is not already enrolled | postconditions: Member account exists and is active | flow: Customer opens the loyalty enrollment flow.; Customer provides the required details and consents.; System validates the submission and creates the member account. | extensions: Enrollment is blocked when required consent is missing.",
+            "Browse Rewards | priority: high | status: confirmed | preconditions: Member is enrolled | postconditions: Eligible rewards and point balance are visible | flow: Customer opens the rewards catalog.; System displays available rewards and points balance.; Customer filters or sorts the catalog. | extensions: Catalog view degrades if an integration is temporarily unavailable.",
+            "Redeem Reward | priority: high | status: confirmed | preconditions: Member is enrolled; Reward is available | postconditions: Redemption is recorded and balance is updated | flow: Customer selects a reward.; System validates reward eligibility and available points.; System reserves the reward and updates the member balance.; System confirms redemption to the customer. | extensions: Reward inventory is exhausted before completion.; Customer does not have enough points.; Payment confirmation is missing for a reward that depends on purchase completion.",
+            "Manage Reward Catalog | priority: medium | status: confirmed | preconditions: Operations Manager is authenticated | postconditions: Reward catalog change is published | flow: Operations Manager opens catalog administration.; Operations Manager updates reward configuration.; System validates and publishes the change. | extensions: A change is rejected because it would make an active reward invalid.",
+            "Review Redemption Analytics | priority: medium | status: confirmed | preconditions: Reporting data is available | postconditions: Operations Manager can inspect campaign and redemption metrics | flow: Operations Manager opens the analytics dashboard.; System shows redemption and campaign metrics. | extensions: A reporting data source is delayed."
+          ]
+        },
+        {
+          "key": "scenarios",
+          "answer": [
+            "Redeem Reward | Reward Inventory Exhausted | Redemption fails because no reward inventory remains. | priority: high | status: open | flow: Customer selects a reward.; System checks reward availability.; System reports that inventory is exhausted.",
+            "Redeem Reward | Missing Payment Confirmation | Redemption pauses until dependent payment confirmation arrives. | priority: medium | status: open | flow: Customer selects a reward.; System requests payment confirmation.; System blocks fulfillment until confirmation arrives.",
+            "Manage Reward Catalog | Invalid Catalog Change | Publication is rejected because the new reward configuration would break an active offer. | priority: medium | status: open | flow: Operations Manager updates reward configuration.; System validates the change.; System rejects the invalid change.",
+            "Review Redemption Analytics | Reporting Delay | Analytics view is partial because a reporting source is delayed. | priority: low | status: open | flow: Operations Manager opens the analytics dashboard.; System detects delayed reporting data.; System shows a partial-data warning."
+          ]
+        },
+        {
+          "key": "ui_notes",
+          "answer": [
+            "Enroll Member | Member-facing responsive enrollment form with consent capture and validation messaging.",
+            "Browse Rewards | Reward catalog view with filters, points balance summary, and eligibility indicators.",
+            "Redeem Reward | Reward detail and redemption confirmation flow with explicit failure states.",
+            "Manage Reward Catalog | Back-office catalog editor with validation messages before publish.",
+            "Review Redemption Analytics | Operational dashboard summarizing redemptions, campaigns, and freshness warnings."
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/test_publication_bundle.py
+++ b/tests/test_publication_bundle.py
@@ -168,7 +168,7 @@ class PublicationBundleTests(unittest.TestCase):
         self.assertEqual(planning_export["summary"]["blocking_ambiguity_count"], 0)
 
     def test_checked_in_loyalty_v2_bundle_preserves_publication_layout(self) -> None:
-        """The loyalty V2 bundle should expose the current publication surface honestly."""
+        """The loyalty V2 bundle should preserve the replay-based publication surface."""
         repo_root = Path(__file__).resolve().parents[1]
         example_dir = repo_root / "examples" / "loyalty-platform-v2"
 
@@ -185,7 +185,7 @@ class PublicationBundleTests(unittest.TestCase):
         self.assertTrue(
             (example_dir / "artifacts" / "ucp" / "ucp-estimate.md").exists()
         )
-        self.assertIn("Important Limitation", readme_path.read_text(encoding="utf-8"))
+        self.assertIn("Speckify Handoff Surface", readme_path.read_text(encoding="utf-8"))
 
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
         planning_export = json.loads(planning_export_path.read_text(encoding="utf-8"))
@@ -198,4 +198,5 @@ class PublicationBundleTests(unittest.TestCase):
             planning_export["export_metadata"]["export_kind"],
             "speckify_planning_export",
         )
-        self.assertEqual(planning_export["summary"]["element_count"], 0)
+        self.assertGreater(planning_export["summary"]["element_count"], 0)
+        self.assertEqual(planning_export["summary"]["blocking_ambiguity_count"], 0)

--- a/tests/test_publication_bundle.py
+++ b/tests/test_publication_bundle.py
@@ -166,3 +166,36 @@ class PublicationBundleTests(unittest.TestCase):
         )
         self.assertEqual(planning_export["export_metadata"]["export_kind"], "speckify_planning_export")
         self.assertEqual(planning_export["summary"]["blocking_ambiguity_count"], 0)
+
+    def test_checked_in_loyalty_v2_bundle_preserves_publication_layout(self) -> None:
+        """The loyalty V2 bundle should expose the current publication surface honestly."""
+        repo_root = Path(__file__).resolve().parents[1]
+        example_dir = repo_root / "examples" / "loyalty-platform-v2"
+
+        manifest_path = example_dir / "bundle-manifest.json"
+        planning_export_path = example_dir / "exports" / "speckify-planning-export.json"
+        readme_path = example_dir / "README.md"
+
+        self.assertTrue(manifest_path.exists())
+        self.assertTrue(planning_export_path.exists())
+        self.assertTrue((example_dir / "model" / "rupify-model.json").exists())
+        self.assertTrue(
+            (example_dir / "artifacts" / "formal" / "requirements-spec.md").exists()
+        )
+        self.assertTrue(
+            (example_dir / "artifacts" / "ucp" / "ucp-estimate.md").exists()
+        )
+        self.assertIn("Important Limitation", readme_path.read_text(encoding="utf-8"))
+
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        planning_export = json.loads(planning_export_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(
+            manifest["bundle_metadata"]["bundle_kind"],
+            "rupify_specification_publication_bundle",
+        )
+        self.assertEqual(
+            planning_export["export_metadata"]["export_kind"],
+            "speckify_planning_export",
+        )
+        self.assertEqual(planning_export["summary"]["element_count"], 0)


### PR DESCRIPTION
## Summary
- add a replayable loyalty-platform interview fixture and regenerate the V2 bundle from the current interview pipeline
- include the current formal, mermaid, UCP, manifest, model snapshot, and planning-export surfaces in the checked-in replay-based bundle
- document and test the loyalty V2 bundle as a real replay/export example rather than a wrapped legacy model

Closes #153

## Verification
- uv run python -m unittest tests.test_publication_bundle
- uv run python -m unittest
