### PR TITLE
Add use-case step sub-actions to Speckify export

### DIFF
--- a/docs/speckify-planning-export.md
+++ b/docs/speckify-planning-export.md
@@ -60,6 +60,20 @@ uv run rupify-export-planning \
       - `acceptance`
       - `parent_requirement_id`
       - `parent_requirement_semantic_id`
+    - optional `sub_actions` for use-case step elements where Rupify has explicit normalized
+      step sub-actions
+      - `id`
+      - `semantic_id`
+      - `title`
+      - `text`
+      - `subject`
+      - `verb`
+      - `target`
+      - `order_index`
+      - `parent_step_id`
+      - `parent_step_semantic_id`
+      - `parent_use_case_id`
+      - `derivation_basis`
 - `ready_normative_elements`
   - the ready subset of `elements` where `content_semantics == normative`
 - `blocking_ambiguities`
@@ -75,3 +89,5 @@ uv run rupify-export-planning \
 - `blocking_ambiguities` should be treated as explicit stop conditions, not hidden warnings.
 - `obligations` should be consumed only when present; Speckify should fail closed rather than
   inferring additional sub-obligations by splitting requirement prose downstream.
+- `sub_actions` should be consumed only when present; Speckify should fail closed rather than
+  inferring internal step decomposition from step prose downstream.

--- a/examples/it-systems-inventory-v2/exports/speckify-planning-export.json
+++ b/examples/it-systems-inventory-v2/exports/speckify-planning-export.json
@@ -974,7 +974,9 @@
       "text": "System Inventory API sends Reporting Consumers"
     },
     {
-      "attributes": {},
+      "attributes": {
+        "use_case_id": "register-a-system"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_interaction_view",
@@ -997,7 +999,9 @@
       "text": ""
     },
     {
-      "attributes": {},
+      "attributes": {
+        "use_case_id": "edit-metadata"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_interaction_view",
@@ -1020,7 +1024,9 @@
       "text": ""
     },
     {
-      "attributes": {},
+      "attributes": {
+        "use_case_id": "compare-overlapping-systems"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_interaction_view",
@@ -1043,7 +1049,9 @@
       "text": ""
     },
     {
-      "attributes": {},
+      "attributes": {
+        "use_case_id": "track-lifecycle-state"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_interaction_view",
@@ -1066,7 +1074,9 @@
       "text": ""
     },
     {
-      "attributes": {},
+      "attributes": {
+        "use_case_id": "review-risks"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_interaction_view",
@@ -1089,7 +1099,9 @@
       "text": ""
     },
     {
-      "attributes": {},
+      "attributes": {
+        "use_case_id": "see-costs"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_interaction_view",
@@ -1112,7 +1124,9 @@
       "text": ""
     },
     {
-      "attributes": {},
+      "attributes": {
+        "use_case_id": "approve-deprecation"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_interaction_view",
@@ -1135,7 +1149,9 @@
       "text": ""
     },
     {
-      "attributes": {},
+      "attributes": {
+        "use_case_id": "report-portfolio-gaps"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_interaction_view",

--- a/examples/loyalty-platform-v2/README.md
+++ b/examples/loyalty-platform-v2/README.md
@@ -52,7 +52,7 @@ This V2 export currently shows:
 - 0 blocking ambiguities
 - 0 duplicate exported element IDs
 - 0 unresolved trace references
-- explicit requirement obligations where the upstream requirement normalization can derive them safely
+- explicit requirement obligations and step sub-actions where the upstream normalization can derive them safely
 
 ## Notes
 

--- a/examples/loyalty-platform-v2/bundle-manifest.json
+++ b/examples/loyalty-platform-v2/bundle-manifest.json
@@ -15,7 +15,7 @@
       "change_source": "normalize_replay_to_model",
       "last_changed_at": "",
       "regenerated_from_version": "",
-      "semantic_hash": "9e539fa7e9653a18",
+      "semantic_hash": "a328534e3404a044",
       "semantic_version": 1,
       "supersedes": []
     },

--- a/examples/loyalty-platform-v2/exports/speckify-planning-export.json
+++ b/examples/loyalty-platform-v2/exports/speckify-planning-export.json
@@ -1048,7 +1048,9 @@
       "text": "Loyalty API sends Analytics Service"
     },
     {
-      "attributes": {},
+      "attributes": {
+        "use_case_id": "enroll-member"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_interaction_view",
@@ -1071,7 +1073,9 @@
       "text": ""
     },
     {
-      "attributes": {},
+      "attributes": {
+        "use_case_id": "browse-rewards"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_interaction_view",
@@ -1094,7 +1098,9 @@
       "text": ""
     },
     {
-      "attributes": {},
+      "attributes": {
+        "use_case_id": "redeem-reward"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_interaction_view",
@@ -1117,7 +1123,9 @@
       "text": ""
     },
     {
-      "attributes": {},
+      "attributes": {
+        "use_case_id": "manage-reward-catalog"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_interaction_view",
@@ -1140,7 +1148,9 @@
       "text": ""
     },
     {
-      "attributes": {},
+      "attributes": {
+        "use_case_id": "review-redemption-analytics"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_interaction_view",
@@ -1760,7 +1770,8 @@
           "System rejects the invalid change."
         ],
         "priority": "medium",
-        "status": "open"
+        "status": "open",
+        "use_case_id": "manage-reward-catalog"
       },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
@@ -1791,7 +1802,8 @@
           "System blocks fulfillment until confirmation arrives."
         ],
         "priority": "medium",
-        "status": "open"
+        "status": "open",
+        "use_case_id": "redeem-reward"
       },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
@@ -1822,7 +1834,8 @@
           "System shows a partial-data warning."
         ],
         "priority": "low",
-        "status": "open"
+        "status": "open",
+        "use_case_id": "review-redemption-analytics"
       },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
@@ -1853,7 +1866,8 @@
           "System reports that inventory is exhausted."
         ],
         "priority": "high",
-        "status": "open"
+        "status": "open",
+        "use_case_id": "redeem-reward"
       },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
@@ -2160,13 +2174,17 @@
       "text": "Catalog validation approval is required before a reward becomes Published"
     },
     {
-      "attributes": {},
+      "attributes": {
+        "step_index": 1,
+        "step_kind": "extension",
+        "use_case_id": "browse-rewards"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_use_case_steps",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "ef38d2cd32f6264d",
+        "semantic_hash": "a64a721dfd3d9559",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -2183,13 +2201,17 @@
       "text": "Catalog view degrades if an integration is temporarily unavailable."
     },
     {
-      "attributes": {},
+      "attributes": {
+        "step_index": 1,
+        "step_kind": "main_success",
+        "use_case_id": "browse-rewards"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_use_case_steps",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "895b68cbcc6073f9",
+        "semantic_hash": "35506d2c88b20ad8",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -2206,13 +2228,17 @@
       "text": "Customer opens the rewards catalog."
     },
     {
-      "attributes": {},
+      "attributes": {
+        "step_index": 2,
+        "step_kind": "main_success",
+        "use_case_id": "browse-rewards"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_use_case_steps",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "dd86222bb48004ab",
+        "semantic_hash": "fc7cc6be6c1b25d4",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -2226,16 +2252,50 @@
       "semantic_id": "browse-rewards-step-2",
       "source_key": "use_cases",
       "source_round": 3,
+      "sub_actions": [
+        {
+          "derivation_basis": "shared_verb_objects",
+          "id": "browse-rewards-step-2-action-1",
+          "order_index": 1,
+          "parent_step_id": "browse-rewards-step-2",
+          "parent_step_semantic_id": "browse-rewards-step-2",
+          "parent_use_case_id": "browse-rewards",
+          "semantic_id": "browse-rewards-step-2-action-display-available-rewards",
+          "subject": "System",
+          "target": "available rewards",
+          "text": "System displays available rewards.",
+          "title": "Display available rewards",
+          "verb": "display"
+        },
+        {
+          "derivation_basis": "shared_verb_objects",
+          "id": "browse-rewards-step-2-action-2",
+          "order_index": 2,
+          "parent_step_id": "browse-rewards-step-2",
+          "parent_step_semantic_id": "browse-rewards-step-2",
+          "parent_use_case_id": "browse-rewards",
+          "semantic_id": "browse-rewards-step-2-action-display-points-balance",
+          "subject": "System",
+          "target": "points balance",
+          "text": "System displays points balance.",
+          "title": "Display points balance",
+          "verb": "display"
+        }
+      ],
       "text": "System displays available rewards and points balance."
     },
     {
-      "attributes": {},
+      "attributes": {
+        "step_index": 3,
+        "step_kind": "main_success",
+        "use_case_id": "browse-rewards"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_use_case_steps",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "96b05cd90d750571",
+        "semantic_hash": "33a4ecdbf1d112e1",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -2252,13 +2312,17 @@
       "text": "Customer filters or sorts the catalog."
     },
     {
-      "attributes": {},
+      "attributes": {
+        "step_index": 1,
+        "step_kind": "extension",
+        "use_case_id": "enroll-member"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_use_case_steps",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "5084306fb28e98a8",
+        "semantic_hash": "40c58be845db580c",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -2275,13 +2339,17 @@
       "text": "Enrollment is blocked when required consent is missing."
     },
     {
-      "attributes": {},
+      "attributes": {
+        "step_index": 1,
+        "step_kind": "main_success",
+        "use_case_id": "enroll-member"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_use_case_steps",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "e7ec46c41fe9cf12",
+        "semantic_hash": "d777d2d2eebcf3c4",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -2298,13 +2366,17 @@
       "text": "Customer opens the loyalty enrollment flow."
     },
     {
-      "attributes": {},
+      "attributes": {
+        "step_index": 2,
+        "step_kind": "main_success",
+        "use_case_id": "enroll-member"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_use_case_steps",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "8c937b53f0ae3e91",
+        "semantic_hash": "6948548191377934",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -2321,13 +2393,17 @@
       "text": "Customer provides the required details and consents."
     },
     {
-      "attributes": {},
+      "attributes": {
+        "step_index": 3,
+        "step_kind": "main_success",
+        "use_case_id": "enroll-member"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_use_case_steps",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "13ee1230b8fb95f9",
+        "semantic_hash": "36343432b1f279ff",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -2341,16 +2417,50 @@
       "semantic_id": "enroll-member-step-3",
       "source_key": "use_cases",
       "source_round": 3,
+      "sub_actions": [
+        {
+          "derivation_basis": "parallel_clauses",
+          "id": "enroll-member-step-3-action-1",
+          "order_index": 1,
+          "parent_step_id": "enroll-member-step-3",
+          "parent_step_semantic_id": "enroll-member-step-3",
+          "parent_use_case_id": "enroll-member",
+          "semantic_id": "enroll-member-step-3-action-validate-the-submission",
+          "subject": "System",
+          "target": "the submission",
+          "text": "System validates the submission.",
+          "title": "Validate the submission",
+          "verb": "validate"
+        },
+        {
+          "derivation_basis": "parallel_clauses",
+          "id": "enroll-member-step-3-action-2",
+          "order_index": 2,
+          "parent_step_id": "enroll-member-step-3",
+          "parent_step_semantic_id": "enroll-member-step-3",
+          "parent_use_case_id": "enroll-member",
+          "semantic_id": "enroll-member-step-3-action-create-the-member-account",
+          "subject": "System",
+          "target": "the member account",
+          "text": "System creates the member account.",
+          "title": "Create the member account",
+          "verb": "create"
+        }
+      ],
       "text": "System validates the submission and creates the member account."
     },
     {
-      "attributes": {},
+      "attributes": {
+        "step_index": 1,
+        "step_kind": "extension",
+        "use_case_id": "manage-reward-catalog"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_use_case_steps",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "52b5017dbd2c3ecf",
+        "semantic_hash": "6f01814c294c0412",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -2367,13 +2477,17 @@
       "text": "A change is rejected because it would make an active reward invalid."
     },
     {
-      "attributes": {},
+      "attributes": {
+        "step_index": 1,
+        "step_kind": "main_success",
+        "use_case_id": "manage-reward-catalog"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_use_case_steps",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "3018683e51bb8375",
+        "semantic_hash": "0d8198473fba05c1",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -2390,13 +2504,17 @@
       "text": "Operations Manager opens catalog administration."
     },
     {
-      "attributes": {},
+      "attributes": {
+        "step_index": 2,
+        "step_kind": "main_success",
+        "use_case_id": "manage-reward-catalog"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_use_case_steps",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "0c9fe51d87cb9b58",
+        "semantic_hash": "75dd9fa8c72016df",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -2413,13 +2531,17 @@
       "text": "Operations Manager updates reward configuration."
     },
     {
-      "attributes": {},
+      "attributes": {
+        "step_index": 3,
+        "step_kind": "main_success",
+        "use_case_id": "manage-reward-catalog"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_use_case_steps",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "7dc4a38b3ca526b1",
+        "semantic_hash": "b107e93d234a6304",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -2433,16 +2555,50 @@
       "semantic_id": "manage-reward-catalog-step-3",
       "source_key": "use_cases",
       "source_round": 3,
+      "sub_actions": [
+        {
+          "derivation_basis": "parallel_verbs_shared_object",
+          "id": "manage-reward-catalog-step-3-action-1",
+          "order_index": 1,
+          "parent_step_id": "manage-reward-catalog-step-3",
+          "parent_step_semantic_id": "manage-reward-catalog-step-3",
+          "parent_use_case_id": "manage-reward-catalog",
+          "semantic_id": "manage-reward-catalog-step-3-action-validate-the-change",
+          "subject": "System",
+          "target": "the change",
+          "text": "System validates the change.",
+          "title": "Validate the change",
+          "verb": "validate"
+        },
+        {
+          "derivation_basis": "parallel_verbs_shared_object",
+          "id": "manage-reward-catalog-step-3-action-2",
+          "order_index": 2,
+          "parent_step_id": "manage-reward-catalog-step-3",
+          "parent_step_semantic_id": "manage-reward-catalog-step-3",
+          "parent_use_case_id": "manage-reward-catalog",
+          "semantic_id": "manage-reward-catalog-step-3-action-publish-the-change",
+          "subject": "System",
+          "target": "the change",
+          "text": "System publishs the change.",
+          "title": "Publish the change",
+          "verb": "publish"
+        }
+      ],
       "text": "System validates and publishes the change."
     },
     {
-      "attributes": {},
+      "attributes": {
+        "step_index": 1,
+        "step_kind": "extension",
+        "use_case_id": "redeem-reward"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_use_case_steps",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "187482a4d085efc5",
+        "semantic_hash": "e8fcf8d9d1a03a9a",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -2459,13 +2615,17 @@
       "text": "Reward inventory is exhausted before completion."
     },
     {
-      "attributes": {},
+      "attributes": {
+        "step_index": 2,
+        "step_kind": "extension",
+        "use_case_id": "redeem-reward"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_use_case_steps",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "00dfc60e4b370401",
+        "semantic_hash": "d3abee3553d806ea",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -2482,13 +2642,17 @@
       "text": "Customer does not have enough points."
     },
     {
-      "attributes": {},
+      "attributes": {
+        "step_index": 3,
+        "step_kind": "extension",
+        "use_case_id": "redeem-reward"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_use_case_steps",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "f97975616da77c4d",
+        "semantic_hash": "f22e363153165e86",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -2505,13 +2669,17 @@
       "text": "Payment confirmation is missing for a reward that depends on purchase completion."
     },
     {
-      "attributes": {},
+      "attributes": {
+        "step_index": 1,
+        "step_kind": "main_success",
+        "use_case_id": "redeem-reward"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_use_case_steps",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "dcf9844b30ea0150",
+        "semantic_hash": "2a23778723871b40",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -2528,13 +2696,17 @@
       "text": "Customer selects a reward."
     },
     {
-      "attributes": {},
+      "attributes": {
+        "step_index": 2,
+        "step_kind": "main_success",
+        "use_case_id": "redeem-reward"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_use_case_steps",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "c92276c94c67212a",
+        "semantic_hash": "15ddca0181cab92d",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -2548,16 +2720,50 @@
       "semantic_id": "redeem-reward-step-2",
       "source_key": "use_cases",
       "source_round": 3,
+      "sub_actions": [
+        {
+          "derivation_basis": "shared_verb_objects",
+          "id": "redeem-reward-step-2-action-1",
+          "order_index": 1,
+          "parent_step_id": "redeem-reward-step-2",
+          "parent_step_semantic_id": "redeem-reward-step-2",
+          "parent_use_case_id": "redeem-reward",
+          "semantic_id": "redeem-reward-step-2-action-validate-reward-eligibility",
+          "subject": "System",
+          "target": "reward eligibility",
+          "text": "System validates reward eligibility.",
+          "title": "Validate reward eligibility",
+          "verb": "validate"
+        },
+        {
+          "derivation_basis": "shared_verb_objects",
+          "id": "redeem-reward-step-2-action-2",
+          "order_index": 2,
+          "parent_step_id": "redeem-reward-step-2",
+          "parent_step_semantic_id": "redeem-reward-step-2",
+          "parent_use_case_id": "redeem-reward",
+          "semantic_id": "redeem-reward-step-2-action-validate-available-points",
+          "subject": "System",
+          "target": "available points",
+          "text": "System validates available points.",
+          "title": "Validate available points",
+          "verb": "validate"
+        }
+      ],
       "text": "System validates reward eligibility and available points."
     },
     {
-      "attributes": {},
+      "attributes": {
+        "step_index": 3,
+        "step_kind": "main_success",
+        "use_case_id": "redeem-reward"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_use_case_steps",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "1c4797621e3c0bc5",
+        "semantic_hash": "b28d32a5bf833137",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -2571,16 +2777,50 @@
       "semantic_id": "redeem-reward-step-3",
       "source_key": "use_cases",
       "source_round": 3,
+      "sub_actions": [
+        {
+          "derivation_basis": "parallel_clauses",
+          "id": "redeem-reward-step-3-action-1",
+          "order_index": 1,
+          "parent_step_id": "redeem-reward-step-3",
+          "parent_step_semantic_id": "redeem-reward-step-3",
+          "parent_use_case_id": "redeem-reward",
+          "semantic_id": "redeem-reward-step-3-action-reserve-the-reward",
+          "subject": "System",
+          "target": "the reward",
+          "text": "System reserves the reward.",
+          "title": "Reserve the reward",
+          "verb": "reserve"
+        },
+        {
+          "derivation_basis": "parallel_clauses",
+          "id": "redeem-reward-step-3-action-2",
+          "order_index": 2,
+          "parent_step_id": "redeem-reward-step-3",
+          "parent_step_semantic_id": "redeem-reward-step-3",
+          "parent_use_case_id": "redeem-reward",
+          "semantic_id": "redeem-reward-step-3-action-update-the-member-balance",
+          "subject": "System",
+          "target": "the member balance",
+          "text": "System updates the member balance.",
+          "title": "Update the member balance",
+          "verb": "update"
+        }
+      ],
       "text": "System reserves the reward and updates the member balance."
     },
     {
-      "attributes": {},
+      "attributes": {
+        "step_index": 4,
+        "step_kind": "main_success",
+        "use_case_id": "redeem-reward"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_use_case_steps",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "6b2b2b1e56451842",
+        "semantic_hash": "75fb909d9ef2c03b",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -2597,13 +2837,17 @@
       "text": "System confirms redemption to the customer."
     },
     {
-      "attributes": {},
+      "attributes": {
+        "step_index": 1,
+        "step_kind": "extension",
+        "use_case_id": "review-redemption-analytics"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_use_case_steps",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "32969fc50ee511ae",
+        "semantic_hash": "cab589e89387ed09",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -2620,13 +2864,17 @@
       "text": "A reporting data source is delayed."
     },
     {
-      "attributes": {},
+      "attributes": {
+        "step_index": 1,
+        "step_kind": "main_success",
+        "use_case_id": "review-redemption-analytics"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_use_case_steps",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "2ad74b487836732e",
+        "semantic_hash": "e4085e0a89ebbab5",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -2643,13 +2891,17 @@
       "text": "Operations Manager opens the analytics dashboard."
     },
     {
-      "attributes": {},
+      "attributes": {
+        "step_index": 2,
+        "step_kind": "main_success",
+        "use_case_id": "review-redemption-analytics"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_use_case_steps",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "c20a2d3b710b92b7",
+        "semantic_hash": "d8a64be2b9c07162",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -2663,6 +2915,36 @@
       "semantic_id": "review-redemption-analytics-step-2",
       "source_key": "use_cases",
       "source_round": 3,
+      "sub_actions": [
+        {
+          "derivation_basis": "shared_verb_objects",
+          "id": "review-redemption-analytics-step-2-action-1",
+          "order_index": 1,
+          "parent_step_id": "review-redemption-analytics-step-2",
+          "parent_step_semantic_id": "review-redemption-analytics-step-2",
+          "parent_use_case_id": "review-redemption-analytics",
+          "semantic_id": "review-redemption-analytics-step-2-action-show-redemption",
+          "subject": "System",
+          "target": "redemption",
+          "text": "System shows redemption.",
+          "title": "Show redemption",
+          "verb": "show"
+        },
+        {
+          "derivation_basis": "shared_verb_objects",
+          "id": "review-redemption-analytics-step-2-action-2",
+          "order_index": 2,
+          "parent_step_id": "review-redemption-analytics-step-2",
+          "parent_step_semantic_id": "review-redemption-analytics-step-2",
+          "parent_use_case_id": "review-redemption-analytics",
+          "semantic_id": "review-redemption-analytics-step-2-action-show-campaign-metrics",
+          "subject": "System",
+          "target": "campaign metrics",
+          "text": "System shows campaign metrics.",
+          "title": "Show campaign metrics",
+          "verb": "show"
+        }
+      ],
       "text": "System shows redemption and campaign metrics."
     },
     {
@@ -2891,7 +3173,7 @@
       "change_source": "normalize_replay_to_model",
       "last_changed_at": "",
       "regenerated_from_version": "",
-      "semantic_hash": "9e539fa7e9653a18",
+      "semantic_hash": "a328534e3404a044",
       "semantic_version": 1,
       "supersedes": []
     },
@@ -3624,7 +3906,8 @@
           "System rejects the invalid change."
         ],
         "priority": "medium",
-        "status": "open"
+        "status": "open",
+        "use_case_id": "manage-reward-catalog"
       },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
@@ -3655,7 +3938,8 @@
           "System blocks fulfillment until confirmation arrives."
         ],
         "priority": "medium",
-        "status": "open"
+        "status": "open",
+        "use_case_id": "redeem-reward"
       },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
@@ -3686,7 +3970,8 @@
           "System shows a partial-data warning."
         ],
         "priority": "low",
-        "status": "open"
+        "status": "open",
+        "use_case_id": "review-redemption-analytics"
       },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
@@ -3717,7 +4002,8 @@
           "System reports that inventory is exhausted."
         ],
         "priority": "high",
-        "status": "open"
+        "status": "open",
+        "use_case_id": "redeem-reward"
       },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
@@ -3932,13 +4218,17 @@
       "text": "Reward Catalog Entry: Draft -> Published -> Retired"
     },
     {
-      "attributes": {},
+      "attributes": {
+        "step_index": 1,
+        "step_kind": "extension",
+        "use_case_id": "browse-rewards"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_use_case_steps",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "ef38d2cd32f6264d",
+        "semantic_hash": "a64a721dfd3d9559",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -3955,13 +4245,17 @@
       "text": "Catalog view degrades if an integration is temporarily unavailable."
     },
     {
-      "attributes": {},
+      "attributes": {
+        "step_index": 1,
+        "step_kind": "main_success",
+        "use_case_id": "browse-rewards"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_use_case_steps",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "895b68cbcc6073f9",
+        "semantic_hash": "35506d2c88b20ad8",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -3978,13 +4272,17 @@
       "text": "Customer opens the rewards catalog."
     },
     {
-      "attributes": {},
+      "attributes": {
+        "step_index": 2,
+        "step_kind": "main_success",
+        "use_case_id": "browse-rewards"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_use_case_steps",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "dd86222bb48004ab",
+        "semantic_hash": "fc7cc6be6c1b25d4",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -3998,16 +4296,50 @@
       "semantic_id": "browse-rewards-step-2",
       "source_key": "use_cases",
       "source_round": 3,
+      "sub_actions": [
+        {
+          "derivation_basis": "shared_verb_objects",
+          "id": "browse-rewards-step-2-action-1",
+          "order_index": 1,
+          "parent_step_id": "browse-rewards-step-2",
+          "parent_step_semantic_id": "browse-rewards-step-2",
+          "parent_use_case_id": "browse-rewards",
+          "semantic_id": "browse-rewards-step-2-action-display-available-rewards",
+          "subject": "System",
+          "target": "available rewards",
+          "text": "System displays available rewards.",
+          "title": "Display available rewards",
+          "verb": "display"
+        },
+        {
+          "derivation_basis": "shared_verb_objects",
+          "id": "browse-rewards-step-2-action-2",
+          "order_index": 2,
+          "parent_step_id": "browse-rewards-step-2",
+          "parent_step_semantic_id": "browse-rewards-step-2",
+          "parent_use_case_id": "browse-rewards",
+          "semantic_id": "browse-rewards-step-2-action-display-points-balance",
+          "subject": "System",
+          "target": "points balance",
+          "text": "System displays points balance.",
+          "title": "Display points balance",
+          "verb": "display"
+        }
+      ],
       "text": "System displays available rewards and points balance."
     },
     {
-      "attributes": {},
+      "attributes": {
+        "step_index": 3,
+        "step_kind": "main_success",
+        "use_case_id": "browse-rewards"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_use_case_steps",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "96b05cd90d750571",
+        "semantic_hash": "33a4ecdbf1d112e1",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -4024,13 +4356,17 @@
       "text": "Customer filters or sorts the catalog."
     },
     {
-      "attributes": {},
+      "attributes": {
+        "step_index": 1,
+        "step_kind": "extension",
+        "use_case_id": "enroll-member"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_use_case_steps",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "5084306fb28e98a8",
+        "semantic_hash": "40c58be845db580c",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -4047,13 +4383,17 @@
       "text": "Enrollment is blocked when required consent is missing."
     },
     {
-      "attributes": {},
+      "attributes": {
+        "step_index": 1,
+        "step_kind": "main_success",
+        "use_case_id": "enroll-member"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_use_case_steps",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "e7ec46c41fe9cf12",
+        "semantic_hash": "d777d2d2eebcf3c4",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -4070,13 +4410,17 @@
       "text": "Customer opens the loyalty enrollment flow."
     },
     {
-      "attributes": {},
+      "attributes": {
+        "step_index": 2,
+        "step_kind": "main_success",
+        "use_case_id": "enroll-member"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_use_case_steps",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "8c937b53f0ae3e91",
+        "semantic_hash": "6948548191377934",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -4093,13 +4437,17 @@
       "text": "Customer provides the required details and consents."
     },
     {
-      "attributes": {},
+      "attributes": {
+        "step_index": 3,
+        "step_kind": "main_success",
+        "use_case_id": "enroll-member"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_use_case_steps",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "13ee1230b8fb95f9",
+        "semantic_hash": "36343432b1f279ff",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -4113,16 +4461,50 @@
       "semantic_id": "enroll-member-step-3",
       "source_key": "use_cases",
       "source_round": 3,
+      "sub_actions": [
+        {
+          "derivation_basis": "parallel_clauses",
+          "id": "enroll-member-step-3-action-1",
+          "order_index": 1,
+          "parent_step_id": "enroll-member-step-3",
+          "parent_step_semantic_id": "enroll-member-step-3",
+          "parent_use_case_id": "enroll-member",
+          "semantic_id": "enroll-member-step-3-action-validate-the-submission",
+          "subject": "System",
+          "target": "the submission",
+          "text": "System validates the submission.",
+          "title": "Validate the submission",
+          "verb": "validate"
+        },
+        {
+          "derivation_basis": "parallel_clauses",
+          "id": "enroll-member-step-3-action-2",
+          "order_index": 2,
+          "parent_step_id": "enroll-member-step-3",
+          "parent_step_semantic_id": "enroll-member-step-3",
+          "parent_use_case_id": "enroll-member",
+          "semantic_id": "enroll-member-step-3-action-create-the-member-account",
+          "subject": "System",
+          "target": "the member account",
+          "text": "System creates the member account.",
+          "title": "Create the member account",
+          "verb": "create"
+        }
+      ],
       "text": "System validates the submission and creates the member account."
     },
     {
-      "attributes": {},
+      "attributes": {
+        "step_index": 1,
+        "step_kind": "extension",
+        "use_case_id": "manage-reward-catalog"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_use_case_steps",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "52b5017dbd2c3ecf",
+        "semantic_hash": "6f01814c294c0412",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -4139,13 +4521,17 @@
       "text": "A change is rejected because it would make an active reward invalid."
     },
     {
-      "attributes": {},
+      "attributes": {
+        "step_index": 1,
+        "step_kind": "main_success",
+        "use_case_id": "manage-reward-catalog"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_use_case_steps",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "3018683e51bb8375",
+        "semantic_hash": "0d8198473fba05c1",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -4162,13 +4548,17 @@
       "text": "Operations Manager opens catalog administration."
     },
     {
-      "attributes": {},
+      "attributes": {
+        "step_index": 2,
+        "step_kind": "main_success",
+        "use_case_id": "manage-reward-catalog"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_use_case_steps",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "0c9fe51d87cb9b58",
+        "semantic_hash": "75dd9fa8c72016df",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -4185,13 +4575,17 @@
       "text": "Operations Manager updates reward configuration."
     },
     {
-      "attributes": {},
+      "attributes": {
+        "step_index": 3,
+        "step_kind": "main_success",
+        "use_case_id": "manage-reward-catalog"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_use_case_steps",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "7dc4a38b3ca526b1",
+        "semantic_hash": "b107e93d234a6304",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -4205,16 +4599,50 @@
       "semantic_id": "manage-reward-catalog-step-3",
       "source_key": "use_cases",
       "source_round": 3,
+      "sub_actions": [
+        {
+          "derivation_basis": "parallel_verbs_shared_object",
+          "id": "manage-reward-catalog-step-3-action-1",
+          "order_index": 1,
+          "parent_step_id": "manage-reward-catalog-step-3",
+          "parent_step_semantic_id": "manage-reward-catalog-step-3",
+          "parent_use_case_id": "manage-reward-catalog",
+          "semantic_id": "manage-reward-catalog-step-3-action-validate-the-change",
+          "subject": "System",
+          "target": "the change",
+          "text": "System validates the change.",
+          "title": "Validate the change",
+          "verb": "validate"
+        },
+        {
+          "derivation_basis": "parallel_verbs_shared_object",
+          "id": "manage-reward-catalog-step-3-action-2",
+          "order_index": 2,
+          "parent_step_id": "manage-reward-catalog-step-3",
+          "parent_step_semantic_id": "manage-reward-catalog-step-3",
+          "parent_use_case_id": "manage-reward-catalog",
+          "semantic_id": "manage-reward-catalog-step-3-action-publish-the-change",
+          "subject": "System",
+          "target": "the change",
+          "text": "System publishs the change.",
+          "title": "Publish the change",
+          "verb": "publish"
+        }
+      ],
       "text": "System validates and publishes the change."
     },
     {
-      "attributes": {},
+      "attributes": {
+        "step_index": 1,
+        "step_kind": "extension",
+        "use_case_id": "redeem-reward"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_use_case_steps",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "187482a4d085efc5",
+        "semantic_hash": "e8fcf8d9d1a03a9a",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -4231,13 +4659,17 @@
       "text": "Reward inventory is exhausted before completion."
     },
     {
-      "attributes": {},
+      "attributes": {
+        "step_index": 2,
+        "step_kind": "extension",
+        "use_case_id": "redeem-reward"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_use_case_steps",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "00dfc60e4b370401",
+        "semantic_hash": "d3abee3553d806ea",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -4254,13 +4686,17 @@
       "text": "Customer does not have enough points."
     },
     {
-      "attributes": {},
+      "attributes": {
+        "step_index": 3,
+        "step_kind": "extension",
+        "use_case_id": "redeem-reward"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_use_case_steps",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "f97975616da77c4d",
+        "semantic_hash": "f22e363153165e86",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -4277,13 +4713,17 @@
       "text": "Payment confirmation is missing for a reward that depends on purchase completion."
     },
     {
-      "attributes": {},
+      "attributes": {
+        "step_index": 1,
+        "step_kind": "main_success",
+        "use_case_id": "redeem-reward"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_use_case_steps",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "dcf9844b30ea0150",
+        "semantic_hash": "2a23778723871b40",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -4300,13 +4740,17 @@
       "text": "Customer selects a reward."
     },
     {
-      "attributes": {},
+      "attributes": {
+        "step_index": 2,
+        "step_kind": "main_success",
+        "use_case_id": "redeem-reward"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_use_case_steps",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "c92276c94c67212a",
+        "semantic_hash": "15ddca0181cab92d",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -4320,16 +4764,50 @@
       "semantic_id": "redeem-reward-step-2",
       "source_key": "use_cases",
       "source_round": 3,
+      "sub_actions": [
+        {
+          "derivation_basis": "shared_verb_objects",
+          "id": "redeem-reward-step-2-action-1",
+          "order_index": 1,
+          "parent_step_id": "redeem-reward-step-2",
+          "parent_step_semantic_id": "redeem-reward-step-2",
+          "parent_use_case_id": "redeem-reward",
+          "semantic_id": "redeem-reward-step-2-action-validate-reward-eligibility",
+          "subject": "System",
+          "target": "reward eligibility",
+          "text": "System validates reward eligibility.",
+          "title": "Validate reward eligibility",
+          "verb": "validate"
+        },
+        {
+          "derivation_basis": "shared_verb_objects",
+          "id": "redeem-reward-step-2-action-2",
+          "order_index": 2,
+          "parent_step_id": "redeem-reward-step-2",
+          "parent_step_semantic_id": "redeem-reward-step-2",
+          "parent_use_case_id": "redeem-reward",
+          "semantic_id": "redeem-reward-step-2-action-validate-available-points",
+          "subject": "System",
+          "target": "available points",
+          "text": "System validates available points.",
+          "title": "Validate available points",
+          "verb": "validate"
+        }
+      ],
       "text": "System validates reward eligibility and available points."
     },
     {
-      "attributes": {},
+      "attributes": {
+        "step_index": 3,
+        "step_kind": "main_success",
+        "use_case_id": "redeem-reward"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_use_case_steps",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "1c4797621e3c0bc5",
+        "semantic_hash": "b28d32a5bf833137",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -4343,16 +4821,50 @@
       "semantic_id": "redeem-reward-step-3",
       "source_key": "use_cases",
       "source_round": 3,
+      "sub_actions": [
+        {
+          "derivation_basis": "parallel_clauses",
+          "id": "redeem-reward-step-3-action-1",
+          "order_index": 1,
+          "parent_step_id": "redeem-reward-step-3",
+          "parent_step_semantic_id": "redeem-reward-step-3",
+          "parent_use_case_id": "redeem-reward",
+          "semantic_id": "redeem-reward-step-3-action-reserve-the-reward",
+          "subject": "System",
+          "target": "the reward",
+          "text": "System reserves the reward.",
+          "title": "Reserve the reward",
+          "verb": "reserve"
+        },
+        {
+          "derivation_basis": "parallel_clauses",
+          "id": "redeem-reward-step-3-action-2",
+          "order_index": 2,
+          "parent_step_id": "redeem-reward-step-3",
+          "parent_step_semantic_id": "redeem-reward-step-3",
+          "parent_use_case_id": "redeem-reward",
+          "semantic_id": "redeem-reward-step-3-action-update-the-member-balance",
+          "subject": "System",
+          "target": "the member balance",
+          "text": "System updates the member balance.",
+          "title": "Update the member balance",
+          "verb": "update"
+        }
+      ],
       "text": "System reserves the reward and updates the member balance."
     },
     {
-      "attributes": {},
+      "attributes": {
+        "step_index": 4,
+        "step_kind": "main_success",
+        "use_case_id": "redeem-reward"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_use_case_steps",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "6b2b2b1e56451842",
+        "semantic_hash": "75fb909d9ef2c03b",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -4369,13 +4881,17 @@
       "text": "System confirms redemption to the customer."
     },
     {
-      "attributes": {},
+      "attributes": {
+        "step_index": 1,
+        "step_kind": "extension",
+        "use_case_id": "review-redemption-analytics"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_use_case_steps",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "32969fc50ee511ae",
+        "semantic_hash": "cab589e89387ed09",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -4392,13 +4908,17 @@
       "text": "A reporting data source is delayed."
     },
     {
-      "attributes": {},
+      "attributes": {
+        "step_index": 1,
+        "step_kind": "main_success",
+        "use_case_id": "review-redemption-analytics"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_use_case_steps",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "2ad74b487836732e",
+        "semantic_hash": "e4085e0a89ebbab5",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -4415,13 +4935,17 @@
       "text": "Operations Manager opens the analytics dashboard."
     },
     {
-      "attributes": {},
+      "attributes": {
+        "step_index": 2,
+        "step_kind": "main_success",
+        "use_case_id": "review-redemption-analytics"
+      },
       "blocking_ambiguity_ids": [],
       "change_metadata": {
         "change_source": "derived_use_case_steps",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "c20a2d3b710b92b7",
+        "semantic_hash": "d8a64be2b9c07162",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -4435,6 +4959,36 @@
       "semantic_id": "review-redemption-analytics-step-2",
       "source_key": "use_cases",
       "source_round": 3,
+      "sub_actions": [
+        {
+          "derivation_basis": "shared_verb_objects",
+          "id": "review-redemption-analytics-step-2-action-1",
+          "order_index": 1,
+          "parent_step_id": "review-redemption-analytics-step-2",
+          "parent_step_semantic_id": "review-redemption-analytics-step-2",
+          "parent_use_case_id": "review-redemption-analytics",
+          "semantic_id": "review-redemption-analytics-step-2-action-show-redemption",
+          "subject": "System",
+          "target": "redemption",
+          "text": "System shows redemption.",
+          "title": "Show redemption",
+          "verb": "show"
+        },
+        {
+          "derivation_basis": "shared_verb_objects",
+          "id": "review-redemption-analytics-step-2-action-2",
+          "order_index": 2,
+          "parent_step_id": "review-redemption-analytics-step-2",
+          "parent_step_semantic_id": "review-redemption-analytics-step-2",
+          "parent_use_case_id": "review-redemption-analytics",
+          "semantic_id": "review-redemption-analytics-step-2-action-show-campaign-metrics",
+          "subject": "System",
+          "target": "campaign metrics",
+          "text": "System shows campaign metrics.",
+          "title": "Show campaign metrics",
+          "verb": "show"
+        }
+      ],
       "text": "System shows redemption and campaign metrics."
     },
     {

--- a/examples/loyalty-platform-v2/model/rupify-model.json
+++ b/examples/loyalty-platform-v2/model/rupify-model.json
@@ -2207,7 +2207,7 @@
           "change_source": "derived_use_case_steps",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "e7ec46c41fe9cf12",
+          "semantic_hash": "d777d2d2eebcf3c4",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -2226,6 +2226,7 @@
         "semantic_id": "enroll-member-step-1",
         "step_index": 1,
         "step_kind": "main_success",
+        "sub_actions": [],
         "text": "Customer opens the loyalty enrollment flow.",
         "trace": {
           "source_key": "use_cases",
@@ -2239,7 +2240,7 @@
           "change_source": "derived_use_case_steps",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "8c937b53f0ae3e91",
+          "semantic_hash": "6948548191377934",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -2258,6 +2259,7 @@
         "semantic_id": "enroll-member-step-2",
         "step_index": 2,
         "step_kind": "main_success",
+        "sub_actions": [],
         "text": "Customer provides the required details and consents.",
         "trace": {
           "source_key": "use_cases",
@@ -2271,7 +2273,7 @@
           "change_source": "derived_use_case_steps",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "13ee1230b8fb95f9",
+          "semantic_hash": "36343432b1f279ff",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -2290,6 +2292,36 @@
         "semantic_id": "enroll-member-step-3",
         "step_index": 3,
         "step_kind": "main_success",
+        "sub_actions": [
+          {
+            "derivation_basis": "parallel_clauses",
+            "id": "enroll-member-step-3-action-1",
+            "order_index": 1,
+            "parent_step_id": "enroll-member-step-3",
+            "parent_step_semantic_id": "enroll-member-step-3",
+            "parent_use_case_id": "enroll-member",
+            "semantic_id": "enroll-member-step-3-action-validate-the-submission",
+            "subject": "System",
+            "target": "the submission",
+            "text": "System validates the submission.",
+            "title": "Validate the submission",
+            "verb": "validate"
+          },
+          {
+            "derivation_basis": "parallel_clauses",
+            "id": "enroll-member-step-3-action-2",
+            "order_index": 2,
+            "parent_step_id": "enroll-member-step-3",
+            "parent_step_semantic_id": "enroll-member-step-3",
+            "parent_use_case_id": "enroll-member",
+            "semantic_id": "enroll-member-step-3-action-create-the-member-account",
+            "subject": "System",
+            "target": "the member account",
+            "text": "System creates the member account.",
+            "title": "Create the member account",
+            "verb": "create"
+          }
+        ],
         "text": "System validates the submission and creates the member account.",
         "trace": {
           "source_key": "use_cases",
@@ -2303,7 +2335,7 @@
           "change_source": "derived_use_case_steps",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "5084306fb28e98a8",
+          "semantic_hash": "40c58be845db580c",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -2322,6 +2354,7 @@
         "semantic_id": "enroll-member-extension-1",
         "step_index": 1,
         "step_kind": "extension",
+        "sub_actions": [],
         "text": "Enrollment is blocked when required consent is missing.",
         "trace": {
           "source_key": "use_cases",
@@ -2335,7 +2368,7 @@
           "change_source": "derived_use_case_steps",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "895b68cbcc6073f9",
+          "semantic_hash": "35506d2c88b20ad8",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -2354,6 +2387,7 @@
         "semantic_id": "browse-rewards-step-1",
         "step_index": 1,
         "step_kind": "main_success",
+        "sub_actions": [],
         "text": "Customer opens the rewards catalog.",
         "trace": {
           "source_key": "use_cases",
@@ -2367,7 +2401,7 @@
           "change_source": "derived_use_case_steps",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "dd86222bb48004ab",
+          "semantic_hash": "fc7cc6be6c1b25d4",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -2386,6 +2420,36 @@
         "semantic_id": "browse-rewards-step-2",
         "step_index": 2,
         "step_kind": "main_success",
+        "sub_actions": [
+          {
+            "derivation_basis": "shared_verb_objects",
+            "id": "browse-rewards-step-2-action-1",
+            "order_index": 1,
+            "parent_step_id": "browse-rewards-step-2",
+            "parent_step_semantic_id": "browse-rewards-step-2",
+            "parent_use_case_id": "browse-rewards",
+            "semantic_id": "browse-rewards-step-2-action-display-available-rewards",
+            "subject": "System",
+            "target": "available rewards",
+            "text": "System displays available rewards.",
+            "title": "Display available rewards",
+            "verb": "display"
+          },
+          {
+            "derivation_basis": "shared_verb_objects",
+            "id": "browse-rewards-step-2-action-2",
+            "order_index": 2,
+            "parent_step_id": "browse-rewards-step-2",
+            "parent_step_semantic_id": "browse-rewards-step-2",
+            "parent_use_case_id": "browse-rewards",
+            "semantic_id": "browse-rewards-step-2-action-display-points-balance",
+            "subject": "System",
+            "target": "points balance",
+            "text": "System displays points balance.",
+            "title": "Display points balance",
+            "verb": "display"
+          }
+        ],
         "text": "System displays available rewards and points balance.",
         "trace": {
           "source_key": "use_cases",
@@ -2399,7 +2463,7 @@
           "change_source": "derived_use_case_steps",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "96b05cd90d750571",
+          "semantic_hash": "33a4ecdbf1d112e1",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -2418,6 +2482,7 @@
         "semantic_id": "browse-rewards-step-3",
         "step_index": 3,
         "step_kind": "main_success",
+        "sub_actions": [],
         "text": "Customer filters or sorts the catalog.",
         "trace": {
           "source_key": "use_cases",
@@ -2431,7 +2496,7 @@
           "change_source": "derived_use_case_steps",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "ef38d2cd32f6264d",
+          "semantic_hash": "a64a721dfd3d9559",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -2450,6 +2515,7 @@
         "semantic_id": "browse-rewards-extension-1",
         "step_index": 1,
         "step_kind": "extension",
+        "sub_actions": [],
         "text": "Catalog view degrades if an integration is temporarily unavailable.",
         "trace": {
           "source_key": "use_cases",
@@ -2463,7 +2529,7 @@
           "change_source": "derived_use_case_steps",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "dcf9844b30ea0150",
+          "semantic_hash": "2a23778723871b40",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -2482,6 +2548,7 @@
         "semantic_id": "redeem-reward-step-1",
         "step_index": 1,
         "step_kind": "main_success",
+        "sub_actions": [],
         "text": "Customer selects a reward.",
         "trace": {
           "source_key": "use_cases",
@@ -2495,7 +2562,7 @@
           "change_source": "derived_use_case_steps",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "c92276c94c67212a",
+          "semantic_hash": "15ddca0181cab92d",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -2514,6 +2581,36 @@
         "semantic_id": "redeem-reward-step-2",
         "step_index": 2,
         "step_kind": "main_success",
+        "sub_actions": [
+          {
+            "derivation_basis": "shared_verb_objects",
+            "id": "redeem-reward-step-2-action-1",
+            "order_index": 1,
+            "parent_step_id": "redeem-reward-step-2",
+            "parent_step_semantic_id": "redeem-reward-step-2",
+            "parent_use_case_id": "redeem-reward",
+            "semantic_id": "redeem-reward-step-2-action-validate-reward-eligibility",
+            "subject": "System",
+            "target": "reward eligibility",
+            "text": "System validates reward eligibility.",
+            "title": "Validate reward eligibility",
+            "verb": "validate"
+          },
+          {
+            "derivation_basis": "shared_verb_objects",
+            "id": "redeem-reward-step-2-action-2",
+            "order_index": 2,
+            "parent_step_id": "redeem-reward-step-2",
+            "parent_step_semantic_id": "redeem-reward-step-2",
+            "parent_use_case_id": "redeem-reward",
+            "semantic_id": "redeem-reward-step-2-action-validate-available-points",
+            "subject": "System",
+            "target": "available points",
+            "text": "System validates available points.",
+            "title": "Validate available points",
+            "verb": "validate"
+          }
+        ],
         "text": "System validates reward eligibility and available points.",
         "trace": {
           "source_key": "use_cases",
@@ -2527,7 +2624,7 @@
           "change_source": "derived_use_case_steps",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "1c4797621e3c0bc5",
+          "semantic_hash": "b28d32a5bf833137",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -2546,6 +2643,36 @@
         "semantic_id": "redeem-reward-step-3",
         "step_index": 3,
         "step_kind": "main_success",
+        "sub_actions": [
+          {
+            "derivation_basis": "parallel_clauses",
+            "id": "redeem-reward-step-3-action-1",
+            "order_index": 1,
+            "parent_step_id": "redeem-reward-step-3",
+            "parent_step_semantic_id": "redeem-reward-step-3",
+            "parent_use_case_id": "redeem-reward",
+            "semantic_id": "redeem-reward-step-3-action-reserve-the-reward",
+            "subject": "System",
+            "target": "the reward",
+            "text": "System reserves the reward.",
+            "title": "Reserve the reward",
+            "verb": "reserve"
+          },
+          {
+            "derivation_basis": "parallel_clauses",
+            "id": "redeem-reward-step-3-action-2",
+            "order_index": 2,
+            "parent_step_id": "redeem-reward-step-3",
+            "parent_step_semantic_id": "redeem-reward-step-3",
+            "parent_use_case_id": "redeem-reward",
+            "semantic_id": "redeem-reward-step-3-action-update-the-member-balance",
+            "subject": "System",
+            "target": "the member balance",
+            "text": "System updates the member balance.",
+            "title": "Update the member balance",
+            "verb": "update"
+          }
+        ],
         "text": "System reserves the reward and updates the member balance.",
         "trace": {
           "source_key": "use_cases",
@@ -2559,7 +2686,7 @@
           "change_source": "derived_use_case_steps",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "6b2b2b1e56451842",
+          "semantic_hash": "75fb909d9ef2c03b",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -2578,6 +2705,7 @@
         "semantic_id": "redeem-reward-step-4",
         "step_index": 4,
         "step_kind": "main_success",
+        "sub_actions": [],
         "text": "System confirms redemption to the customer.",
         "trace": {
           "source_key": "use_cases",
@@ -2591,7 +2719,7 @@
           "change_source": "derived_use_case_steps",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "187482a4d085efc5",
+          "semantic_hash": "e8fcf8d9d1a03a9a",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -2610,6 +2738,7 @@
         "semantic_id": "redeem-reward-extension-1",
         "step_index": 1,
         "step_kind": "extension",
+        "sub_actions": [],
         "text": "Reward inventory is exhausted before completion.",
         "trace": {
           "source_key": "use_cases",
@@ -2623,7 +2752,7 @@
           "change_source": "derived_use_case_steps",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "00dfc60e4b370401",
+          "semantic_hash": "d3abee3553d806ea",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -2642,6 +2771,7 @@
         "semantic_id": "redeem-reward-extension-2",
         "step_index": 2,
         "step_kind": "extension",
+        "sub_actions": [],
         "text": "Customer does not have enough points.",
         "trace": {
           "source_key": "use_cases",
@@ -2655,7 +2785,7 @@
           "change_source": "derived_use_case_steps",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "f97975616da77c4d",
+          "semantic_hash": "f22e363153165e86",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -2674,6 +2804,7 @@
         "semantic_id": "redeem-reward-extension-3",
         "step_index": 3,
         "step_kind": "extension",
+        "sub_actions": [],
         "text": "Payment confirmation is missing for a reward that depends on purchase completion.",
         "trace": {
           "source_key": "use_cases",
@@ -2687,7 +2818,7 @@
           "change_source": "derived_use_case_steps",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "3018683e51bb8375",
+          "semantic_hash": "0d8198473fba05c1",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -2706,6 +2837,7 @@
         "semantic_id": "manage-reward-catalog-step-1",
         "step_index": 1,
         "step_kind": "main_success",
+        "sub_actions": [],
         "text": "Operations Manager opens catalog administration.",
         "trace": {
           "source_key": "use_cases",
@@ -2719,7 +2851,7 @@
           "change_source": "derived_use_case_steps",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "0c9fe51d87cb9b58",
+          "semantic_hash": "75dd9fa8c72016df",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -2738,6 +2870,7 @@
         "semantic_id": "manage-reward-catalog-step-2",
         "step_index": 2,
         "step_kind": "main_success",
+        "sub_actions": [],
         "text": "Operations Manager updates reward configuration.",
         "trace": {
           "source_key": "use_cases",
@@ -2751,7 +2884,7 @@
           "change_source": "derived_use_case_steps",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "7dc4a38b3ca526b1",
+          "semantic_hash": "b107e93d234a6304",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -2770,6 +2903,36 @@
         "semantic_id": "manage-reward-catalog-step-3",
         "step_index": 3,
         "step_kind": "main_success",
+        "sub_actions": [
+          {
+            "derivation_basis": "parallel_verbs_shared_object",
+            "id": "manage-reward-catalog-step-3-action-1",
+            "order_index": 1,
+            "parent_step_id": "manage-reward-catalog-step-3",
+            "parent_step_semantic_id": "manage-reward-catalog-step-3",
+            "parent_use_case_id": "manage-reward-catalog",
+            "semantic_id": "manage-reward-catalog-step-3-action-validate-the-change",
+            "subject": "System",
+            "target": "the change",
+            "text": "System validates the change.",
+            "title": "Validate the change",
+            "verb": "validate"
+          },
+          {
+            "derivation_basis": "parallel_verbs_shared_object",
+            "id": "manage-reward-catalog-step-3-action-2",
+            "order_index": 2,
+            "parent_step_id": "manage-reward-catalog-step-3",
+            "parent_step_semantic_id": "manage-reward-catalog-step-3",
+            "parent_use_case_id": "manage-reward-catalog",
+            "semantic_id": "manage-reward-catalog-step-3-action-publish-the-change",
+            "subject": "System",
+            "target": "the change",
+            "text": "System publishs the change.",
+            "title": "Publish the change",
+            "verb": "publish"
+          }
+        ],
         "text": "System validates and publishes the change.",
         "trace": {
           "source_key": "use_cases",
@@ -2783,7 +2946,7 @@
           "change_source": "derived_use_case_steps",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "52b5017dbd2c3ecf",
+          "semantic_hash": "6f01814c294c0412",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -2802,6 +2965,7 @@
         "semantic_id": "manage-reward-catalog-extension-1",
         "step_index": 1,
         "step_kind": "extension",
+        "sub_actions": [],
         "text": "A change is rejected because it would make an active reward invalid.",
         "trace": {
           "source_key": "use_cases",
@@ -2815,7 +2979,7 @@
           "change_source": "derived_use_case_steps",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "2ad74b487836732e",
+          "semantic_hash": "e4085e0a89ebbab5",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -2834,6 +2998,7 @@
         "semantic_id": "review-redemption-analytics-step-1",
         "step_index": 1,
         "step_kind": "main_success",
+        "sub_actions": [],
         "text": "Operations Manager opens the analytics dashboard.",
         "trace": {
           "source_key": "use_cases",
@@ -2847,7 +3012,7 @@
           "change_source": "derived_use_case_steps",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "c20a2d3b710b92b7",
+          "semantic_hash": "d8a64be2b9c07162",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -2866,6 +3031,36 @@
         "semantic_id": "review-redemption-analytics-step-2",
         "step_index": 2,
         "step_kind": "main_success",
+        "sub_actions": [
+          {
+            "derivation_basis": "shared_verb_objects",
+            "id": "review-redemption-analytics-step-2-action-1",
+            "order_index": 1,
+            "parent_step_id": "review-redemption-analytics-step-2",
+            "parent_step_semantic_id": "review-redemption-analytics-step-2",
+            "parent_use_case_id": "review-redemption-analytics",
+            "semantic_id": "review-redemption-analytics-step-2-action-show-redemption",
+            "subject": "System",
+            "target": "redemption",
+            "text": "System shows redemption.",
+            "title": "Show redemption",
+            "verb": "show"
+          },
+          {
+            "derivation_basis": "shared_verb_objects",
+            "id": "review-redemption-analytics-step-2-action-2",
+            "order_index": 2,
+            "parent_step_id": "review-redemption-analytics-step-2",
+            "parent_step_semantic_id": "review-redemption-analytics-step-2",
+            "parent_use_case_id": "review-redemption-analytics",
+            "semantic_id": "review-redemption-analytics-step-2-action-show-campaign-metrics",
+            "subject": "System",
+            "target": "campaign metrics",
+            "text": "System shows campaign metrics.",
+            "title": "Show campaign metrics",
+            "verb": "show"
+          }
+        ],
         "text": "System shows redemption and campaign metrics.",
         "trace": {
           "source_key": "use_cases",
@@ -2879,7 +3074,7 @@
           "change_source": "derived_use_case_steps",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "32969fc50ee511ae",
+          "semantic_hash": "cab589e89387ed09",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -2898,6 +3093,7 @@
         "semantic_id": "review-redemption-analytics-extension-1",
         "step_index": 1,
         "step_kind": "extension",
+        "sub_actions": [],
         "text": "A reporting data source is delayed.",
         "trace": {
           "source_key": "use_cases",
@@ -5571,7 +5767,7 @@
       "change_source": "normalize_replay_to_model",
       "last_changed_at": "",
       "regenerated_from_version": "",
-      "semantic_hash": "9e539fa7e9653a18",
+      "semantic_hash": "a328534e3404a044",
       "semantic_version": 1,
       "supersedes": []
     },

--- a/skills/rupify/references/rupify-model.md
+++ b/skills/rupify/references/rupify-model.md
@@ -77,6 +77,19 @@ The canonical project model is `rupify-model.yaml`.
     - `step_index`
     - `step_kind`
     - `text`
+    - `sub_actions`
+      - `id`
+      - `semantic_id`
+      - `title`
+      - `text`
+      - `subject`
+      - `verb`
+      - `target`
+      - `order_index`
+      - `parent_step_id`
+      - `parent_step_semantic_id`
+      - `parent_use_case_id`
+      - `derivation_basis`
     - `model_layer`: `analysis`
     - `trace`
 - `scenarios` (compatibility mirror derived from `analysis_view.scenario_objects`)

--- a/src/rupify_tools/discovery.py
+++ b/src/rupify_tools/discovery.py
@@ -49,6 +49,28 @@ ENVIRONMENTAL_FACTOR_ALIASES = {
     "difficult programming language": "difficult_programming_language",
 }
 
+STEP_VERB_LEMMAS = {
+    "approves": "approve",
+    "confirms": "confirm",
+    "creates": "create",
+    "displays": "display",
+    "exports": "export",
+    "maintains": "maintain",
+    "provides": "provide",
+    "publishes": "publish",
+    "records": "record",
+    "rejects": "reject",
+    "reserves": "reserve",
+    "reviews": "review",
+    "selects": "select",
+    "shows": "show",
+    "submits": "submit",
+    "updates": "update",
+    "validates": "validate",
+}
+
+STEP_SHARED_OBJECT_VERBS = {"display", "show", "validate"}
+
 
 def _slugify(value: str) -> str:
     """Create a stable slug-like identifier."""
@@ -827,6 +849,146 @@ def _bind_requirement_sub_obligations(requirements: list[dict[str, Any]]) -> Non
             sub_obligation["parent_requirement_semantic_id"] = parent_semantic_id
 
 
+def _parse_step_clause(clause: str) -> tuple[str, str, str]:
+    """Return the inflected verb, lemma, and remainder for one supported step clause."""
+    cleaned = _clean_sentence(clause)
+    lowered = cleaned.lower()
+    for inflected, lemma in STEP_VERB_LEMMAS.items():
+        prefix = f"{inflected} "
+        if lowered.startswith(prefix):
+            remainder = cleaned[len(prefix) :].strip()
+            return inflected, lemma, remainder
+    return "", "", ""
+
+
+def _split_step_subject_predicate(text: str) -> tuple[str, str]:
+    """Split one step into subject and supported predicate, if possible."""
+    cleaned = _clean_sentence(text)
+    lowered = cleaned.lower()
+    matches: list[tuple[int, str]] = []
+    for inflected in STEP_VERB_LEMMAS:
+        token = f" {inflected} "
+        index = lowered.find(token)
+        if index != -1:
+            matches.append((index, inflected))
+    if not matches:
+        return "", ""
+    index, _ = min(matches, key=lambda item: item[0])
+    return cleaned[:index].strip(), cleaned[index + 1 :].strip()
+
+
+def _build_step_sub_action(
+    *,
+    subject: str,
+    verb: str,
+    target: str,
+    derivation_basis: str,
+) -> dict[str, Any]:
+    """Build one normalized step sub-action record."""
+    title = f"{verb.capitalize()} {target}"
+    return {
+        "id": "",
+        "semantic_id": "",
+        "title": title,
+        "text": f"{subject} {verb}s {target}.",
+        "subject": subject,
+        "verb": verb,
+        "target": target,
+        "order_index": 0,
+        "parent_step_id": "",
+        "parent_step_semantic_id": "",
+        "parent_use_case_id": "",
+        "derivation_basis": derivation_basis,
+    }
+
+
+def _derive_step_sub_actions(step_text: str) -> list[dict[str, Any]]:
+    """Derive conservative step sub-actions from explicit step conjunction structure."""
+    cleaned = _clean_sentence(step_text)
+    if not cleaned or " and " not in cleaned:
+        return []
+
+    subject, predicate = _split_step_subject_predicate(cleaned)
+    if not subject or not predicate:
+        return []
+
+    shared_object_match = re.match(
+        r"^(?P<verb_one>\w+) and (?P<verb_two>\w+) (?P<target>.+)$",
+        predicate,
+        flags=re.IGNORECASE,
+    )
+    if shared_object_match:
+        verb_one = STEP_VERB_LEMMAS.get(shared_object_match.group("verb_one").lower(), "")
+        verb_two = STEP_VERB_LEMMAS.get(shared_object_match.group("verb_two").lower(), "")
+        target = shared_object_match.group("target").strip()
+        if verb_one and verb_two and target:
+            return [
+                _build_step_sub_action(
+                    subject=subject,
+                    verb=verb_one,
+                    target=target,
+                    derivation_basis="parallel_verbs_shared_object",
+                ),
+                _build_step_sub_action(
+                    subject=subject,
+                    verb=verb_two,
+                    target=target,
+                    derivation_basis="parallel_verbs_shared_object",
+                ),
+            ]
+
+    left_clause, right_clause = predicate.split(" and ", 1)
+    _, left_verb, left_target = _parse_step_clause(left_clause)
+    _, right_verb, right_target = _parse_step_clause(right_clause)
+    if left_verb and left_target and right_verb and right_target:
+        return [
+            _build_step_sub_action(
+                subject=subject,
+                verb=left_verb,
+                target=left_target,
+                derivation_basis="parallel_clauses",
+            ),
+            _build_step_sub_action(
+                subject=subject,
+                verb=right_verb,
+                target=right_target,
+                derivation_basis="parallel_clauses",
+            ),
+        ]
+
+    _, shared_verb, shared_target = _parse_step_clause(predicate)
+    if shared_verb in STEP_SHARED_OBJECT_VERBS:
+        targets, suffix = _split_conjoined_objects(shared_target)
+        if len(targets) >= 2:
+            return [
+                _build_step_sub_action(
+                    subject=subject,
+                    verb=shared_verb,
+                    target=f"{target}{suffix}",
+                    derivation_basis="shared_verb_objects",
+                )
+                for target in targets
+            ]
+
+    return []
+
+
+def _bind_step_sub_actions(step_objects: list[dict[str, Any]]) -> None:
+    """Bind ids, semantic ids, lineage, and ordering onto nested step sub-actions."""
+    for step_object in step_objects:
+        parent_id = step_object.get("id", "")
+        parent_semantic_id = step_object.get("semantic_id", parent_id)
+        parent_use_case_id = step_object.get("use_case_id", "")
+        for index, sub_action in enumerate(step_object.get("sub_actions", []), 1):
+            title = sub_action.get("title", f"Sub Action {index}")
+            sub_action["id"] = f"{parent_id}-action-{index}"
+            sub_action["semantic_id"] = f"{parent_semantic_id}-action-{_slugify(title)}"
+            sub_action["order_index"] = index
+            sub_action["parent_step_id"] = parent_id
+            sub_action["parent_step_semantic_id"] = parent_semantic_id
+            sub_action["parent_use_case_id"] = parent_use_case_id
+
+
 def _split_structured_parts(item: str) -> list[str]:
     """Split a pipe-delimited structured answer into trimmed parts."""
     return [part.strip() for part in item.split("|") if part.strip()]
@@ -1043,6 +1205,7 @@ def _build_use_case_step_objects(use_cases: list[dict[str, Any]]) -> list[dict[s
                     "step_index": index,
                     "step_kind": "main_success",
                     "text": step_text,
+                    "sub_actions": _derive_step_sub_actions(step_text),
                     "model_layer": "analysis",
                     "trace": use_case.get("trace", {}),
                 }
@@ -1056,6 +1219,7 @@ def _build_use_case_step_objects(use_cases: list[dict[str, Any]]) -> list[dict[s
                     "step_index": index,
                     "step_kind": "extension",
                     "text": step_text,
+                    "sub_actions": _derive_step_sub_actions(step_text),
                     "model_layer": "analysis",
                     "trace": use_case.get("trace", {}),
                 }
@@ -2193,6 +2357,7 @@ def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
     _stamp_semantic_identity(normalized_actors, change_source="round_3")
     _stamp_semantic_identity(normalized_use_cases, change_source="round_3")
     _stamp_semantic_identity(use_case_step_objects, change_source="derived_use_case_steps")
+    _bind_step_sub_actions(use_case_step_objects)
     _stamp_semantic_identity(scenario_objects, change_source="round_13")
     _stamp_semantic_identity(risk_objects, change_source="round_12")
     _stamp_semantic_identity(domain_entity_objects, change_source="round_5")

--- a/src/rupify_tools/planning_export.py
+++ b/src/rupify_tools/planning_export.py
@@ -80,6 +80,9 @@ def _export_attributes(item: dict[str, Any]) -> dict[str, Any]:
         "primary_actor_id",
         "supporting_actor_ids",
         "scenario_ids",
+        "use_case_id",
+        "step_index",
+        "step_kind",
         "used_use_case_ids",
         "subordinate_use_case_ids",
         "preconditions",
@@ -141,6 +144,28 @@ def _export_obligations(item: dict[str, Any]) -> list[dict[str, Any]]:
     ]
 
 
+def _export_sub_actions(item: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return exported step sub-action records for one canonical element."""
+    return [
+        {
+            "id": sub_action.get("id", ""),
+            "semantic_id": sub_action.get("semantic_id", sub_action.get("id", "")),
+            "title": sub_action.get("title", ""),
+            "text": sub_action.get("text", ""),
+            "subject": sub_action.get("subject", ""),
+            "verb": sub_action.get("verb", ""),
+            "target": sub_action.get("target", ""),
+            "order_index": sub_action.get("order_index", 0),
+            "parent_step_id": sub_action.get("parent_step_id", ""),
+            "parent_step_semantic_id": sub_action.get("parent_step_semantic_id", ""),
+            "parent_use_case_id": sub_action.get("parent_use_case_id", ""),
+            "derivation_basis": sub_action.get("derivation_basis", ""),
+        }
+        for sub_action in item.get("sub_actions", [])
+        if isinstance(sub_action, dict)
+    ]
+
+
 def _export_element(item: dict[str, Any], family: str) -> dict[str, Any]:
     """Convert one canonical element into the planning export shape."""
     readiness = item.get("readiness", {})
@@ -164,6 +189,9 @@ def _export_element(item: dict[str, Any], family: str) -> dict[str, Any]:
     obligations = _export_obligations(item)
     if obligations:
         exported["obligations"] = obligations
+    sub_actions = _export_sub_actions(item)
+    if sub_actions:
+        exported["sub_actions"] = sub_actions
     return exported
 
 

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -356,6 +356,65 @@ class DiscoveryTests(unittest.TestCase):
         self.assertEqual(model["actors"], [])
         self.assertEqual(model["use_cases"], [])
 
+    def test_normalize_replay_to_model_derives_use_case_step_sub_actions(self) -> None:
+        """Use-case step objects should expose safe explicit sub-actions with lineage and order."""
+        replay = replay_session(
+            [
+                {
+                    "round": 3,
+                    "responses": [
+                        {
+                            "key": "use_cases",
+                            "answer": ["Redeem Reward"],
+                        },
+                    ],
+                },
+                {
+                    "round": 13,
+                    "responses": [
+                        {
+                            "key": "use_case_details",
+                            "answer": [
+                                (
+                                    "Redeem Reward | flow: "
+                                    "System validates reward eligibility and available points; "
+                                    "System reserves the reward and updates the member balance; "
+                                    "System validates and publishes the change; "
+                                    "Customer provides the required details and consents"
+                                ),
+                            ],
+                        },
+                    ],
+                },
+            ]
+        )
+
+        model = normalize_replay_to_model(replay)
+        step_objects = model["analysis_view"]["use_case_step_objects"]
+
+        self.assertEqual(
+            [item["title"] for item in step_objects[0]["sub_actions"]],
+            ["Validate reward eligibility", "Validate available points"],
+        )
+        self.assertEqual(
+            step_objects[0]["sub_actions"][0]["derivation_basis"],
+            "shared_verb_objects",
+        )
+        self.assertEqual(
+            step_objects[0]["sub_actions"][0]["parent_step_id"],
+            "redeem-reward-step-1",
+        )
+        self.assertEqual(step_objects[0]["sub_actions"][0]["order_index"], 1)
+        self.assertEqual(
+            [item["title"] for item in step_objects[1]["sub_actions"]],
+            ["Reserve the reward", "Update the member balance"],
+        )
+        self.assertEqual(
+            [item["title"] for item in step_objects[2]["sub_actions"]],
+            ["Validate the change", "Publish the change"],
+        )
+        self.assertEqual(step_objects[3]["sub_actions"], [])
+
     def test_normalize_replay_to_model_maps_actors_and_use_cases(self) -> None:
         """Round-3 actor and use-case discovery should produce structured canonical objects."""
         replay = replay_session(

--- a/tests/test_planning_export.py
+++ b/tests/test_planning_export.py
@@ -93,7 +93,26 @@ class PlanningExportTests(unittest.TestCase):
                 {
                     "id": "uc-redeem-step-1",
                     "semantic_id": "uc-redeem-step-1",
+                    "use_case_id": "uc-redeem",
+                    "step_index": 1,
+                    "step_kind": "main_success",
                     "text": "Customer selects reward.",
+                    "sub_actions": [
+                        {
+                            "id": "uc-redeem-step-1-action-1",
+                            "semantic_id": "uc-redeem-step-1-action-select-reward",
+                            "title": "Select reward",
+                            "text": "Customer selects reward.",
+                            "subject": "Customer",
+                            "verb": "select",
+                            "target": "reward",
+                            "order_index": 1,
+                            "parent_step_id": "uc-redeem-step-1",
+                            "parent_step_semantic_id": "uc-redeem-step-1",
+                            "parent_use_case_id": "uc-redeem",
+                            "derivation_basis": "single_clause",
+                        }
+                    ],
                     "content_semantics": "normative",
                     "readiness": {
                         "status": "ready",
@@ -246,6 +265,12 @@ class PlanningExportTests(unittest.TestCase):
             "approve-system-changes",
         )
         self.assertEqual(
+            next(
+                item for item in export["elements"] if item["id"] == "uc-redeem-step-1"
+            )["sub_actions"][0]["semantic_id"],
+            "uc-redeem-step-1-action-select-reward",
+        )
+        self.assertEqual(
             next(item for item in export["elements"] if item["id"] == "acceptance-constraint-1")["attributes"]["linked_use_case_ids"],
             ["uc-redeem"],
         )
@@ -366,6 +391,36 @@ class PlanningExportTests(unittest.TestCase):
                 if item["id"] == "functional-requirement-1"
             )["obligations"][1]["id"],
             "support-approval-states",
+        )
+
+    def test_checked_in_loyalty_v2_export_includes_step_sub_actions(self) -> None:
+        """The checked-in loyalty V2 export should surface explicit step sub-actions."""
+        repo_root = Path(__file__).resolve().parents[1]
+        export_path = (
+            repo_root
+            / "examples"
+            / "loyalty-platform-v2"
+            / "exports"
+            / "speckify-planning-export.json"
+        )
+        payload = json.loads(export_path.read_text(encoding="utf-8"))
+        redeem_step = next(
+            item for item in payload["elements"] if item["id"] == "redeem-reward-step-2"
+        )
+        self.assertEqual(
+            [item["id"] for item in redeem_step["sub_actions"]],
+            [
+                "redeem-reward-step-2-action-1",
+                "redeem-reward-step-2-action-2",
+            ],
+        )
+        self.assertEqual(
+            [item["title"] for item in redeem_step["sub_actions"]],
+            ["Validate reward eligibility", "Validate available points"],
+        )
+        self.assertEqual(
+            redeem_step["sub_actions"][0]["derivation_basis"],
+            "shared_verb_objects",
         )
 
 


### PR DESCRIPTION
Closes #158

## Summary
- add canonical `sub_actions` to `use_case_step_objects` for safe explicit step-conjunction patterns
- bind stable ids, semantic ids, parent lineage, derivation basis, and ordering on those nested step parts
- expose step `sub_actions` in the Speckify planning export and refresh the checked-in V2 bundles

## Verification
- uv run python -m unittest tests.test_discovery tests.test_planning_export
- uv run python -m unittest
