### PR TITLE
Add guard-condition parts to Speckify export

### DIFF
--- a/docs/speckify-planning-export.md
+++ b/docs/speckify-planning-export.md
@@ -74,6 +74,16 @@ uv run rupify-export-planning \
       - `parent_step_semantic_id`
       - `parent_use_case_id`
       - `derivation_basis`
+    - optional `guard_parts` for guard-condition elements where Rupify has explicit normalized
+      guard structure
+      - `id`
+      - `semantic_id`
+      - `part_kind`
+      - `text`
+      - `order_index`
+      - `parent_guard_id`
+      - `parent_guard_semantic_id`
+      - `derivation_basis`
 - `ready_normative_elements`
   - the ready subset of `elements` where `content_semantics == normative`
 - `blocking_ambiguities`
@@ -91,3 +101,5 @@ uv run rupify-export-planning \
   inferring additional sub-obligations by splitting requirement prose downstream.
 - `sub_actions` should be consumed only when present; Speckify should fail closed rather than
   inferring internal step decomposition from step prose downstream.
+- `guard_parts` should be consumed only when present; Speckify should fail closed rather than
+  inferring guard structure from free-text guard descriptions downstream.

--- a/examples/it-systems-inventory-v2/README.md
+++ b/examples/it-systems-inventory-v2/README.md
@@ -56,6 +56,7 @@ This V2 export currently shows:
 - 0 unresolved trace references
 - 0 duplicate exported element IDs
 - explicit requirement obligations where the upstream requirement normalization can derive them safely
+- explicit guard parts where the upstream guard normalization can derive them safely
 
 ## Known Limits In This Example
 

--- a/examples/it-systems-inventory-v2/bundle-manifest.json
+++ b/examples/it-systems-inventory-v2/bundle-manifest.json
@@ -15,7 +15,7 @@
       "change_source": "normalize_replay_to_model",
       "last_changed_at": "",
       "regenerated_from_version": "",
-      "semantic_hash": "818aeb022ab1efc9",
+      "semantic_hash": "e436559f48487608",
       "semantic_version": 1,
       "supersedes": []
     },

--- a/examples/it-systems-inventory-v2/exports/speckify-planning-export.json
+++ b/examples/it-systems-inventory-v2/exports/speckify-planning-export.json
@@ -878,12 +878,44 @@
         "change_source": "derived_guard_conditions",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "065fe600e6dfe1f2",
+        "semantic_hash": "7874f5c348e97b09",
         "semantic_version": 1,
         "supersedes": []
       },
       "content_semantics": "normative",
       "family": "guard_conditions",
+      "guard_parts": [
+        {
+          "derivation_basis": "requires_clause",
+          "id": "guard-condition-1-part-1",
+          "order_index": 1,
+          "parent_guard_id": "guard-condition-1",
+          "parent_guard_semantic_id": "guard-condition-1",
+          "part_kind": "context",
+          "semantic_id": "guard-condition-1-part-context-deprecation-approval",
+          "text": "Deprecation approval"
+        },
+        {
+          "derivation_basis": "requires_clause",
+          "id": "guard-condition-1-part-2",
+          "order_index": 2,
+          "parent_guard_id": "guard-condition-1",
+          "parent_guard_semantic_id": "guard-condition-1",
+          "part_kind": "condition",
+          "semantic_id": "guard-condition-1-part-condition-enterprise-architect-review",
+          "text": "enterprise architect review"
+        },
+        {
+          "derivation_basis": "approval_requirement",
+          "id": "guard-condition-1-part-3",
+          "order_index": 3,
+          "parent_guard_id": "guard-condition-1",
+          "parent_guard_semantic_id": "guard-condition-1",
+          "part_kind": "block_outcome",
+          "semantic_id": "guard-condition-1-part-block_outcome-block-progression-until-enterprise-architect-review-is-satisfied",
+          "text": "Block progression until enterprise architect review is satisfied"
+        }
+      ],
       "id": "guard-condition-1",
       "missing_fields": [
         "related_transition_ids"
@@ -905,12 +937,34 @@
         "change_source": "derived_guard_conditions",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "bed0aa2ab2818dc4",
+        "semantic_hash": "72cee81d943695d1",
         "semantic_version": 1,
         "supersedes": []
       },
       "content_semantics": "normative",
       "family": "guard_conditions",
+      "guard_parts": [
+        {
+          "derivation_basis": "trigger_clause",
+          "id": "guard-condition-2-part-1",
+          "order_index": 1,
+          "parent_guard_id": "guard-condition-2",
+          "parent_guard_semantic_id": "guard-condition-2",
+          "part_kind": "context",
+          "semantic_id": "guard-condition-2-part-context-contract-expiry",
+          "text": "Contract expiry"
+        },
+        {
+          "derivation_basis": "trigger_clause",
+          "id": "guard-condition-2-part-2",
+          "order_index": 2,
+          "parent_guard_id": "guard-condition-2",
+          "parent_guard_semantic_id": "guard-condition-2",
+          "part_kind": "allow_outcome",
+          "semantic_id": "guard-condition-2-part-allow_outcome-lifecycle-review",
+          "text": "lifecycle review"
+        }
+      ],
       "id": "guard-condition-2",
       "missing_fields": [
         "related_transition_ids"
@@ -2109,7 +2163,7 @@
       "change_source": "normalize_replay_to_model",
       "last_changed_at": "",
       "regenerated_from_version": "",
-      "semantic_hash": "818aeb022ab1efc9",
+      "semantic_hash": "e436559f48487608",
       "semantic_version": 1,
       "supersedes": []
     },

--- a/examples/it-systems-inventory-v2/model/rupify-model.json
+++ b/examples/it-systems-inventory-v2/model/rupify-model.json
@@ -1103,13 +1103,45 @@
           "change_source": "derived_guard_conditions",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "065fe600e6dfe1f2",
+          "semantic_hash": "7874f5c348e97b09",
           "semantic_version": 1,
           "supersedes": []
         },
         "condition_text": "Deprecation approval requires enterprise architect review",
         "content_semantics": "normative",
         "description": "Deprecation approval requires enterprise architect review",
+        "guard_parts": [
+          {
+            "derivation_basis": "requires_clause",
+            "id": "guard-condition-1-part-1",
+            "order_index": 1,
+            "parent_guard_id": "guard-condition-1",
+            "parent_guard_semantic_id": "guard-condition-1",
+            "part_kind": "context",
+            "semantic_id": "guard-condition-1-part-context-deprecation-approval",
+            "text": "Deprecation approval"
+          },
+          {
+            "derivation_basis": "requires_clause",
+            "id": "guard-condition-1-part-2",
+            "order_index": 2,
+            "parent_guard_id": "guard-condition-1",
+            "parent_guard_semantic_id": "guard-condition-1",
+            "part_kind": "condition",
+            "semantic_id": "guard-condition-1-part-condition-enterprise-architect-review",
+            "text": "enterprise architect review"
+          },
+          {
+            "derivation_basis": "approval_requirement",
+            "id": "guard-condition-1-part-3",
+            "order_index": 3,
+            "parent_guard_id": "guard-condition-1",
+            "parent_guard_semantic_id": "guard-condition-1",
+            "part_kind": "block_outcome",
+            "semantic_id": "guard-condition-1-part-block_outcome-block-progression-until-enterprise-architect-review-is-satisfied",
+            "text": "Block progression until enterprise architect review is satisfied"
+          }
+        ],
         "id": "guard-condition-1",
         "model_layer": "analysis",
         "name": "Deprecation approval",
@@ -1138,13 +1170,35 @@
           "change_source": "derived_guard_conditions",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "bed0aa2ab2818dc4",
+          "semantic_hash": "72cee81d943695d1",
           "semantic_version": 1,
           "supersedes": []
         },
         "condition_text": "Contract expiry triggers lifecycle review",
         "content_semantics": "normative",
         "description": "Contract expiry triggers lifecycle review",
+        "guard_parts": [
+          {
+            "derivation_basis": "trigger_clause",
+            "id": "guard-condition-2-part-1",
+            "order_index": 1,
+            "parent_guard_id": "guard-condition-2",
+            "parent_guard_semantic_id": "guard-condition-2",
+            "part_kind": "context",
+            "semantic_id": "guard-condition-2-part-context-contract-expiry",
+            "text": "Contract expiry"
+          },
+          {
+            "derivation_basis": "trigger_clause",
+            "id": "guard-condition-2-part-2",
+            "order_index": 2,
+            "parent_guard_id": "guard-condition-2",
+            "parent_guard_semantic_id": "guard-condition-2",
+            "part_kind": "allow_outcome",
+            "semantic_id": "guard-condition-2-part-allow_outcome-lifecycle-review",
+            "text": "lifecycle review"
+          }
+        ],
         "id": "guard-condition-2",
         "model_layer": "analysis",
         "name": "Contract expiry",
@@ -4117,7 +4171,7 @@
       "change_source": "normalize_replay_to_model",
       "last_changed_at": "",
       "regenerated_from_version": "",
-      "semantic_hash": "818aeb022ab1efc9",
+      "semantic_hash": "e436559f48487608",
       "semantic_version": 1,
       "supersedes": []
     },
@@ -4134,13 +4188,45 @@
           "change_source": "derived_guard_conditions",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "065fe600e6dfe1f2",
+          "semantic_hash": "7874f5c348e97b09",
           "semantic_version": 1,
           "supersedes": []
         },
         "condition_text": "Deprecation approval requires enterprise architect review",
         "content_semantics": "normative",
         "description": "Deprecation approval requires enterprise architect review",
+        "guard_parts": [
+          {
+            "derivation_basis": "requires_clause",
+            "id": "guard-condition-1-part-1",
+            "order_index": 1,
+            "parent_guard_id": "guard-condition-1",
+            "parent_guard_semantic_id": "guard-condition-1",
+            "part_kind": "context",
+            "semantic_id": "guard-condition-1-part-context-deprecation-approval",
+            "text": "Deprecation approval"
+          },
+          {
+            "derivation_basis": "requires_clause",
+            "id": "guard-condition-1-part-2",
+            "order_index": 2,
+            "parent_guard_id": "guard-condition-1",
+            "parent_guard_semantic_id": "guard-condition-1",
+            "part_kind": "condition",
+            "semantic_id": "guard-condition-1-part-condition-enterprise-architect-review",
+            "text": "enterprise architect review"
+          },
+          {
+            "derivation_basis": "approval_requirement",
+            "id": "guard-condition-1-part-3",
+            "order_index": 3,
+            "parent_guard_id": "guard-condition-1",
+            "parent_guard_semantic_id": "guard-condition-1",
+            "part_kind": "block_outcome",
+            "semantic_id": "guard-condition-1-part-block_outcome-block-progression-until-enterprise-architect-review-is-satisfied",
+            "text": "Block progression until enterprise architect review is satisfied"
+          }
+        ],
         "id": "guard-condition-1",
         "model_layer": "analysis",
         "name": "Deprecation approval",
@@ -4169,13 +4255,35 @@
           "change_source": "derived_guard_conditions",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "bed0aa2ab2818dc4",
+          "semantic_hash": "72cee81d943695d1",
           "semantic_version": 1,
           "supersedes": []
         },
         "condition_text": "Contract expiry triggers lifecycle review",
         "content_semantics": "normative",
         "description": "Contract expiry triggers lifecycle review",
+        "guard_parts": [
+          {
+            "derivation_basis": "trigger_clause",
+            "id": "guard-condition-2-part-1",
+            "order_index": 1,
+            "parent_guard_id": "guard-condition-2",
+            "parent_guard_semantic_id": "guard-condition-2",
+            "part_kind": "context",
+            "semantic_id": "guard-condition-2-part-context-contract-expiry",
+            "text": "Contract expiry"
+          },
+          {
+            "derivation_basis": "trigger_clause",
+            "id": "guard-condition-2-part-2",
+            "order_index": 2,
+            "parent_guard_id": "guard-condition-2",
+            "parent_guard_semantic_id": "guard-condition-2",
+            "part_kind": "allow_outcome",
+            "semantic_id": "guard-condition-2-part-allow_outcome-lifecycle-review",
+            "text": "lifecycle review"
+          }
+        ],
         "id": "guard-condition-2",
         "model_layer": "analysis",
         "name": "Contract expiry",

--- a/examples/loyalty-platform-v2/README.md
+++ b/examples/loyalty-platform-v2/README.md
@@ -52,7 +52,7 @@ This V2 export currently shows:
 - 0 blocking ambiguities
 - 0 duplicate exported element IDs
 - 0 unresolved trace references
-- explicit requirement obligations and step sub-actions where the upstream normalization can derive them safely
+- explicit requirement obligations, step sub-actions, and guard parts where the upstream normalization can derive them safely
 
 ## Notes
 

--- a/examples/loyalty-platform-v2/bundle-manifest.json
+++ b/examples/loyalty-platform-v2/bundle-manifest.json
@@ -15,7 +15,7 @@
       "change_source": "normalize_replay_to_model",
       "last_changed_at": "",
       "regenerated_from_version": "",
-      "semantic_hash": "a328534e3404a044",
+      "semantic_hash": "6f1ce484202a5571",
       "semantic_version": 1,
       "supersedes": []
     },

--- a/examples/loyalty-platform-v2/exports/speckify-planning-export.json
+++ b/examples/loyalty-platform-v2/exports/speckify-planning-export.json
@@ -897,12 +897,34 @@
         "change_source": "derived_guard_conditions",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "5af79f330a184976",
+        "semantic_hash": "1e1f82c6ae508035",
         "semantic_version": 1,
         "supersedes": []
       },
       "content_semantics": "normative",
       "family": "guard_conditions",
+      "guard_parts": [
+        {
+          "derivation_basis": "trigger_clause",
+          "id": "guard-condition-1-part-1",
+          "order_index": 1,
+          "parent_guard_id": "guard-condition-1",
+          "parent_guard_semantic_id": "guard-condition-1",
+          "part_kind": "context",
+          "semantic_id": "guard-condition-1-part-context-payment-confirmation",
+          "text": "Payment confirmation"
+        },
+        {
+          "derivation_basis": "trigger_clause",
+          "id": "guard-condition-1-part-2",
+          "order_index": 2,
+          "parent_guard_id": "guard-condition-1",
+          "parent_guard_semantic_id": "guard-condition-1",
+          "part_kind": "allow_outcome",
+          "semantic_id": "guard-condition-1-part-allow_outcome-redemption-fulfillment",
+          "text": "redemption fulfillment"
+        }
+      ],
       "id": "guard-condition-1",
       "missing_fields": [
         "related_transition_ids"
@@ -931,12 +953,44 @@
         "change_source": "derived_guard_conditions",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "8c5e2e061f6f6c0b",
+        "semantic_hash": "669407c759ca3d1c",
         "semantic_version": 1,
         "supersedes": []
       },
       "content_semantics": "normative",
       "family": "guard_conditions",
+      "guard_parts": [
+        {
+          "derivation_basis": "required_before_clause",
+          "id": "guard-condition-2-part-1",
+          "order_index": 1,
+          "parent_guard_id": "guard-condition-2",
+          "parent_guard_semantic_id": "guard-condition-2",
+          "part_kind": "condition",
+          "semantic_id": "guard-condition-2-part-condition-catalog-validation-approval",
+          "text": "Catalog validation approval"
+        },
+        {
+          "derivation_basis": "required_before_clause",
+          "id": "guard-condition-2-part-2",
+          "order_index": 2,
+          "parent_guard_id": "guard-condition-2",
+          "parent_guard_semantic_id": "guard-condition-2",
+          "part_kind": "allow_outcome",
+          "semantic_id": "guard-condition-2-part-allow_outcome-a-reward-becomes-published",
+          "text": "a reward becomes Published"
+        },
+        {
+          "derivation_basis": "required_before_clause",
+          "id": "guard-condition-2-part-3",
+          "order_index": 3,
+          "parent_guard_id": "guard-condition-2",
+          "parent_guard_semantic_id": "guard-condition-2",
+          "part_kind": "block_outcome",
+          "semantic_id": "guard-condition-2-part-block_outcome-block-progression-until-catalog-validation-approval-is-satisfied",
+          "text": "Block progression until Catalog validation approval is satisfied"
+        }
+      ],
       "id": "guard-condition-2",
       "missing_fields": [],
       "name": "Guard Condition 2",
@@ -3173,7 +3227,7 @@
       "change_source": "normalize_replay_to_model",
       "last_changed_at": "",
       "regenerated_from_version": "",
-      "semantic_hash": "a328534e3404a044",
+      "semantic_hash": "6f1ce484202a5571",
       "semantic_version": 1,
       "supersedes": []
     },
@@ -3650,12 +3704,44 @@
         "change_source": "derived_guard_conditions",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "8c5e2e061f6f6c0b",
+        "semantic_hash": "669407c759ca3d1c",
         "semantic_version": 1,
         "supersedes": []
       },
       "content_semantics": "normative",
       "family": "guard_conditions",
+      "guard_parts": [
+        {
+          "derivation_basis": "required_before_clause",
+          "id": "guard-condition-2-part-1",
+          "order_index": 1,
+          "parent_guard_id": "guard-condition-2",
+          "parent_guard_semantic_id": "guard-condition-2",
+          "part_kind": "condition",
+          "semantic_id": "guard-condition-2-part-condition-catalog-validation-approval",
+          "text": "Catalog validation approval"
+        },
+        {
+          "derivation_basis": "required_before_clause",
+          "id": "guard-condition-2-part-2",
+          "order_index": 2,
+          "parent_guard_id": "guard-condition-2",
+          "parent_guard_semantic_id": "guard-condition-2",
+          "part_kind": "allow_outcome",
+          "semantic_id": "guard-condition-2-part-allow_outcome-a-reward-becomes-published",
+          "text": "a reward becomes Published"
+        },
+        {
+          "derivation_basis": "required_before_clause",
+          "id": "guard-condition-2-part-3",
+          "order_index": 3,
+          "parent_guard_id": "guard-condition-2",
+          "parent_guard_semantic_id": "guard-condition-2",
+          "part_kind": "block_outcome",
+          "semantic_id": "guard-condition-2-part-block_outcome-block-progression-until-catalog-validation-approval-is-satisfied",
+          "text": "Block progression until Catalog validation approval is satisfied"
+        }
+      ],
       "id": "guard-condition-2",
       "missing_fields": [],
       "name": "Guard Condition 2",

--- a/examples/loyalty-platform-v2/model/rupify-model.json
+++ b/examples/loyalty-platform-v2/model/rupify-model.json
@@ -913,13 +913,35 @@
           "change_source": "derived_guard_conditions",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "5af79f330a184976",
+          "semantic_hash": "1e1f82c6ae508035",
           "semantic_version": 1,
           "supersedes": []
         },
         "condition_text": "Payment confirmation triggers redemption fulfillment",
         "content_semantics": "normative",
         "description": "Payment confirmation triggers redemption fulfillment",
+        "guard_parts": [
+          {
+            "derivation_basis": "trigger_clause",
+            "id": "guard-condition-1-part-1",
+            "order_index": 1,
+            "parent_guard_id": "guard-condition-1",
+            "parent_guard_semantic_id": "guard-condition-1",
+            "part_kind": "context",
+            "semantic_id": "guard-condition-1-part-context-payment-confirmation",
+            "text": "Payment confirmation"
+          },
+          {
+            "derivation_basis": "trigger_clause",
+            "id": "guard-condition-1-part-2",
+            "order_index": 2,
+            "parent_guard_id": "guard-condition-1",
+            "parent_guard_semantic_id": "guard-condition-1",
+            "part_kind": "allow_outcome",
+            "semantic_id": "guard-condition-1-part-allow_outcome-redemption-fulfillment",
+            "text": "redemption fulfillment"
+          }
+        ],
         "id": "guard-condition-1",
         "model_layer": "analysis",
         "name": "Payment confirmation",
@@ -950,13 +972,45 @@
           "change_source": "derived_guard_conditions",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "8c5e2e061f6f6c0b",
+          "semantic_hash": "669407c759ca3d1c",
           "semantic_version": 1,
           "supersedes": []
         },
         "condition_text": "Catalog validation approval is required before a reward becomes Published",
         "content_semantics": "normative",
         "description": "Catalog validation approval is required before a reward becomes Published",
+        "guard_parts": [
+          {
+            "derivation_basis": "required_before_clause",
+            "id": "guard-condition-2-part-1",
+            "order_index": 1,
+            "parent_guard_id": "guard-condition-2",
+            "parent_guard_semantic_id": "guard-condition-2",
+            "part_kind": "condition",
+            "semantic_id": "guard-condition-2-part-condition-catalog-validation-approval",
+            "text": "Catalog validation approval"
+          },
+          {
+            "derivation_basis": "required_before_clause",
+            "id": "guard-condition-2-part-2",
+            "order_index": 2,
+            "parent_guard_id": "guard-condition-2",
+            "parent_guard_semantic_id": "guard-condition-2",
+            "part_kind": "allow_outcome",
+            "semantic_id": "guard-condition-2-part-allow_outcome-a-reward-becomes-published",
+            "text": "a reward becomes Published"
+          },
+          {
+            "derivation_basis": "required_before_clause",
+            "id": "guard-condition-2-part-3",
+            "order_index": 3,
+            "parent_guard_id": "guard-condition-2",
+            "parent_guard_semantic_id": "guard-condition-2",
+            "part_kind": "block_outcome",
+            "semantic_id": "guard-condition-2-part-block_outcome-block-progression-until-catalog-validation-approval-is-satisfied",
+            "text": "Block progression until Catalog validation approval is satisfied"
+          }
+        ],
         "id": "guard-condition-2",
         "model_layer": "analysis",
         "name": "Guard Condition 2",
@@ -5767,7 +5821,7 @@
       "change_source": "normalize_replay_to_model",
       "last_changed_at": "",
       "regenerated_from_version": "",
-      "semantic_hash": "a328534e3404a044",
+      "semantic_hash": "6f1ce484202a5571",
       "semantic_version": 1,
       "supersedes": []
     },
@@ -5821,13 +5875,35 @@
           "change_source": "derived_guard_conditions",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "5af79f330a184976",
+          "semantic_hash": "1e1f82c6ae508035",
           "semantic_version": 1,
           "supersedes": []
         },
         "condition_text": "Payment confirmation triggers redemption fulfillment",
         "content_semantics": "normative",
         "description": "Payment confirmation triggers redemption fulfillment",
+        "guard_parts": [
+          {
+            "derivation_basis": "trigger_clause",
+            "id": "guard-condition-1-part-1",
+            "order_index": 1,
+            "parent_guard_id": "guard-condition-1",
+            "parent_guard_semantic_id": "guard-condition-1",
+            "part_kind": "context",
+            "semantic_id": "guard-condition-1-part-context-payment-confirmation",
+            "text": "Payment confirmation"
+          },
+          {
+            "derivation_basis": "trigger_clause",
+            "id": "guard-condition-1-part-2",
+            "order_index": 2,
+            "parent_guard_id": "guard-condition-1",
+            "parent_guard_semantic_id": "guard-condition-1",
+            "part_kind": "allow_outcome",
+            "semantic_id": "guard-condition-1-part-allow_outcome-redemption-fulfillment",
+            "text": "redemption fulfillment"
+          }
+        ],
         "id": "guard-condition-1",
         "model_layer": "analysis",
         "name": "Payment confirmation",
@@ -5858,13 +5934,45 @@
           "change_source": "derived_guard_conditions",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "8c5e2e061f6f6c0b",
+          "semantic_hash": "669407c759ca3d1c",
           "semantic_version": 1,
           "supersedes": []
         },
         "condition_text": "Catalog validation approval is required before a reward becomes Published",
         "content_semantics": "normative",
         "description": "Catalog validation approval is required before a reward becomes Published",
+        "guard_parts": [
+          {
+            "derivation_basis": "required_before_clause",
+            "id": "guard-condition-2-part-1",
+            "order_index": 1,
+            "parent_guard_id": "guard-condition-2",
+            "parent_guard_semantic_id": "guard-condition-2",
+            "part_kind": "condition",
+            "semantic_id": "guard-condition-2-part-condition-catalog-validation-approval",
+            "text": "Catalog validation approval"
+          },
+          {
+            "derivation_basis": "required_before_clause",
+            "id": "guard-condition-2-part-2",
+            "order_index": 2,
+            "parent_guard_id": "guard-condition-2",
+            "parent_guard_semantic_id": "guard-condition-2",
+            "part_kind": "allow_outcome",
+            "semantic_id": "guard-condition-2-part-allow_outcome-a-reward-becomes-published",
+            "text": "a reward becomes Published"
+          },
+          {
+            "derivation_basis": "required_before_clause",
+            "id": "guard-condition-2-part-3",
+            "order_index": 3,
+            "parent_guard_id": "guard-condition-2",
+            "parent_guard_semantic_id": "guard-condition-2",
+            "part_kind": "block_outcome",
+            "semantic_id": "guard-condition-2-part-block_outcome-block-progression-until-catalog-validation-approval-is-satisfied",
+            "text": "Block progression until Catalog validation approval is satisfied"
+          }
+        ],
         "id": "guard-condition-2",
         "model_layer": "analysis",
         "name": "Guard Condition 2",

--- a/skills/rupify/references/rupify-model.md
+++ b/skills/rupify/references/rupify-model.md
@@ -291,6 +291,15 @@ The canonical project model is `rupify-model.yaml`.
     - `name`
     - `description`
     - `condition_text`
+    - `guard_parts`
+      - `id`
+      - `semantic_id`
+      - `part_kind`
+      - `text`
+      - `order_index`
+      - `parent_guard_id`
+      - `parent_guard_semantic_id`
+      - `derivation_basis`
     - `state_entity_ids`
     - `related_transition_ids`
     - `source_trigger_id`

--- a/src/rupify_tools/discovery.py
+++ b/src/rupify_tools/discovery.py
@@ -989,6 +989,118 @@ def _bind_step_sub_actions(step_objects: list[dict[str, Any]]) -> None:
             sub_action["parent_use_case_id"] = parent_use_case_id
 
 
+def _build_guard_part(
+    *,
+    part_kind: str,
+    text: str,
+    derivation_basis: str,
+) -> dict[str, Any]:
+    """Build one normalized guard part record."""
+    return {
+        "id": "",
+        "semantic_id": "",
+        "part_kind": part_kind,
+        "text": text.strip(),
+        "order_index": 0,
+        "parent_guard_id": "",
+        "parent_guard_semantic_id": "",
+        "derivation_basis": derivation_basis,
+    }
+
+
+def _derive_guard_parts(trigger: dict[str, Any]) -> list[dict[str, Any]]:
+    """Derive conservative structured guard parts from explicit trigger semantics and text."""
+    description = _clean_sentence(trigger.get("description", ""))
+    event_name = trigger.get("event_name", "").strip()
+    outcome = trigger.get("outcome", "").strip()
+    lowered = description.lower()
+
+    if not description:
+        return []
+
+    if " triggers " in lowered and event_name and outcome:
+        return [
+            _build_guard_part(
+                part_kind="context",
+                text=event_name,
+                derivation_basis="trigger_clause",
+            ),
+            _build_guard_part(
+                part_kind="allow_outcome",
+                text=outcome,
+                derivation_basis="trigger_clause",
+            ),
+        ]
+
+    if " requires " in lowered and event_name and outcome:
+        parts = [
+            _build_guard_part(
+                part_kind="context",
+                text=event_name,
+                derivation_basis="requires_clause",
+            ),
+            _build_guard_part(
+                part_kind="condition",
+                text=outcome,
+                derivation_basis="requires_clause",
+            ),
+        ]
+        if trigger.get("approval_required"):
+            parts.append(
+                _build_guard_part(
+                    part_kind="block_outcome",
+                    text=f"Block progression until {outcome} is satisfied",
+                    derivation_basis="approval_requirement",
+                )
+            )
+        return parts
+
+    required_before_match = re.match(
+        r"^(?P<condition>.+?) is required before (?P<outcome>.+)$",
+        description,
+        flags=re.IGNORECASE,
+    )
+    if required_before_match:
+        condition = required_before_match.group("condition").strip()
+        outcome_text = required_before_match.group("outcome").strip()
+        return [
+            _build_guard_part(
+                part_kind="condition",
+                text=condition,
+                derivation_basis="required_before_clause",
+            ),
+            _build_guard_part(
+                part_kind="allow_outcome",
+                text=outcome_text,
+                derivation_basis="required_before_clause",
+            ),
+            _build_guard_part(
+                part_kind="block_outcome",
+                text=f"Block progression until {condition} is satisfied",
+                derivation_basis="required_before_clause",
+            ),
+        ]
+
+    return []
+
+
+def _bind_guard_parts(guard_objects: list[dict[str, Any]]) -> None:
+    """Bind ids, semantic ids, lineage, and ordering onto nested guard parts."""
+    for guard_object in guard_objects:
+        parent_id = guard_object.get("id", "")
+        parent_semantic_id = guard_object.get("semantic_id", parent_id)
+        for index, guard_part in enumerate(guard_object.get("guard_parts", []), 1):
+            part_kind = guard_part.get("part_kind", f"part-{index}")
+            text = guard_part.get("text", "")
+            guard_part["id"] = f"{parent_id}-part-{index}"
+            guard_part["semantic_id"] = (
+                f"{parent_semantic_id}-part-{part_kind}-{_slugify(text)}"
+            )
+            guard_part["order_index"] = index
+            guard_part["parent_guard_id"] = parent_id
+            guard_part["parent_guard_semantic_id"] = parent_semantic_id
+
+
 def _split_structured_parts(item: str) -> list[str]:
     """Split a pipe-delimited structured answer into trimmed parts."""
     return [part.strip() for part in item.split("|") if part.strip()]
@@ -1321,6 +1433,7 @@ def _build_guard_condition_objects(
                 "name": trigger.get("event_name", "") or f"Guard Condition {index}",
                 "description": description,
                 "condition_text": description,
+                "guard_parts": _derive_guard_parts(trigger),
                 "state_entity_ids": _matched_object_ids(description, state_entities),
                 "related_transition_ids": related_transition_ids,
                 "source_trigger_id": trigger.get("id", ""),
@@ -2369,6 +2482,7 @@ def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
     _stamp_semantic_identity(state_transition_objects, change_source="round_6")
     _stamp_semantic_identity(trigger_objects, change_source="round_6")
     _stamp_semantic_identity(guard_condition_objects, change_source="derived_guard_conditions")
+    _bind_guard_parts(guard_condition_objects)
     _stamp_semantic_identity(
         forbidden_transition_objects,
         change_source="derived_forbidden_transitions",

--- a/src/rupify_tools/planning_export.py
+++ b/src/rupify_tools/planning_export.py
@@ -166,6 +166,24 @@ def _export_sub_actions(item: dict[str, Any]) -> list[dict[str, Any]]:
     ]
 
 
+def _export_guard_parts(item: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return exported guard-part records for one canonical element."""
+    return [
+        {
+            "id": guard_part.get("id", ""),
+            "semantic_id": guard_part.get("semantic_id", guard_part.get("id", "")),
+            "part_kind": guard_part.get("part_kind", ""),
+            "text": guard_part.get("text", ""),
+            "order_index": guard_part.get("order_index", 0),
+            "parent_guard_id": guard_part.get("parent_guard_id", ""),
+            "parent_guard_semantic_id": guard_part.get("parent_guard_semantic_id", ""),
+            "derivation_basis": guard_part.get("derivation_basis", ""),
+        }
+        for guard_part in item.get("guard_parts", [])
+        if isinstance(guard_part, dict)
+    ]
+
+
 def _export_element(item: dict[str, Any], family: str) -> dict[str, Any]:
     """Convert one canonical element into the planning export shape."""
     readiness = item.get("readiness", {})
@@ -192,6 +210,9 @@ def _export_element(item: dict[str, Any], family: str) -> dict[str, Any]:
     sub_actions = _export_sub_actions(item)
     if sub_actions:
         exported["sub_actions"] = sub_actions
+    guard_parts = _export_guard_parts(item)
+    if guard_parts:
+        exported["guard_parts"] = guard_parts
     return exported
 
 

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1117,3 +1117,52 @@ class DiscoveryTests(unittest.TestCase):
         self.assertEqual(triggers[0]["constraint_type"], "approval")
         self.assertEqual(triggers[1]["exceptional_behavior"], True)
         self.assertEqual(model["architecture_view"]["runtime_boundary_objects"], [])
+
+    def test_normalize_replay_to_model_derives_guard_parts(self) -> None:
+        """Guard-condition objects should expose explicit ordered guard parts for safe patterns."""
+        replay = replay_session(
+            [
+                {
+                    "round": 6,
+                    "responses": [
+                        {"key": "state_entities", "answer": ["Reward Catalog Entry"]},
+                        {
+                            "key": "states_and_transitions",
+                            "answer": [
+                                "Reward Catalog Entry: Draft -> Published -> Retired",
+                            ],
+                        },
+                        {
+                            "key": "triggers_and_approvals",
+                            "answer": [
+                                "Payment confirmation triggers redemption fulfillment",
+                                "Catalog validation approval is required before a reward becomes Published",
+                                "Deprecation approval requires enterprise architect review",
+                            ],
+                        },
+                    ],
+                },
+            ]
+        )
+
+        model = normalize_replay_to_model(replay)
+        guard_objects = model["process_view"]["guard_condition_objects"]
+
+        self.assertEqual(
+            [item["part_kind"] for item in guard_objects[0]["guard_parts"]],
+            ["context", "allow_outcome"],
+        )
+        self.assertEqual(guard_objects[0]["guard_parts"][0]["text"], "Payment confirmation")
+        self.assertEqual(
+            [item["part_kind"] for item in guard_objects[1]["guard_parts"]],
+            ["condition", "allow_outcome", "block_outcome"],
+        )
+        self.assertEqual(
+            guard_objects[1]["guard_parts"][0]["parent_guard_id"],
+            "guard-condition-2",
+        )
+        self.assertEqual(guard_objects[1]["guard_parts"][0]["order_index"], 1)
+        self.assertEqual(
+            [item["part_kind"] for item in guard_objects[2]["guard_parts"]],
+            ["context", "condition", "block_outcome"],
+        )

--- a/tests/test_planning_export.py
+++ b/tests/test_planning_export.py
@@ -159,7 +159,49 @@ class PlanningExportTests(unittest.TestCase):
             "state_transition_objects": [],
             "trigger_objects": [],
             "state_invariant_objects": [],
-            "guard_condition_objects": [],
+            "guard_condition_objects": [
+                {
+                    "id": "guard-condition-1",
+                    "semantic_id": "guard-condition-1",
+                    "name": "Payment confirmation",
+                    "description": "Payment confirmation triggers redemption fulfillment",
+                    "condition_text": "Payment confirmation triggers redemption fulfillment",
+                    "guard_parts": [
+                        {
+                            "id": "guard-condition-1-part-1",
+                            "semantic_id": "guard-condition-1-part-context-payment-confirmation",
+                            "part_kind": "context",
+                            "text": "Payment confirmation",
+                            "order_index": 1,
+                            "parent_guard_id": "guard-condition-1",
+                            "parent_guard_semantic_id": "guard-condition-1",
+                            "derivation_basis": "trigger_clause",
+                        },
+                        {
+                            "id": "guard-condition-1-part-2",
+                            "semantic_id": "guard-condition-1-part-allow-outcome-redemption-fulfillment",
+                            "part_kind": "allow_outcome",
+                            "text": "redemption fulfillment",
+                            "order_index": 2,
+                            "parent_guard_id": "guard-condition-1",
+                            "parent_guard_semantic_id": "guard-condition-1",
+                            "derivation_basis": "trigger_clause",
+                        },
+                    ],
+                    "content_semantics": "normative",
+                    "readiness": {
+                        "status": "ready",
+                        "normative_ready": True,
+                        "missing_fields": [],
+                        "blocking_ambiguity_ids": [],
+                    },
+                    "change_metadata": {"semantic_hash": "guardhash"},
+                    "trace": {"source_round": 6, "source_key": "triggers_and_approvals"},
+                    "state_entity_ids": [],
+                    "related_transition_ids": ["state-transition-1"],
+                    "source_trigger_id": "trigger-1",
+                }
+            ],
             "forbidden_transition_objects": [],
         }
         model["architecture_view"] = {
@@ -245,7 +287,7 @@ class PlanningExportTests(unittest.TestCase):
         self.assertEqual(export["export_metadata"]["export_kind"], "speckify_planning_export")
         self.assertEqual(
             export["summary"]["ready_normative_ids"],
-            ["functional-requirement-1", "uc-redeem-step-1", "uc-redeem"],
+            ["functional-requirement-1", "guard-condition-1", "uc-redeem-step-1", "uc-redeem"],
         )
         self.assertEqual(export["summary"]["blocking_ambiguity_ids"], ["ambiguity-open-question-1"])
         self.assertEqual(
@@ -269,6 +311,12 @@ class PlanningExportTests(unittest.TestCase):
                 item for item in export["elements"] if item["id"] == "uc-redeem-step-1"
             )["sub_actions"][0]["semantic_id"],
             "uc-redeem-step-1-action-select-reward",
+        )
+        self.assertEqual(
+            next(
+                item for item in export["elements"] if item["id"] == "guard-condition-1"
+            )["guard_parts"][0]["part_kind"],
+            "context",
         )
         self.assertEqual(
             next(item for item in export["elements"] if item["id"] == "acceptance-constraint-1")["attributes"]["linked_use_case_ids"],
@@ -421,6 +469,29 @@ class PlanningExportTests(unittest.TestCase):
         self.assertEqual(
             redeem_step["sub_actions"][0]["derivation_basis"],
             "shared_verb_objects",
+        )
+
+    def test_checked_in_loyalty_v2_export_includes_guard_parts(self) -> None:
+        """The checked-in loyalty V2 export should surface explicit guard parts."""
+        repo_root = Path(__file__).resolve().parents[1]
+        export_path = (
+            repo_root
+            / "examples"
+            / "loyalty-platform-v2"
+            / "exports"
+            / "speckify-planning-export.json"
+        )
+        payload = json.loads(export_path.read_text(encoding="utf-8"))
+        guard = next(
+            item for item in payload["elements"] if item["id"] == "guard-condition-2"
+        )
+        self.assertEqual(
+            [item["part_kind"] for item in guard["guard_parts"]],
+            ["condition", "allow_outcome", "block_outcome"],
+        )
+        self.assertEqual(
+            guard["guard_parts"][0]["derivation_basis"],
+            "required_before_clause",
         )
 
 


### PR DESCRIPTION
Closes #159

## Summary
- add canonical `guard_parts` to `guard_condition_objects` for safe explicit trigger and approval patterns
- bind stable ids, semantic ids, parent lineage, derivation basis, and ordering on those nested guard parts
- expose `guard_parts` in the Speckify planning export and refresh the checked-in V2 bundles

## Verification
- uv run python -m unittest tests.test_discovery tests.test_planning_export
- uv run python -m unittest
