### PR TITLE
Add requirement sub-obligations to Speckify export

### DIFF
--- a/docs/speckify-planning-export.md
+++ b/docs/speckify-planning-export.md
@@ -52,6 +52,14 @@ uv run rupify-export-planning \
     - `source_key`
     - `change_metadata`
     - `attributes`
+    - optional `obligations` for requirement elements where Rupify has explicit normalized
+      requirement sub-obligations
+      - `id`
+      - `title`
+      - `summary`
+      - `acceptance`
+      - `parent_requirement_id`
+      - `parent_requirement_semantic_id`
 - `ready_normative_elements`
   - the ready subset of `elements` where `content_semantics == normative`
 - `blocking_ambiguities`
@@ -65,3 +73,5 @@ uv run rupify-export-planning \
 - `elements` should still be retained for context, partial markers, and auditability.
 - `trace_links` should be treated as the canonical link surface for downstream graph traversal.
 - `blocking_ambiguities` should be treated as explicit stop conditions, not hidden warnings.
+- `obligations` should be consumed only when present; Speckify should fail closed rather than
+  inferring additional sub-obligations by splitting requirement prose downstream.

--- a/examples/it-systems-inventory-v2/README.md
+++ b/examples/it-systems-inventory-v2/README.md
@@ -55,6 +55,7 @@ This V2 export currently shows:
 - 0 blocking ambiguities
 - 0 unresolved trace references
 - 0 duplicate exported element IDs
+- explicit requirement obligations where the upstream requirement normalization can derive them safely
 
 ## Known Limits In This Example
 

--- a/examples/it-systems-inventory-v2/bundle-manifest.json
+++ b/examples/it-systems-inventory-v2/bundle-manifest.json
@@ -15,7 +15,7 @@
       "change_source": "normalize_replay_to_model",
       "last_changed_at": "",
       "regenerated_from_version": "",
-      "semantic_hash": "62d266a14515319f",
+      "semantic_hash": "818aeb022ab1efc9",
       "semantic_version": 1,
       "supersedes": []
     },

--- a/examples/it-systems-inventory-v2/exports/speckify-planning-export.json
+++ b/examples/it-systems-inventory-v2/exports/speckify-planning-export.json
@@ -810,7 +810,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "b817426cb7205235",
+        "semantic_hash": "a3ef6c1c703ff787",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -820,6 +820,24 @@
       "missing_fields": [],
       "name": "",
       "normative_ready": true,
+      "obligations": [
+        {
+          "acceptance": "Stage gates is supported.",
+          "id": "support-stage-gates",
+          "parent_requirement_id": "functional-requirement-1",
+          "parent_requirement_semantic_id": "functional-requirement-1",
+          "summary": "Support stage gates.",
+          "title": "Support stage gates"
+        },
+        {
+          "acceptance": "Approval states is supported.",
+          "id": "support-approval-states",
+          "parent_requirement_id": "functional-requirement-1",
+          "parent_requirement_semantic_id": "functional-requirement-1",
+          "summary": "Support approval states.",
+          "title": "Support approval states"
+        }
+      ],
       "readiness_status": "ready",
       "semantic_id": "functional-requirement-1",
       "source_key": "workflow_scope",
@@ -835,7 +853,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "82d1c204f7e647cb",
+        "semantic_hash": "9bb5aa0707f8efc1",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -1202,7 +1220,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "35140189626f3690",
+        "semantic_hash": "728a95357563e5c3",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -1227,7 +1245,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "2cfeeb6b1a5d6cf3",
+        "semantic_hash": "4777a0dcede17d97",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -1252,7 +1270,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "fea688a24e60eb26",
+        "semantic_hash": "5ce87fea5d01eec6",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -1277,7 +1295,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "06a6d153cde6db09",
+        "semantic_hash": "1301748bdf90f823",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -1302,7 +1320,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "a58c2dc37a3500ae",
+        "semantic_hash": "124f23d7f07094d7",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -1327,7 +1345,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "e0effb42b6bd2a5e",
+        "semantic_hash": "cefdf9f48c729e40",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -1352,7 +1370,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "f4298ae6bd42c9e4",
+        "semantic_hash": "425cdfebd017021e",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -1377,7 +1395,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "7fbb857a1cf2c508",
+        "semantic_hash": "7baedc3ac0f26991",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -2075,7 +2093,7 @@
       "change_source": "normalize_replay_to_model",
       "last_changed_at": "",
       "regenerated_from_version": "",
-      "semantic_hash": "62d266a14515319f",
+      "semantic_hash": "818aeb022ab1efc9",
       "semantic_version": 1,
       "supersedes": []
     },
@@ -2409,7 +2427,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "b817426cb7205235",
+        "semantic_hash": "a3ef6c1c703ff787",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -2419,6 +2437,24 @@
       "missing_fields": [],
       "name": "",
       "normative_ready": true,
+      "obligations": [
+        {
+          "acceptance": "Stage gates is supported.",
+          "id": "support-stage-gates",
+          "parent_requirement_id": "functional-requirement-1",
+          "parent_requirement_semantic_id": "functional-requirement-1",
+          "summary": "Support stage gates.",
+          "title": "Support stage gates"
+        },
+        {
+          "acceptance": "Approval states is supported.",
+          "id": "support-approval-states",
+          "parent_requirement_id": "functional-requirement-1",
+          "parent_requirement_semantic_id": "functional-requirement-1",
+          "summary": "Support approval states.",
+          "title": "Support approval states"
+        }
+      ],
       "readiness_status": "ready",
       "semantic_id": "functional-requirement-1",
       "source_key": "workflow_scope",
@@ -2434,7 +2470,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "82d1c204f7e647cb",
+        "semantic_hash": "9bb5aa0707f8efc1",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -2459,7 +2495,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "35140189626f3690",
+        "semantic_hash": "728a95357563e5c3",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -2484,7 +2520,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "2cfeeb6b1a5d6cf3",
+        "semantic_hash": "4777a0dcede17d97",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -2509,7 +2545,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "fea688a24e60eb26",
+        "semantic_hash": "5ce87fea5d01eec6",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -2534,7 +2570,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "06a6d153cde6db09",
+        "semantic_hash": "1301748bdf90f823",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -2559,7 +2595,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "a58c2dc37a3500ae",
+        "semantic_hash": "124f23d7f07094d7",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -2584,7 +2620,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "e0effb42b6bd2a5e",
+        "semantic_hash": "cefdf9f48c729e40",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -2609,7 +2645,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "f4298ae6bd42c9e4",
+        "semantic_hash": "425cdfebd017021e",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -2634,7 +2670,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "7fbb857a1cf2c508",
+        "semantic_hash": "7baedc3ac0f26991",
         "semantic_version": 1,
         "supersedes": []
       },

--- a/examples/it-systems-inventory-v2/model/rupify-model.json
+++ b/examples/it-systems-inventory-v2/model/rupify-model.json
@@ -1394,7 +1394,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "b817426cb7205235",
+          "semantic_hash": "a3ef6c1c703ff787",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -1417,6 +1417,24 @@
         "requirement_kind": "functional",
         "semantic_id": "functional-requirement-1",
         "statement": "Yes business processes like stage gates and approval states must be supported",
+        "sub_obligations": [
+          {
+            "acceptance": "Stage gates is supported.",
+            "id": "support-stage-gates",
+            "parent_requirement_id": "functional-requirement-1",
+            "parent_requirement_semantic_id": "functional-requirement-1",
+            "summary": "Support stage gates.",
+            "title": "Support stage gates"
+          },
+          {
+            "acceptance": "Approval states is supported.",
+            "id": "support-approval-states",
+            "parent_requirement_id": "functional-requirement-1",
+            "parent_requirement_semantic_id": "functional-requirement-1",
+            "summary": "Support approval states.",
+            "title": "Support approval states"
+          }
+        ],
         "trace": {
           "source_key": "workflow_scope",
           "source_round": 4
@@ -1427,7 +1445,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "82d1c204f7e647cb",
+          "semantic_hash": "9bb5aa0707f8efc1",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -1450,6 +1468,7 @@
         "requirement_kind": "functional",
         "semantic_id": "functional-requirement-2",
         "statement": "I think this will be the CMDB for IT Applications/systems - we need to be able to export data to various system for reporting.",
+        "sub_obligations": [],
         "trace": {
           "source_key": "integrations",
           "source_round": 3
@@ -1460,7 +1479,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "35140189626f3690",
+          "semantic_hash": "728a95357563e5c3",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -1483,6 +1502,7 @@
         "requirement_kind": "non_functional",
         "semantic_id": "non_functional-requirement-1",
         "statement": "UI must be web based",
+        "sub_obligations": [],
         "trace": {
           "source_key": "constraints",
           "source_round": 2
@@ -1493,7 +1513,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "2cfeeb6b1a5d6cf3",
+          "semantic_hash": "4777a0dcede17d97",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -1516,6 +1536,7 @@
         "requirement_kind": "non_functional",
         "semantic_id": "non_functional-requirement-2",
         "statement": "SSO",
+        "sub_obligations": [],
         "trace": {
           "source_key": "non_functional_requirements",
           "source_round": 4
@@ -1526,7 +1547,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "fea688a24e60eb26",
+          "semantic_hash": "5ce87fea5d01eec6",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -1549,6 +1570,7 @@
         "requirement_kind": "non_functional",
         "semantic_id": "non_functional-requirement-3",
         "statement": "role-based access",
+        "sub_obligations": [],
         "trace": {
           "source_key": "non_functional_requirements",
           "source_round": 4
@@ -1559,7 +1581,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "06a6d153cde6db09",
+          "semantic_hash": "1301748bdf90f823",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -1582,6 +1604,7 @@
         "requirement_kind": "non_functional",
         "semantic_id": "non_functional-requirement-4",
         "statement": "audit trail",
+        "sub_obligations": [],
         "trace": {
           "source_key": "non_functional_requirements",
           "source_round": 4
@@ -1592,7 +1615,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "a58c2dc37a3500ae",
+          "semantic_hash": "124f23d7f07094d7",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -1615,6 +1638,7 @@
         "requirement_kind": "non_functional",
         "semantic_id": "non_functional-requirement-5",
         "statement": "search",
+        "sub_obligations": [],
         "trace": {
           "source_key": "non_functional_requirements",
           "source_round": 4
@@ -1625,7 +1649,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "e0effb42b6bd2a5e",
+          "semantic_hash": "cefdf9f48c729e40",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -1648,6 +1672,7 @@
         "requirement_kind": "non_functional",
         "semantic_id": "non_functional-requirement-6",
         "statement": "filtering",
+        "sub_obligations": [],
         "trace": {
           "source_key": "non_functional_requirements",
           "source_round": 4
@@ -1658,7 +1683,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "f4298ae6bd42c9e4",
+          "semantic_hash": "425cdfebd017021e",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -1681,6 +1706,7 @@
         "requirement_kind": "non_functional",
         "semantic_id": "non_functional-requirement-7",
         "statement": "performance (regular >1s for web page rendering)",
+        "sub_obligations": [],
         "trace": {
           "source_key": "non_functional_requirements",
           "source_round": 4
@@ -1691,7 +1717,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "7fbb857a1cf2c508",
+          "semantic_hash": "7baedc3ac0f26991",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -1714,6 +1740,7 @@
         "requirement_kind": "non_functional",
         "semantic_id": "non_functional-requirement-8",
         "statement": "availability >=99%",
+        "sub_obligations": [],
         "trace": {
           "source_key": "non_functional_requirements",
           "source_round": 4
@@ -4090,7 +4117,7 @@
       "change_source": "normalize_replay_to_model",
       "last_changed_at": "",
       "regenerated_from_version": "",
-      "semantic_hash": "62d266a14515319f",
+      "semantic_hash": "818aeb022ab1efc9",
       "semantic_version": 1,
       "supersedes": []
     },
@@ -4841,7 +4868,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "b817426cb7205235",
+          "semantic_hash": "a3ef6c1c703ff787",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -4864,6 +4891,24 @@
         "requirement_kind": "functional",
         "semantic_id": "functional-requirement-1",
         "statement": "Yes business processes like stage gates and approval states must be supported",
+        "sub_obligations": [
+          {
+            "acceptance": "Stage gates is supported.",
+            "id": "support-stage-gates",
+            "parent_requirement_id": "functional-requirement-1",
+            "parent_requirement_semantic_id": "functional-requirement-1",
+            "summary": "Support stage gates.",
+            "title": "Support stage gates"
+          },
+          {
+            "acceptance": "Approval states is supported.",
+            "id": "support-approval-states",
+            "parent_requirement_id": "functional-requirement-1",
+            "parent_requirement_semantic_id": "functional-requirement-1",
+            "summary": "Support approval states.",
+            "title": "Support approval states"
+          }
+        ],
         "trace": {
           "source_key": "workflow_scope",
           "source_round": 4
@@ -4874,7 +4919,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "82d1c204f7e647cb",
+          "semantic_hash": "9bb5aa0707f8efc1",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -4897,6 +4942,7 @@
         "requirement_kind": "functional",
         "semantic_id": "functional-requirement-2",
         "statement": "I think this will be the CMDB for IT Applications/systems - we need to be able to export data to various system for reporting.",
+        "sub_obligations": [],
         "trace": {
           "source_key": "integrations",
           "source_round": 3
@@ -4919,7 +4965,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "35140189626f3690",
+          "semantic_hash": "728a95357563e5c3",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -4942,6 +4988,7 @@
         "requirement_kind": "non_functional",
         "semantic_id": "non_functional-requirement-1",
         "statement": "UI must be web based",
+        "sub_obligations": [],
         "trace": {
           "source_key": "constraints",
           "source_round": 2
@@ -4952,7 +4999,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "2cfeeb6b1a5d6cf3",
+          "semantic_hash": "4777a0dcede17d97",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -4975,6 +5022,7 @@
         "requirement_kind": "non_functional",
         "semantic_id": "non_functional-requirement-2",
         "statement": "SSO",
+        "sub_obligations": [],
         "trace": {
           "source_key": "non_functional_requirements",
           "source_round": 4
@@ -4985,7 +5033,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "fea688a24e60eb26",
+          "semantic_hash": "5ce87fea5d01eec6",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -5008,6 +5056,7 @@
         "requirement_kind": "non_functional",
         "semantic_id": "non_functional-requirement-3",
         "statement": "role-based access",
+        "sub_obligations": [],
         "trace": {
           "source_key": "non_functional_requirements",
           "source_round": 4
@@ -5018,7 +5067,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "06a6d153cde6db09",
+          "semantic_hash": "1301748bdf90f823",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -5041,6 +5090,7 @@
         "requirement_kind": "non_functional",
         "semantic_id": "non_functional-requirement-4",
         "statement": "audit trail",
+        "sub_obligations": [],
         "trace": {
           "source_key": "non_functional_requirements",
           "source_round": 4
@@ -5051,7 +5101,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "a58c2dc37a3500ae",
+          "semantic_hash": "124f23d7f07094d7",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -5074,6 +5124,7 @@
         "requirement_kind": "non_functional",
         "semantic_id": "non_functional-requirement-5",
         "statement": "search",
+        "sub_obligations": [],
         "trace": {
           "source_key": "non_functional_requirements",
           "source_round": 4
@@ -5084,7 +5135,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "e0effb42b6bd2a5e",
+          "semantic_hash": "cefdf9f48c729e40",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -5107,6 +5158,7 @@
         "requirement_kind": "non_functional",
         "semantic_id": "non_functional-requirement-6",
         "statement": "filtering",
+        "sub_obligations": [],
         "trace": {
           "source_key": "non_functional_requirements",
           "source_round": 4
@@ -5117,7 +5169,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "f4298ae6bd42c9e4",
+          "semantic_hash": "425cdfebd017021e",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -5140,6 +5192,7 @@
         "requirement_kind": "non_functional",
         "semantic_id": "non_functional-requirement-7",
         "statement": "performance (regular >1s for web page rendering)",
+        "sub_obligations": [],
         "trace": {
           "source_key": "non_functional_requirements",
           "source_round": 4
@@ -5150,7 +5203,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "7fbb857a1cf2c508",
+          "semantic_hash": "7baedc3ac0f26991",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -5173,6 +5226,7 @@
         "requirement_kind": "non_functional",
         "semantic_id": "non_functional-requirement-8",
         "statement": "availability >=99%",
+        "sub_obligations": [],
         "trace": {
           "source_key": "non_functional_requirements",
           "source_round": 4

--- a/examples/loyalty-platform-v2/README.md
+++ b/examples/loyalty-platform-v2/README.md
@@ -52,6 +52,7 @@ This V2 export currently shows:
 - 0 blocking ambiguities
 - 0 duplicate exported element IDs
 - 0 unresolved trace references
+- explicit requirement obligations where the upstream requirement normalization can derive them safely
 
 ## Notes
 

--- a/examples/loyalty-platform-v2/bundle-manifest.json
+++ b/examples/loyalty-platform-v2/bundle-manifest.json
@@ -15,7 +15,7 @@
       "change_source": "normalize_replay_to_model",
       "last_changed_at": "",
       "regenerated_from_version": "",
-      "semantic_hash": "f53b334e86e54b91",
+      "semantic_hash": "9e539fa7e9653a18",
       "semantic_version": 1,
       "supersedes": []
     },

--- a/examples/loyalty-platform-v2/exports/speckify-planning-export.json
+++ b/examples/loyalty-platform-v2/exports/speckify-planning-export.json
@@ -808,7 +808,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "50ca3d7990de2576",
+        "semantic_hash": "2e8b905f864b8055",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -818,6 +818,24 @@
       "missing_fields": [],
       "name": "",
       "normative_ready": true,
+      "obligations": [
+        {
+          "acceptance": "Operations managers can maintain reward catalog entries.",
+          "id": "maintain-reward-catalog-entries",
+          "parent_requirement_id": "functional-requirement-1",
+          "parent_requirement_semantic_id": "functional-requirement-1",
+          "summary": "Allow operations managers to maintain reward catalog entries.",
+          "title": "Maintain reward catalog entries"
+        },
+        {
+          "acceptance": "Operations managers can maintain campaign rules.",
+          "id": "maintain-campaign-rules",
+          "parent_requirement_id": "functional-requirement-1",
+          "parent_requirement_semantic_id": "functional-requirement-1",
+          "summary": "Allow operations managers to maintain campaign rules.",
+          "title": "Maintain campaign rules"
+        }
+      ],
       "readiness_status": "ready",
       "semantic_id": "functional-requirement-1",
       "source_key": "workflow_scope",
@@ -833,7 +851,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "137be52a3e449f36",
+        "semantic_hash": "dc3d2831f79f8c13",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -843,6 +861,24 @@
       "missing_fields": [],
       "name": "",
       "normative_ready": true,
+      "obligations": [
+        {
+          "acceptance": "Payment confirmation is supported.",
+          "id": "integrate-with-payment-confirmation",
+          "parent_requirement_id": "functional-requirement-2",
+          "parent_requirement_semantic_id": "functional-requirement-2",
+          "summary": "Integrate with payment confirmation.",
+          "title": "Integrate with payment confirmation"
+        },
+        {
+          "acceptance": "Downstream reporting sources is supported.",
+          "id": "integrate-with-downstream-reporting-sources",
+          "parent_requirement_id": "functional-requirement-2",
+          "parent_requirement_semantic_id": "functional-requirement-2",
+          "summary": "Integrate with downstream reporting sources.",
+          "title": "Integrate with downstream reporting sources"
+        }
+      ],
       "readiness_status": "ready",
       "semantic_id": "functional-requirement-2",
       "source_key": "integrations",
@@ -1243,7 +1279,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "6d25cd70cc309bd6",
+        "semantic_hash": "9fce780019db01af",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -1253,6 +1289,24 @@
       "missing_fields": [],
       "name": "",
       "normative_ready": true,
+      "obligations": [
+        {
+          "acceptance": "Member with appropriate security controls is supported.",
+          "id": "protect-member",
+          "parent_requirement_id": "non_functional-requirement-1",
+          "parent_requirement_semantic_id": "non_functional-requirement-1",
+          "summary": "Protect member with appropriate security controls.",
+          "title": "Protect member"
+        },
+        {
+          "acceptance": "Reward transactions with appropriate security controls is supported.",
+          "id": "protect-reward-transactions",
+          "parent_requirement_id": "non_functional-requirement-1",
+          "parent_requirement_semantic_id": "non_functional-requirement-1",
+          "summary": "Protect reward transactions with appropriate security controls.",
+          "title": "Protect reward transactions"
+        }
+      ],
       "readiness_status": "ready",
       "semantic_id": "non_functional-requirement-1",
       "source_key": "constraints",
@@ -1268,7 +1322,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "3c50cc9fdf143ffc",
+        "semantic_hash": "f34eab98113e6cb9",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -1293,7 +1347,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "123d736840c12b01",
+        "semantic_hash": "1e8d913324d95244",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -1318,7 +1372,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "91b01cf0f9df4489",
+        "semantic_hash": "e16e61e669d9d038",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -1343,7 +1397,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "c869b78025ab245a",
+        "semantic_hash": "dd40814a68e5ea4c",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -1353,6 +1407,24 @@
       "missing_fields": [],
       "name": "",
       "normative_ready": true,
+      "obligations": [
+        {
+          "acceptance": "Point balance to eligible members is supported.",
+          "id": "show-point-balance",
+          "parent_requirement_id": "non_functional-requirement-5",
+          "parent_requirement_semantic_id": "non_functional-requirement-5",
+          "summary": "Show point balance to eligible members.",
+          "title": "Show point balance"
+        },
+        {
+          "acceptance": "Available rewards to eligible members is supported.",
+          "id": "show-available-rewards",
+          "parent_requirement_id": "non_functional-requirement-5",
+          "parent_requirement_semantic_id": "non_functional-requirement-5",
+          "summary": "Show available rewards to eligible members.",
+          "title": "Show available rewards"
+        }
+      ],
       "readiness_status": "ready",
       "semantic_id": "non_functional-requirement-5",
       "source_key": "non_functional_requirements",
@@ -1371,7 +1443,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "5f03cdaaa89ad4e1",
+        "semantic_hash": "986075ab3840cbda",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -1396,7 +1468,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "925c5506da0bb97a",
+        "semantic_hash": "0812eed1d3237b95",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -1406,6 +1478,24 @@
       "missing_fields": [],
       "name": "",
       "normative_ready": true,
+      "obligations": [
+        {
+          "acceptance": "Reporting on redemptions is supported.",
+          "id": "provide-reporting-on-redemptions",
+          "parent_requirement_id": "non_functional-requirement-7",
+          "parent_requirement_semantic_id": "non_functional-requirement-7",
+          "summary": "Provide reporting on redemptions.",
+          "title": "Provide reporting on redemptions"
+        },
+        {
+          "acceptance": "Campaign performance is supported.",
+          "id": "provide-campaign-performance",
+          "parent_requirement_id": "non_functional-requirement-7",
+          "parent_requirement_semantic_id": "non_functional-requirement-7",
+          "summary": "Provide campaign performance.",
+          "title": "Provide campaign performance"
+        }
+      ],
       "readiness_status": "ready",
       "semantic_id": "non_functional-requirement-7",
       "source_key": "non_functional_requirements",
@@ -2801,7 +2891,7 @@
       "change_source": "normalize_replay_to_model",
       "last_changed_at": "",
       "regenerated_from_version": "",
-      "semantic_hash": "f53b334e86e54b91",
+      "semantic_hash": "9e539fa7e9653a18",
       "semantic_version": 1,
       "supersedes": []
     },
@@ -3185,7 +3275,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "50ca3d7990de2576",
+        "semantic_hash": "2e8b905f864b8055",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -3195,6 +3285,24 @@
       "missing_fields": [],
       "name": "",
       "normative_ready": true,
+      "obligations": [
+        {
+          "acceptance": "Operations managers can maintain reward catalog entries.",
+          "id": "maintain-reward-catalog-entries",
+          "parent_requirement_id": "functional-requirement-1",
+          "parent_requirement_semantic_id": "functional-requirement-1",
+          "summary": "Allow operations managers to maintain reward catalog entries.",
+          "title": "Maintain reward catalog entries"
+        },
+        {
+          "acceptance": "Operations managers can maintain campaign rules.",
+          "id": "maintain-campaign-rules",
+          "parent_requirement_id": "functional-requirement-1",
+          "parent_requirement_semantic_id": "functional-requirement-1",
+          "summary": "Allow operations managers to maintain campaign rules.",
+          "title": "Maintain campaign rules"
+        }
+      ],
       "readiness_status": "ready",
       "semantic_id": "functional-requirement-1",
       "source_key": "workflow_scope",
@@ -3210,7 +3318,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "137be52a3e449f36",
+        "semantic_hash": "dc3d2831f79f8c13",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -3220,6 +3328,24 @@
       "missing_fields": [],
       "name": "",
       "normative_ready": true,
+      "obligations": [
+        {
+          "acceptance": "Payment confirmation is supported.",
+          "id": "integrate-with-payment-confirmation",
+          "parent_requirement_id": "functional-requirement-2",
+          "parent_requirement_semantic_id": "functional-requirement-2",
+          "summary": "Integrate with payment confirmation.",
+          "title": "Integrate with payment confirmation"
+        },
+        {
+          "acceptance": "Downstream reporting sources is supported.",
+          "id": "integrate-with-downstream-reporting-sources",
+          "parent_requirement_id": "functional-requirement-2",
+          "parent_requirement_semantic_id": "functional-requirement-2",
+          "summary": "Integrate with downstream reporting sources.",
+          "title": "Integrate with downstream reporting sources"
+        }
+      ],
       "readiness_status": "ready",
       "semantic_id": "functional-requirement-2",
       "source_key": "integrations",
@@ -3267,7 +3393,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "6d25cd70cc309bd6",
+        "semantic_hash": "9fce780019db01af",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -3277,6 +3403,24 @@
       "missing_fields": [],
       "name": "",
       "normative_ready": true,
+      "obligations": [
+        {
+          "acceptance": "Member with appropriate security controls is supported.",
+          "id": "protect-member",
+          "parent_requirement_id": "non_functional-requirement-1",
+          "parent_requirement_semantic_id": "non_functional-requirement-1",
+          "summary": "Protect member with appropriate security controls.",
+          "title": "Protect member"
+        },
+        {
+          "acceptance": "Reward transactions with appropriate security controls is supported.",
+          "id": "protect-reward-transactions",
+          "parent_requirement_id": "non_functional-requirement-1",
+          "parent_requirement_semantic_id": "non_functional-requirement-1",
+          "summary": "Protect reward transactions with appropriate security controls.",
+          "title": "Protect reward transactions"
+        }
+      ],
       "readiness_status": "ready",
       "semantic_id": "non_functional-requirement-1",
       "source_key": "constraints",
@@ -3292,7 +3436,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "3c50cc9fdf143ffc",
+        "semantic_hash": "f34eab98113e6cb9",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -3317,7 +3461,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "123d736840c12b01",
+        "semantic_hash": "1e8d913324d95244",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -3342,7 +3486,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "91b01cf0f9df4489",
+        "semantic_hash": "e16e61e669d9d038",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -3367,7 +3511,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "c869b78025ab245a",
+        "semantic_hash": "dd40814a68e5ea4c",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -3377,6 +3521,24 @@
       "missing_fields": [],
       "name": "",
       "normative_ready": true,
+      "obligations": [
+        {
+          "acceptance": "Point balance to eligible members is supported.",
+          "id": "show-point-balance",
+          "parent_requirement_id": "non_functional-requirement-5",
+          "parent_requirement_semantic_id": "non_functional-requirement-5",
+          "summary": "Show point balance to eligible members.",
+          "title": "Show point balance"
+        },
+        {
+          "acceptance": "Available rewards to eligible members is supported.",
+          "id": "show-available-rewards",
+          "parent_requirement_id": "non_functional-requirement-5",
+          "parent_requirement_semantic_id": "non_functional-requirement-5",
+          "summary": "Show available rewards to eligible members.",
+          "title": "Show available rewards"
+        }
+      ],
       "readiness_status": "ready",
       "semantic_id": "non_functional-requirement-5",
       "source_key": "non_functional_requirements",
@@ -3395,7 +3557,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "5f03cdaaa89ad4e1",
+        "semantic_hash": "986075ab3840cbda",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -3420,7 +3582,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "925c5506da0bb97a",
+        "semantic_hash": "0812eed1d3237b95",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -3430,6 +3592,24 @@
       "missing_fields": [],
       "name": "",
       "normative_ready": true,
+      "obligations": [
+        {
+          "acceptance": "Reporting on redemptions is supported.",
+          "id": "provide-reporting-on-redemptions",
+          "parent_requirement_id": "non_functional-requirement-7",
+          "parent_requirement_semantic_id": "non_functional-requirement-7",
+          "summary": "Provide reporting on redemptions.",
+          "title": "Provide reporting on redemptions"
+        },
+        {
+          "acceptance": "Campaign performance is supported.",
+          "id": "provide-campaign-performance",
+          "parent_requirement_id": "non_functional-requirement-7",
+          "parent_requirement_semantic_id": "non_functional-requirement-7",
+          "summary": "Provide campaign performance.",
+          "title": "Provide campaign performance"
+        }
+      ],
       "readiness_status": "ready",
       "semantic_id": "non_functional-requirement-7",
       "source_key": "non_functional_requirements",

--- a/examples/loyalty-platform-v2/model/rupify-model.json
+++ b/examples/loyalty-platform-v2/model/rupify-model.json
@@ -1151,7 +1151,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "50ca3d7990de2576",
+          "semantic_hash": "2e8b905f864b8055",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -1174,6 +1174,24 @@
         "requirement_kind": "functional",
         "semantic_id": "functional-requirement-1",
         "statement": "The system must allow operations managers to maintain reward catalog entries and campaign rules.",
+        "sub_obligations": [
+          {
+            "acceptance": "Operations managers can maintain reward catalog entries.",
+            "id": "maintain-reward-catalog-entries",
+            "parent_requirement_id": "functional-requirement-1",
+            "parent_requirement_semantic_id": "functional-requirement-1",
+            "summary": "Allow operations managers to maintain reward catalog entries.",
+            "title": "Maintain reward catalog entries"
+          },
+          {
+            "acceptance": "Operations managers can maintain campaign rules.",
+            "id": "maintain-campaign-rules",
+            "parent_requirement_id": "functional-requirement-1",
+            "parent_requirement_semantic_id": "functional-requirement-1",
+            "summary": "Allow operations managers to maintain campaign rules.",
+            "title": "Maintain campaign rules"
+          }
+        ],
         "trace": {
           "source_key": "workflow_scope",
           "source_round": 4
@@ -1184,7 +1202,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "137be52a3e449f36",
+          "semantic_hash": "dc3d2831f79f8c13",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -1207,6 +1225,24 @@
         "requirement_kind": "functional",
         "semantic_id": "functional-requirement-2",
         "statement": "The platform must integrate with payment confirmation and downstream reporting sources.",
+        "sub_obligations": [
+          {
+            "acceptance": "Payment confirmation is supported.",
+            "id": "integrate-with-payment-confirmation",
+            "parent_requirement_id": "functional-requirement-2",
+            "parent_requirement_semantic_id": "functional-requirement-2",
+            "summary": "Integrate with payment confirmation.",
+            "title": "Integrate with payment confirmation"
+          },
+          {
+            "acceptance": "Downstream reporting sources is supported.",
+            "id": "integrate-with-downstream-reporting-sources",
+            "parent_requirement_id": "functional-requirement-2",
+            "parent_requirement_semantic_id": "functional-requirement-2",
+            "summary": "Integrate with downstream reporting sources.",
+            "title": "Integrate with downstream reporting sources"
+          }
+        ],
         "trace": {
           "source_key": "integrations",
           "source_round": 3
@@ -1217,7 +1253,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "6d25cd70cc309bd6",
+          "semantic_hash": "9fce780019db01af",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -1240,6 +1276,24 @@
         "requirement_kind": "non_functional",
         "semantic_id": "non_functional-requirement-1",
         "statement": "The system must protect member and reward transactions with appropriate security controls.",
+        "sub_obligations": [
+          {
+            "acceptance": "Member with appropriate security controls is supported.",
+            "id": "protect-member",
+            "parent_requirement_id": "non_functional-requirement-1",
+            "parent_requirement_semantic_id": "non_functional-requirement-1",
+            "summary": "Protect member with appropriate security controls.",
+            "title": "Protect member"
+          },
+          {
+            "acceptance": "Reward transactions with appropriate security controls is supported.",
+            "id": "protect-reward-transactions",
+            "parent_requirement_id": "non_functional-requirement-1",
+            "parent_requirement_semantic_id": "non_functional-requirement-1",
+            "summary": "Protect reward transactions with appropriate security controls.",
+            "title": "Protect reward transactions"
+          }
+        ],
         "trace": {
           "source_key": "constraints",
           "source_round": 2
@@ -1250,7 +1304,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "3c50cc9fdf143ffc",
+          "semantic_hash": "f34eab98113e6cb9",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -1273,6 +1327,7 @@
         "requirement_kind": "non_functional",
         "semantic_id": "non_functional-requirement-2",
         "statement": "The member-facing experience must remain usable on common digital channels.",
+        "sub_obligations": [],
         "trace": {
           "source_key": "constraints",
           "source_round": 2
@@ -1283,7 +1338,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "123d736840c12b01",
+          "semantic_hash": "1e8d913324d95244",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -1306,6 +1361,7 @@
         "requirement_kind": "non_functional",
         "semantic_id": "non_functional-requirement-3",
         "statement": "The platform must support integrations with external systems such as payment confirmation and reporting sources.",
+        "sub_obligations": [],
         "trace": {
           "source_key": "constraints",
           "source_round": 2
@@ -1316,7 +1372,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "91b01cf0f9df4489",
+          "semantic_hash": "e16e61e669d9d038",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -1339,6 +1395,7 @@
         "requirement_kind": "non_functional",
         "semantic_id": "non_functional-requirement-4",
         "statement": "The system must allow customers to enroll in the loyalty program digitally.",
+        "sub_obligations": [],
         "trace": {
           "source_key": "non_functional_requirements",
           "source_round": 4
@@ -1349,7 +1406,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "c869b78025ab245a",
+          "semantic_hash": "dd40814a68e5ea4c",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -1372,6 +1429,24 @@
         "requirement_kind": "non_functional",
         "semantic_id": "non_functional-requirement-5",
         "statement": "The system must show point balance and available rewards to eligible members.",
+        "sub_obligations": [
+          {
+            "acceptance": "Point balance to eligible members is supported.",
+            "id": "show-point-balance",
+            "parent_requirement_id": "non_functional-requirement-5",
+            "parent_requirement_semantic_id": "non_functional-requirement-5",
+            "summary": "Show point balance to eligible members.",
+            "title": "Show point balance"
+          },
+          {
+            "acceptance": "Available rewards to eligible members is supported.",
+            "id": "show-available-rewards",
+            "parent_requirement_id": "non_functional-requirement-5",
+            "parent_requirement_semantic_id": "non_functional-requirement-5",
+            "summary": "Show available rewards to eligible members.",
+            "title": "Show available rewards"
+          }
+        ],
         "trace": {
           "source_key": "non_functional_requirements",
           "source_round": 4
@@ -1382,7 +1457,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "5f03cdaaa89ad4e1",
+          "semantic_hash": "986075ab3840cbda",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -1407,6 +1482,7 @@
         "requirement_kind": "non_functional",
         "semantic_id": "non_functional-requirement-6",
         "statement": "The system must allow members to redeem rewards when eligibility conditions are satisfied.",
+        "sub_obligations": [],
         "trace": {
           "source_key": "non_functional_requirements",
           "source_round": 4
@@ -1417,7 +1493,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "925c5506da0bb97a",
+          "semantic_hash": "0812eed1d3237b95",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -1440,6 +1516,24 @@
         "requirement_kind": "non_functional",
         "semantic_id": "non_functional-requirement-7",
         "statement": "The system must provide reporting on redemptions and campaign performance.",
+        "sub_obligations": [
+          {
+            "acceptance": "Reporting on redemptions is supported.",
+            "id": "provide-reporting-on-redemptions",
+            "parent_requirement_id": "non_functional-requirement-7",
+            "parent_requirement_semantic_id": "non_functional-requirement-7",
+            "summary": "Provide reporting on redemptions.",
+            "title": "Provide reporting on redemptions"
+          },
+          {
+            "acceptance": "Campaign performance is supported.",
+            "id": "provide-campaign-performance",
+            "parent_requirement_id": "non_functional-requirement-7",
+            "parent_requirement_semantic_id": "non_functional-requirement-7",
+            "summary": "Provide campaign performance.",
+            "title": "Provide campaign performance"
+          }
+        ],
         "trace": {
           "source_key": "non_functional_requirements",
           "source_round": 4
@@ -5477,7 +5571,7 @@
       "change_source": "normalize_replay_to_model",
       "last_changed_at": "",
       "regenerated_from_version": "",
-      "semantic_hash": "f53b334e86e54b91",
+      "semantic_hash": "9e539fa7e9653a18",
       "semantic_version": 1,
       "supersedes": []
     },
@@ -6333,7 +6427,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "50ca3d7990de2576",
+          "semantic_hash": "2e8b905f864b8055",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -6356,6 +6450,24 @@
         "requirement_kind": "functional",
         "semantic_id": "functional-requirement-1",
         "statement": "The system must allow operations managers to maintain reward catalog entries and campaign rules.",
+        "sub_obligations": [
+          {
+            "acceptance": "Operations managers can maintain reward catalog entries.",
+            "id": "maintain-reward-catalog-entries",
+            "parent_requirement_id": "functional-requirement-1",
+            "parent_requirement_semantic_id": "functional-requirement-1",
+            "summary": "Allow operations managers to maintain reward catalog entries.",
+            "title": "Maintain reward catalog entries"
+          },
+          {
+            "acceptance": "Operations managers can maintain campaign rules.",
+            "id": "maintain-campaign-rules",
+            "parent_requirement_id": "functional-requirement-1",
+            "parent_requirement_semantic_id": "functional-requirement-1",
+            "summary": "Allow operations managers to maintain campaign rules.",
+            "title": "Maintain campaign rules"
+          }
+        ],
         "trace": {
           "source_key": "workflow_scope",
           "source_round": 4
@@ -6366,7 +6478,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "137be52a3e449f36",
+          "semantic_hash": "dc3d2831f79f8c13",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -6389,6 +6501,24 @@
         "requirement_kind": "functional",
         "semantic_id": "functional-requirement-2",
         "statement": "The platform must integrate with payment confirmation and downstream reporting sources.",
+        "sub_obligations": [
+          {
+            "acceptance": "Payment confirmation is supported.",
+            "id": "integrate-with-payment-confirmation",
+            "parent_requirement_id": "functional-requirement-2",
+            "parent_requirement_semantic_id": "functional-requirement-2",
+            "summary": "Integrate with payment confirmation.",
+            "title": "Integrate with payment confirmation"
+          },
+          {
+            "acceptance": "Downstream reporting sources is supported.",
+            "id": "integrate-with-downstream-reporting-sources",
+            "parent_requirement_id": "functional-requirement-2",
+            "parent_requirement_semantic_id": "functional-requirement-2",
+            "summary": "Integrate with downstream reporting sources.",
+            "title": "Integrate with downstream reporting sources"
+          }
+        ],
         "trace": {
           "source_key": "integrations",
           "source_round": 3
@@ -6410,7 +6540,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "6d25cd70cc309bd6",
+          "semantic_hash": "9fce780019db01af",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -6433,6 +6563,24 @@
         "requirement_kind": "non_functional",
         "semantic_id": "non_functional-requirement-1",
         "statement": "The system must protect member and reward transactions with appropriate security controls.",
+        "sub_obligations": [
+          {
+            "acceptance": "Member with appropriate security controls is supported.",
+            "id": "protect-member",
+            "parent_requirement_id": "non_functional-requirement-1",
+            "parent_requirement_semantic_id": "non_functional-requirement-1",
+            "summary": "Protect member with appropriate security controls.",
+            "title": "Protect member"
+          },
+          {
+            "acceptance": "Reward transactions with appropriate security controls is supported.",
+            "id": "protect-reward-transactions",
+            "parent_requirement_id": "non_functional-requirement-1",
+            "parent_requirement_semantic_id": "non_functional-requirement-1",
+            "summary": "Protect reward transactions with appropriate security controls.",
+            "title": "Protect reward transactions"
+          }
+        ],
         "trace": {
           "source_key": "constraints",
           "source_round": 2
@@ -6443,7 +6591,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "3c50cc9fdf143ffc",
+          "semantic_hash": "f34eab98113e6cb9",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -6466,6 +6614,7 @@
         "requirement_kind": "non_functional",
         "semantic_id": "non_functional-requirement-2",
         "statement": "The member-facing experience must remain usable on common digital channels.",
+        "sub_obligations": [],
         "trace": {
           "source_key": "constraints",
           "source_round": 2
@@ -6476,7 +6625,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "123d736840c12b01",
+          "semantic_hash": "1e8d913324d95244",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -6499,6 +6648,7 @@
         "requirement_kind": "non_functional",
         "semantic_id": "non_functional-requirement-3",
         "statement": "The platform must support integrations with external systems such as payment confirmation and reporting sources.",
+        "sub_obligations": [],
         "trace": {
           "source_key": "constraints",
           "source_round": 2
@@ -6509,7 +6659,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "91b01cf0f9df4489",
+          "semantic_hash": "e16e61e669d9d038",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -6532,6 +6682,7 @@
         "requirement_kind": "non_functional",
         "semantic_id": "non_functional-requirement-4",
         "statement": "The system must allow customers to enroll in the loyalty program digitally.",
+        "sub_obligations": [],
         "trace": {
           "source_key": "non_functional_requirements",
           "source_round": 4
@@ -6542,7 +6693,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "c869b78025ab245a",
+          "semantic_hash": "dd40814a68e5ea4c",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -6565,6 +6716,24 @@
         "requirement_kind": "non_functional",
         "semantic_id": "non_functional-requirement-5",
         "statement": "The system must show point balance and available rewards to eligible members.",
+        "sub_obligations": [
+          {
+            "acceptance": "Point balance to eligible members is supported.",
+            "id": "show-point-balance",
+            "parent_requirement_id": "non_functional-requirement-5",
+            "parent_requirement_semantic_id": "non_functional-requirement-5",
+            "summary": "Show point balance to eligible members.",
+            "title": "Show point balance"
+          },
+          {
+            "acceptance": "Available rewards to eligible members is supported.",
+            "id": "show-available-rewards",
+            "parent_requirement_id": "non_functional-requirement-5",
+            "parent_requirement_semantic_id": "non_functional-requirement-5",
+            "summary": "Show available rewards to eligible members.",
+            "title": "Show available rewards"
+          }
+        ],
         "trace": {
           "source_key": "non_functional_requirements",
           "source_round": 4
@@ -6575,7 +6744,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "5f03cdaaa89ad4e1",
+          "semantic_hash": "986075ab3840cbda",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -6600,6 +6769,7 @@
         "requirement_kind": "non_functional",
         "semantic_id": "non_functional-requirement-6",
         "statement": "The system must allow members to redeem rewards when eligibility conditions are satisfied.",
+        "sub_obligations": [],
         "trace": {
           "source_key": "non_functional_requirements",
           "source_round": 4
@@ -6610,7 +6780,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "925c5506da0bb97a",
+          "semantic_hash": "0812eed1d3237b95",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -6633,6 +6803,24 @@
         "requirement_kind": "non_functional",
         "semantic_id": "non_functional-requirement-7",
         "statement": "The system must provide reporting on redemptions and campaign performance.",
+        "sub_obligations": [
+          {
+            "acceptance": "Reporting on redemptions is supported.",
+            "id": "provide-reporting-on-redemptions",
+            "parent_requirement_id": "non_functional-requirement-7",
+            "parent_requirement_semantic_id": "non_functional-requirement-7",
+            "summary": "Provide reporting on redemptions.",
+            "title": "Provide reporting on redemptions"
+          },
+          {
+            "acceptance": "Campaign performance is supported.",
+            "id": "provide-campaign-performance",
+            "parent_requirement_id": "non_functional-requirement-7",
+            "parent_requirement_semantic_id": "non_functional-requirement-7",
+            "summary": "Provide campaign performance.",
+            "title": "Provide campaign performance"
+          }
+        ],
         "trace": {
           "source_key": "non_functional_requirements",
           "source_round": 4

--- a/skills/rupify/references/rupify-model.md
+++ b/skills/rupify/references/rupify-model.md
@@ -108,6 +108,13 @@ The canonical project model is `rupify-model.yaml`.
     - `linked_use_case_ids`
     - `linked_step_ids`
     - `fit_criterion`
+    - `sub_obligations`
+      - `id`
+      - `title`
+      - `summary`
+      - `acceptance`
+      - `parent_requirement_id`
+      - `parent_requirement_semantic_id`
     - `trace`
     - `content_semantics`: `normative` or `informative`
     - `readiness`
@@ -121,6 +128,13 @@ The canonical project model is `rupify-model.yaml`.
     - `linked_use_case_ids`
     - `linked_step_ids`
     - `fit_criterion`
+    - `sub_obligations`
+      - `id`
+      - `title`
+      - `summary`
+      - `acceptance`
+      - `parent_requirement_id`
+      - `parent_requirement_semantic_id`
     - `trace`
     - `content_semantics`: `normative` or `informative`
     - `readiness`

--- a/src/rupify_tools/discovery.py
+++ b/src/rupify_tools/discovery.py
@@ -669,6 +669,7 @@ def _normalize_requirement_objects(
                 "model_layer": "analysis",
                 "linked_use_case_ids": [],
                 "fit_criterion": "",
+                "sub_obligations": _derive_requirement_sub_obligations(text),
                 "trace": {},
             }
         )
@@ -682,6 +683,148 @@ def _reindex_requirement_objects(
     """Assign stable sequential requirement ids across one combined requirement family."""
     for index, item in enumerate(items, 1):
         item["id"] = f"{requirement_kind}-requirement-{index}"
+
+
+def _clean_sentence(text: str) -> str:
+    """Return one normalized sentence without trailing punctuation."""
+    return text.strip().rstrip(".")
+
+
+def _capitalize_phrase(text: str) -> str:
+    """Capitalize the first character of a phrase without changing the rest."""
+    cleaned = text.strip()
+    if not cleaned:
+        return ""
+    return cleaned[0].upper() + cleaned[1:]
+
+
+def _split_conjoined_objects(text: str) -> tuple[list[str], str]:
+    """Split a simple conjunction into object parts plus a shared suffix."""
+    cleaned = _clean_sentence(text)
+    suffix = ""
+    for marker in (" to ", " for ", " when ", " with ", " against ", " before ", " after "):
+        marker_index = cleaned.find(marker)
+        if marker_index != -1:
+            suffix = cleaned[marker_index:]
+            cleaned = cleaned[:marker_index]
+            break
+    parts = [part.strip() for part in cleaned.split(" and ") if part.strip()]
+    if len(parts) < 2:
+        return [], ""
+    return parts, suffix
+
+
+def _build_sub_obligation(
+    obligation_id: str,
+    title: str,
+    summary: str,
+    acceptance: str,
+) -> dict[str, str]:
+    """Build one normalized sub-obligation record."""
+    return {
+        "id": obligation_id,
+        "title": title,
+        "summary": summary,
+        "acceptance": acceptance,
+        "parent_requirement_id": "",
+        "parent_requirement_semantic_id": "",
+    }
+
+
+def _derive_requirement_sub_obligations(statement: str) -> list[dict[str, str]]:
+    """Derive conservative requirement sub-obligations from explicit shared-prefix conjunctions."""
+    cleaned = _clean_sentence(statement)
+    if not cleaned or " and " not in cleaned:
+        return []
+
+    allow_match = re.match(
+        r"^(?P<subject>.+?) must allow (?P<actor>.+?) to (?P<action>.+)$",
+        cleaned,
+        flags=re.IGNORECASE,
+    )
+    if allow_match:
+        actor = allow_match.group("actor").strip()
+        action = allow_match.group("action").strip()
+        for prefix in ("maintain", "show", "support", "record", "protect", "provide"):
+            prefix_with_space = f"{prefix} "
+            if not action.lower().startswith(prefix_with_space):
+                continue
+            objects, suffix = _split_conjoined_objects(action[len(prefix_with_space) :])
+            if len(objects) < 2:
+                continue
+            obligations = []
+            for item in objects:
+                title = f"{prefix.capitalize()} {item}"
+                obligations.append(
+                    _build_sub_obligation(
+                        obligation_id=_slugify(title),
+                        title=title,
+                        summary=f"Allow {actor} to {prefix} {item}{suffix}.",
+                        acceptance=f"{_capitalize_phrase(actor)} can {prefix} {item}{suffix}.",
+                    )
+                )
+            return obligations
+
+    direct_match = re.match(
+        r"^(?P<subject>.+?) must (?P<action>.+)$",
+        cleaned,
+        flags=re.IGNORECASE,
+    )
+    if direct_match:
+        action = direct_match.group("action").strip()
+        for prefix in ("integrate with", "record", "show", "support", "protect", "provide"):
+            prefix_with_space = f"{prefix} "
+            if not action.lower().startswith(prefix_with_space):
+                continue
+            objects, suffix = _split_conjoined_objects(action[len(prefix_with_space) :])
+            if len(objects) < 2:
+                continue
+            obligations = []
+            for item in objects:
+                title = f"{prefix.capitalize()} {item}"
+                obligations.append(
+                    _build_sub_obligation(
+                        obligation_id=_slugify(title),
+                        title=title,
+                        summary=f"{prefix.capitalize()} {item}{suffix}.",
+                        acceptance=f"{_capitalize_phrase(item)}{suffix} is supported.",
+                    )
+                )
+            return obligations
+
+    support_match = re.match(
+        r"^(?P<prefix>.+? like )(?P<objects>.+?) must be supported$",
+        cleaned,
+        flags=re.IGNORECASE,
+    )
+    if support_match:
+        objects, _ = _split_conjoined_objects(support_match.group("objects"))
+        if len(objects) < 2:
+            return []
+        obligations = []
+        for item in objects:
+            title = f"Support {item}"
+            obligations.append(
+                _build_sub_obligation(
+                    obligation_id=_slugify(title),
+                    title=title,
+                    summary=f"Support {item}.",
+                    acceptance=f"{_capitalize_phrase(item)} is supported.",
+                )
+            )
+        return obligations
+
+    return []
+
+
+def _bind_requirement_sub_obligations(requirements: list[dict[str, Any]]) -> None:
+    """Bind parent requirement ids and semantic ids onto nested sub-obligations."""
+    for requirement in requirements:
+        parent_id = requirement.get("id", "")
+        parent_semantic_id = requirement.get("semantic_id", parent_id)
+        for sub_obligation in requirement.get("sub_obligations", []):
+            sub_obligation["parent_requirement_id"] = parent_id
+            sub_obligation["parent_requirement_semantic_id"] = parent_semantic_id
 
 
 def _split_structured_parts(item: str) -> list[str]:
@@ -2072,6 +2215,8 @@ def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
     _stamp_semantic_identity(functional_requirement_objects, change_source="round_4")
     _stamp_semantic_identity(non_functional_requirement_objects, change_source="round_2_or_4")
     _stamp_semantic_identity(all_requirement_objects, change_source="requirements")
+    _bind_requirement_sub_obligations(functional_requirement_objects)
+    _bind_requirement_sub_obligations(non_functional_requirement_objects)
     _stamp_semantic_identity(
         acceptance_constraint_objects,
         change_source="derived_acceptance_constraints",

--- a/src/rupify_tools/planning_export.py
+++ b/src/rupify_tools/planning_export.py
@@ -122,11 +122,30 @@ def _export_attributes(item: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _export_obligations(item: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return exported sub-obligation records for one canonical element."""
+    return [
+        {
+            "id": obligation.get("id", ""),
+            "title": obligation.get("title", ""),
+            "summary": obligation.get("summary", ""),
+            "acceptance": obligation.get("acceptance", ""),
+            "parent_requirement_id": obligation.get("parent_requirement_id", ""),
+            "parent_requirement_semantic_id": obligation.get(
+                "parent_requirement_semantic_id",
+                "",
+            ),
+        }
+        for obligation in item.get("sub_obligations", [])
+        if isinstance(obligation, dict)
+    ]
+
+
 def _export_element(item: dict[str, Any], family: str) -> dict[str, Any]:
     """Convert one canonical element into the planning export shape."""
     readiness = item.get("readiness", {})
     trace = item.get("trace", {})
-    return {
+    exported = {
         "id": item.get("id", ""),
         "semantic_id": item.get("semantic_id", item.get("id", "")),
         "family": family,
@@ -142,6 +161,10 @@ def _export_element(item: dict[str, Any], family: str) -> dict[str, Any]:
         "change_metadata": item.get("change_metadata", {}),
         "attributes": _export_attributes(item),
     }
+    obligations = _export_obligations(item)
+    if obligations:
+        exported["obligations"] = obligations
+    return exported
 
 
 def _export_trace_link(link: dict[str, Any], family: str) -> dict[str, Any]:

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -275,6 +275,58 @@ class DiscoveryTests(unittest.TestCase):
             ],
         )
 
+    def test_normalize_replay_to_model_derives_requirement_sub_obligations(self) -> None:
+        """Requirement objects should carry explicit sub-obligations for safe shared-prefix splits."""
+        replay = replay_session(
+            [
+                {
+                    "round": 4,
+                    "responses": [
+                        {
+                            "key": "workflow_scope",
+                            "answer": (
+                                "The system must allow operations managers to maintain reward catalog "
+                                "entries and campaign rules."
+                            ),
+                        },
+                        {
+                            "key": "non_functional_requirements",
+                            "answer": [
+                                "The platform must integrate with payment confirmation and downstream reporting sources."
+                            ],
+                        },
+                    ],
+                }
+            ]
+        )
+
+        model = normalize_replay_to_model(replay)
+
+        functional_sub_obligations = model["requirements"]["functional_objects"][0]["sub_obligations"]
+        self.assertEqual(
+            [item["title"] for item in functional_sub_obligations],
+            ["Maintain reward catalog entries", "Maintain campaign rules"],
+        )
+        self.assertEqual(
+            functional_sub_obligations[0]["parent_requirement_id"],
+            "functional-requirement-1",
+        )
+        self.assertIn(
+            "Operations managers can maintain reward catalog entries.",
+            functional_sub_obligations[0]["acceptance"],
+        )
+
+        non_functional_sub_obligations = model["requirements"]["non_functional_objects"][0][
+            "sub_obligations"
+        ]
+        self.assertEqual(
+            [item["title"] for item in non_functional_sub_obligations],
+            [
+                "Integrate with payment confirmation",
+                "Integrate with downstream reporting sources",
+            ],
+        )
+
     def test_normalize_replay_to_model_keeps_empty_sections_explicit(self) -> None:
         """Missing optional view rounds should still produce stable empty sections."""
         replay = replay_session(

--- a/tests/test_planning_export.py
+++ b/tests/test_planning_export.py
@@ -28,6 +28,16 @@ class PlanningExportTests(unittest.TestCase):
                     "id": "functional-requirement-1",
                     "semantic_id": "functional-requirement-1",
                     "statement": "Approve system changes",
+                    "sub_obligations": [
+                        {
+                            "id": "approve-system-changes",
+                            "title": "Approve system changes",
+                            "summary": "Approve system changes.",
+                            "acceptance": "System changes can be approved.",
+                            "parent_requirement_id": "functional-requirement-1",
+                            "parent_requirement_semantic_id": "functional-requirement-1",
+                        }
+                    ],
                     "content_semantics": "normative",
                     "readiness": {
                         "status": "ready",
@@ -230,6 +240,12 @@ class PlanningExportTests(unittest.TestCase):
         self.assertTrue(any(link["family"] == "ambiguity_to_element" for link in export["trace_links"]))
         self.assertTrue(any(item["family"] == "interaction_messages" for item in export["elements"]))
         self.assertEqual(
+            next(
+                item for item in export["elements"] if item["id"] == "functional-requirement-1"
+            )["obligations"][0]["id"],
+            "approve-system-changes",
+        )
+        self.assertEqual(
             next(item for item in export["elements"] if item["id"] == "acceptance-constraint-1")["attributes"]["linked_use_case_ids"],
             ["uc-redeem"],
         )
@@ -335,6 +351,22 @@ class PlanningExportTests(unittest.TestCase):
             if link.get("to_id") and link["to_id"] not in element_id_set:
                 unresolved.append(("to", link["id"], link["to_id"]))
         self.assertEqual(unresolved, [])
+        self.assertEqual(
+            next(
+                item
+                for item in payload["elements"]
+                if item["id"] == "functional-requirement-1"
+            )["obligations"][0]["id"],
+            "support-stage-gates",
+        )
+        self.assertEqual(
+            next(
+                item
+                for item in payload["elements"]
+                if item["id"] == "functional-requirement-1"
+            )["obligations"][1]["id"],
+            "support-approval-states",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #155

## Summary
- add conservative upstream requirement `sub_obligations` to canonical functional and non-functional requirement objects
- surface those normalized requirement obligations in the Speckify planning export as nested `obligations`
- regenerate the CMDB V2 and loyalty V2 publication bundles and export fixtures against the new contract

## Verification
- uv run python -m unittest tests.test_discovery tests.test_planning_export
- uv run python -m unittest
