### PR TITLE
Expand requirement clause structure for Speckify export

### DIFF
--- a/examples/loyalty-platform-v2/bundle-manifest.json
+++ b/examples/loyalty-platform-v2/bundle-manifest.json
@@ -15,7 +15,7 @@
       "change_source": "normalize_replay_to_model",
       "last_changed_at": "",
       "regenerated_from_version": "",
-      "semantic_hash": "6f1ce484202a5571",
+      "semantic_hash": "1e4a32ec4521ade8",
       "semantic_version": 1,
       "supersedes": []
     },

--- a/examples/loyalty-platform-v2/exports/speckify-planning-export.json
+++ b/examples/loyalty-platform-v2/exports/speckify-planning-export.json
@@ -1411,7 +1411,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "1e8d913324d95244",
+        "semantic_hash": "6343566b4bf3c59c",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -1421,6 +1421,24 @@
       "missing_fields": [],
       "name": "",
       "normative_ready": true,
+      "obligations": [
+        {
+          "acceptance": "Integration with external systems with payment confirmation is supported.",
+          "id": "support-integration-with-external-systems-with-payment-confirmation",
+          "parent_requirement_id": "non_functional-requirement-3",
+          "parent_requirement_semantic_id": "non_functional-requirement-3",
+          "summary": "Support integration with external systems with payment confirmation.",
+          "title": "Support integration with external systems with payment confirmation"
+        },
+        {
+          "acceptance": "Integration with external systems with reporting sources is supported.",
+          "id": "support-integration-with-external-systems-with-reporting-sources",
+          "parent_requirement_id": "non_functional-requirement-3",
+          "parent_requirement_semantic_id": "non_functional-requirement-3",
+          "summary": "Support integration with external systems with reporting sources.",
+          "title": "Support integration with external systems with reporting sources"
+        }
+      ],
       "readiness_status": "ready",
       "semantic_id": "non_functional-requirement-3",
       "source_key": "constraints",
@@ -3227,7 +3245,7 @@
       "change_source": "normalize_replay_to_model",
       "last_changed_at": "",
       "regenerated_from_version": "",
-      "semantic_hash": "6f1ce484202a5571",
+      "semantic_hash": "1e4a32ec4521ade8",
       "semantic_version": 1,
       "supersedes": []
     },
@@ -3829,7 +3847,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "1e8d913324d95244",
+        "semantic_hash": "6343566b4bf3c59c",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -3839,6 +3857,24 @@
       "missing_fields": [],
       "name": "",
       "normative_ready": true,
+      "obligations": [
+        {
+          "acceptance": "Integration with external systems with payment confirmation is supported.",
+          "id": "support-integration-with-external-systems-with-payment-confirmation",
+          "parent_requirement_id": "non_functional-requirement-3",
+          "parent_requirement_semantic_id": "non_functional-requirement-3",
+          "summary": "Support integration with external systems with payment confirmation.",
+          "title": "Support integration with external systems with payment confirmation"
+        },
+        {
+          "acceptance": "Integration with external systems with reporting sources is supported.",
+          "id": "support-integration-with-external-systems-with-reporting-sources",
+          "parent_requirement_id": "non_functional-requirement-3",
+          "parent_requirement_semantic_id": "non_functional-requirement-3",
+          "summary": "Support integration with external systems with reporting sources.",
+          "title": "Support integration with external systems with reporting sources"
+        }
+      ],
       "readiness_status": "ready",
       "semantic_id": "non_functional-requirement-3",
       "source_key": "constraints",

--- a/examples/loyalty-platform-v2/model/rupify-model.json
+++ b/examples/loyalty-platform-v2/model/rupify-model.json
@@ -1392,7 +1392,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "1e8d913324d95244",
+          "semantic_hash": "6343566b4bf3c59c",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -1415,7 +1415,24 @@
         "requirement_kind": "non_functional",
         "semantic_id": "non_functional-requirement-3",
         "statement": "The platform must support integrations with external systems such as payment confirmation and reporting sources.",
-        "sub_obligations": [],
+        "sub_obligations": [
+          {
+            "acceptance": "Integration with external systems with payment confirmation is supported.",
+            "id": "support-integration-with-external-systems-with-payment-confirmation",
+            "parent_requirement_id": "non_functional-requirement-3",
+            "parent_requirement_semantic_id": "non_functional-requirement-3",
+            "summary": "Support integration with external systems with payment confirmation.",
+            "title": "Support integration with external systems with payment confirmation"
+          },
+          {
+            "acceptance": "Integration with external systems with reporting sources is supported.",
+            "id": "support-integration-with-external-systems-with-reporting-sources",
+            "parent_requirement_id": "non_functional-requirement-3",
+            "parent_requirement_semantic_id": "non_functional-requirement-3",
+            "summary": "Support integration with external systems with reporting sources.",
+            "title": "Support integration with external systems with reporting sources"
+          }
+        ],
         "trace": {
           "source_key": "constraints",
           "source_round": 2
@@ -5821,7 +5838,7 @@
       "change_source": "normalize_replay_to_model",
       "last_changed_at": "",
       "regenerated_from_version": "",
-      "semantic_hash": "6f1ce484202a5571",
+      "semantic_hash": "1e4a32ec4521ade8",
       "semantic_version": 1,
       "supersedes": []
     },
@@ -6929,7 +6946,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "1e8d913324d95244",
+          "semantic_hash": "6343566b4bf3c59c",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -6952,7 +6969,24 @@
         "requirement_kind": "non_functional",
         "semantic_id": "non_functional-requirement-3",
         "statement": "The platform must support integrations with external systems such as payment confirmation and reporting sources.",
-        "sub_obligations": [],
+        "sub_obligations": [
+          {
+            "acceptance": "Integration with external systems with payment confirmation is supported.",
+            "id": "support-integration-with-external-systems-with-payment-confirmation",
+            "parent_requirement_id": "non_functional-requirement-3",
+            "parent_requirement_semantic_id": "non_functional-requirement-3",
+            "summary": "Support integration with external systems with payment confirmation.",
+            "title": "Support integration with external systems with payment confirmation"
+          },
+          {
+            "acceptance": "Integration with external systems with reporting sources is supported.",
+            "id": "support-integration-with-external-systems-with-reporting-sources",
+            "parent_requirement_id": "non_functional-requirement-3",
+            "parent_requirement_semantic_id": "non_functional-requirement-3",
+            "summary": "Support integration with external systems with reporting sources.",
+            "title": "Support integration with external systems with reporting sources"
+          }
+        ],
         "trace": {
           "source_key": "constraints",
           "source_round": 2

--- a/src/rupify_tools/discovery.py
+++ b/src/rupify_tools/discovery.py
@@ -720,6 +720,16 @@ def _capitalize_phrase(text: str) -> str:
     return cleaned[0].upper() + cleaned[1:]
 
 
+def _singularize_leading_token(text: str) -> str:
+    """Singularize only the leading token in a phrase when it is a simple plural noun."""
+    tokens = text.strip().split()
+    if not tokens:
+        return ""
+    if len(tokens[0]) > 3 and tokens[0].endswith("s"):
+        tokens[0] = tokens[0][:-1]
+    return " ".join(tokens)
+
+
 def _split_conjoined_objects(text: str) -> tuple[list[str], str]:
     """Split a simple conjunction into object parts plus a shared suffix."""
     cleaned = _clean_sentence(text)
@@ -832,6 +842,33 @@ def _derive_requirement_sub_obligations(statement: str) -> list[dict[str, str]]:
                     title=title,
                     summary=f"Support {item}.",
                     acceptance=f"{_capitalize_phrase(item)} is supported.",
+                )
+            )
+        return obligations
+
+    such_as_match = re.match(
+        (
+            r"^(?P<subject>.+?) must support (?P<context>.+?) such as "
+            r"(?P<objects>.+)$"
+        ),
+        cleaned,
+        flags=re.IGNORECASE,
+    )
+    if such_as_match:
+        context = such_as_match.group("context").strip()
+        objects, suffix = _split_conjoined_objects(such_as_match.group("objects"))
+        if len(objects) < 2:
+            return []
+        obligations = []
+        singular_context = _singularize_leading_token(context)
+        for item in objects:
+            title = f"Support {singular_context} with {item}"
+            obligations.append(
+                _build_sub_obligation(
+                    obligation_id=_slugify(title),
+                    title=title,
+                    summary=f"Support {singular_context} with {item}{suffix}.",
+                    acceptance=f"{_capitalize_phrase(singular_context)} with {item}{suffix} is supported.",
                 )
             )
         return obligations

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -327,6 +327,45 @@ class DiscoveryTests(unittest.TestCase):
             ],
         )
 
+    def test_normalize_replay_to_model_derives_requirement_sub_obligations_for_such_as_support(self) -> None:
+        """Enumerated `support ... such as` requirements should promote explicit clause structure."""
+        replay = replay_session(
+            [
+                {
+                    "round": 2,
+                    "responses": [
+                        {
+                            "key": "constraints",
+                            "answer": [
+                                (
+                                    "The platform must support integrations with external systems "
+                                    "such as payment confirmation and reporting sources."
+                                )
+                            ],
+                        },
+                    ],
+                }
+            ]
+        )
+
+        model = normalize_replay_to_model(replay)
+        sub_obligations = model["requirements"]["non_functional_objects"][0]["sub_obligations"]
+
+        self.assertEqual(
+            [item["title"] for item in sub_obligations],
+            [
+                "Support integration with external systems with payment confirmation",
+                "Support integration with external systems with reporting sources",
+            ],
+        )
+        self.assertEqual(
+            [item["id"] for item in sub_obligations],
+            [
+                "support-integration-with-external-systems-with-payment-confirmation",
+                "support-integration-with-external-systems-with-reporting-sources",
+            ],
+        )
+
     def test_normalize_replay_to_model_keeps_empty_sections_explicit(self) -> None:
         """Missing optional view rounds should still produce stable empty sections."""
         replay = replay_session(

--- a/tests/test_planning_export.py
+++ b/tests/test_planning_export.py
@@ -494,6 +494,28 @@ class PlanningExportTests(unittest.TestCase):
             "required_before_clause",
         )
 
+    def test_checked_in_loyalty_v2_export_includes_expanded_requirement_obligations(self) -> None:
+        """The checked-in loyalty V2 export should include broader requirement clause structure."""
+        repo_root = Path(__file__).resolve().parents[1]
+        export_path = (
+            repo_root
+            / "examples"
+            / "loyalty-platform-v2"
+            / "exports"
+            / "speckify-planning-export.json"
+        )
+        payload = json.loads(export_path.read_text(encoding="utf-8"))
+        requirement = next(
+            item for item in payload["elements"] if item["id"] == "non_functional-requirement-3"
+        )
+        self.assertEqual(
+            [item["title"] for item in requirement["obligations"]],
+            [
+                "Support integration with external systems with payment confirmation",
+                "Support integration with external systems with reporting sources",
+            ],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #160

## Summary
- broaden canonical requirement clause normalization for the remaining safe `support ... such as A and B` pattern
- preserve stable ids, parent lineage, and deterministic upstream obligation derivation
- refresh the loyalty V2 bundle and add regression coverage for the expanded requirement clause case

## Verification
- uv run python -m unittest tests.test_discovery tests.test_planning_export
- uv run python -m unittest
