### PR TITLE
Add invariant clause structure to Speckify export

### DIFF
--- a/docs/speckify-planning-export.md
+++ b/docs/speckify-planning-export.md
@@ -84,6 +84,17 @@ uv run rupify-export-planning \
       - `parent_guard_id`
       - `parent_guard_semantic_id`
       - `derivation_basis`
+    - optional `invariant_clauses` for invariant elements where Rupify has explicit normalized
+      invariant clause structure
+      - `id`
+      - `semantic_id`
+      - `clause_kind`
+      - `title`
+      - `text`
+      - `order_index`
+      - `parent_invariant_id`
+      - `parent_invariant_semantic_id`
+      - `derivation_basis`
 - `ready_normative_elements`
   - the ready subset of `elements` where `content_semantics == normative`
 - `blocking_ambiguities`
@@ -103,3 +114,5 @@ uv run rupify-export-planning \
   inferring internal step decomposition from step prose downstream.
 - `guard_parts` should be consumed only when present; Speckify should fail closed rather than
   inferring guard structure from free-text guard descriptions downstream.
+- `invariant_clauses` should be consumed only when present; Speckify should fail closed rather than
+  inferring invariant structure from broad rule prose downstream.

--- a/examples/it-systems-inventory-v2/README.md
+++ b/examples/it-systems-inventory-v2/README.md
@@ -57,6 +57,7 @@ This V2 export currently shows:
 - 0 duplicate exported element IDs
 - explicit requirement obligations where the upstream requirement normalization can derive them safely
 - explicit guard parts where the upstream guard normalization can derive them safely
+- explicit invariant clauses where the upstream invariant normalization can derive them safely
 
 ## Known Limits In This Example
 

--- a/examples/it-systems-inventory-v2/bundle-manifest.json
+++ b/examples/it-systems-inventory-v2/bundle-manifest.json
@@ -15,7 +15,7 @@
       "change_source": "normalize_replay_to_model",
       "last_changed_at": "",
       "regenerated_from_version": "",
-      "semantic_hash": "e436559f48487608",
+      "semantic_hash": "50298153f054adc9",
       "semantic_version": 1,
       "supersedes": []
     },

--- a/examples/it-systems-inventory-v2/exports/speckify-planning-export.json
+++ b/examples/it-systems-inventory-v2/exports/speckify-planning-export.json
@@ -728,7 +728,7 @@
         "change_source": "derived_domain_invariants",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "a0838e2d92556587",
+        "semantic_hash": "f86b8e56c059947a",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -756,7 +756,7 @@
         "change_source": "derived_domain_invariants",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "0faa9d909ed4effe",
+        "semantic_hash": "10237eaa6ca821d7",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -785,13 +785,37 @@
         "change_source": "derived_domain_invariants",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "ae58a8512d9d5819",
+        "semantic_hash": "9595d29dc493d82e",
         "semantic_version": 1,
         "supersedes": []
       },
       "content_semantics": "normative",
       "family": "domain_invariants",
       "id": "domain-invariant-3",
+      "invariant_clauses": [
+        {
+          "clause_kind": "obligation",
+          "derivation_basis": "shared_verb_objects",
+          "id": "domain-invariant-3-clause-1",
+          "order_index": 1,
+          "parent_invariant_id": "domain-invariant-3",
+          "parent_invariant_semantic_id": "domain-invariant-3",
+          "semantic_id": "domain-invariant-3-clause-obligation-record-vendor",
+          "text": "Record vendor.",
+          "title": "Record vendor"
+        },
+        {
+          "clause_kind": "obligation",
+          "derivation_basis": "shared_verb_objects",
+          "id": "domain-invariant-3-clause-2",
+          "order_index": 2,
+          "parent_invariant_id": "domain-invariant-3",
+          "parent_invariant_semantic_id": "domain-invariant-3",
+          "semantic_id": "domain-invariant-3-clause-obligation-record-contract-dates",
+          "text": "Record contract dates.",
+          "title": "Record contract dates"
+        }
+      ],
       "missing_fields": [],
       "name": "Rule 3",
       "normative_ready": true,
@@ -1713,7 +1737,7 @@
         "change_source": "derived_state_invariants",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "e99d374908167c66",
+        "semantic_hash": "6cd13106207f8897",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -1741,7 +1765,7 @@
         "change_source": "derived_state_invariants",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "d3f0734ba4f5d238",
+        "semantic_hash": "04bf083cf9ba66fd",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -1769,13 +1793,37 @@
         "change_source": "derived_state_invariants",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "86c22df4bc630d1b",
+        "semantic_hash": "3fac42f8e26890a5",
         "semantic_version": 1,
         "supersedes": []
       },
       "content_semantics": "normative",
       "family": "state_invariants",
       "id": "state-invariant-3",
+      "invariant_clauses": [
+        {
+          "clause_kind": "obligation",
+          "derivation_basis": "shared_verb_objects",
+          "id": "state-invariant-3-clause-1",
+          "order_index": 1,
+          "parent_invariant_id": "state-invariant-3",
+          "parent_invariant_semantic_id": "state-invariant-3",
+          "semantic_id": "state-invariant-3-clause-obligation-record-vendor",
+          "text": "Record vendor.",
+          "title": "Record vendor"
+        },
+        {
+          "clause_kind": "obligation",
+          "derivation_basis": "shared_verb_objects",
+          "id": "state-invariant-3-clause-2",
+          "order_index": 2,
+          "parent_invariant_id": "state-invariant-3",
+          "parent_invariant_semantic_id": "state-invariant-3",
+          "semantic_id": "state-invariant-3-clause-obligation-record-contract-dates",
+          "text": "Record contract dates.",
+          "title": "Record contract dates"
+        }
+      ],
       "missing_fields": [],
       "name": "Rule 3",
       "normative_ready": true,
@@ -2163,7 +2211,7 @@
       "change_source": "normalize_replay_to_model",
       "last_changed_at": "",
       "regenerated_from_version": "",
-      "semantic_hash": "e436559f48487608",
+      "semantic_hash": "50298153f054adc9",
       "semantic_version": 1,
       "supersedes": []
     },
@@ -2415,7 +2463,7 @@
         "change_source": "derived_domain_invariants",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "a0838e2d92556587",
+        "semantic_hash": "f86b8e56c059947a",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -2443,7 +2491,7 @@
         "change_source": "derived_domain_invariants",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "0faa9d909ed4effe",
+        "semantic_hash": "10237eaa6ca821d7",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -2472,13 +2520,37 @@
         "change_source": "derived_domain_invariants",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "ae58a8512d9d5819",
+        "semantic_hash": "9595d29dc493d82e",
         "semantic_version": 1,
         "supersedes": []
       },
       "content_semantics": "normative",
       "family": "domain_invariants",
       "id": "domain-invariant-3",
+      "invariant_clauses": [
+        {
+          "clause_kind": "obligation",
+          "derivation_basis": "shared_verb_objects",
+          "id": "domain-invariant-3-clause-1",
+          "order_index": 1,
+          "parent_invariant_id": "domain-invariant-3",
+          "parent_invariant_semantic_id": "domain-invariant-3",
+          "semantic_id": "domain-invariant-3-clause-obligation-record-vendor",
+          "text": "Record vendor.",
+          "title": "Record vendor"
+        },
+        {
+          "clause_kind": "obligation",
+          "derivation_basis": "shared_verb_objects",
+          "id": "domain-invariant-3-clause-2",
+          "order_index": 2,
+          "parent_invariant_id": "domain-invariant-3",
+          "parent_invariant_semantic_id": "domain-invariant-3",
+          "semantic_id": "domain-invariant-3-clause-obligation-record-contract-dates",
+          "text": "Record contract dates.",
+          "title": "Record contract dates"
+        }
+      ],
       "missing_fields": [],
       "name": "Rule 3",
       "normative_ready": true,
@@ -2768,7 +2840,7 @@
         "change_source": "derived_state_invariants",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "e99d374908167c66",
+        "semantic_hash": "6cd13106207f8897",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -2796,7 +2868,7 @@
         "change_source": "derived_state_invariants",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "d3f0734ba4f5d238",
+        "semantic_hash": "04bf083cf9ba66fd",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -2824,13 +2896,37 @@
         "change_source": "derived_state_invariants",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "86c22df4bc630d1b",
+        "semantic_hash": "3fac42f8e26890a5",
         "semantic_version": 1,
         "supersedes": []
       },
       "content_semantics": "normative",
       "family": "state_invariants",
       "id": "state-invariant-3",
+      "invariant_clauses": [
+        {
+          "clause_kind": "obligation",
+          "derivation_basis": "shared_verb_objects",
+          "id": "state-invariant-3-clause-1",
+          "order_index": 1,
+          "parent_invariant_id": "state-invariant-3",
+          "parent_invariant_semantic_id": "state-invariant-3",
+          "semantic_id": "state-invariant-3-clause-obligation-record-vendor",
+          "text": "Record vendor.",
+          "title": "Record vendor"
+        },
+        {
+          "clause_kind": "obligation",
+          "derivation_basis": "shared_verb_objects",
+          "id": "state-invariant-3-clause-2",
+          "order_index": 2,
+          "parent_invariant_id": "state-invariant-3",
+          "parent_invariant_semantic_id": "state-invariant-3",
+          "semantic_id": "state-invariant-3-clause-obligation-record-contract-dates",
+          "text": "Record contract dates.",
+          "title": "Record contract dates"
+        }
+      ],
       "missing_fields": [],
       "name": "Rule 3",
       "normative_ready": true,

--- a/examples/it-systems-inventory-v2/model/rupify-model.json
+++ b/examples/it-systems-inventory-v2/model/rupify-model.json
@@ -995,13 +995,14 @@
           "change_source": "derived_domain_invariants",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "a0838e2d92556587",
+          "semantic_hash": "f86b8e56c059947a",
           "semantic_version": 1,
           "supersedes": []
         },
         "content_semantics": "normative",
         "description": "A System must have a business owner before it becomes Active.",
         "id": "domain-invariant-1",
+        "invariant_clauses": [],
         "model_layer": "analysis",
         "name": "Rule 1",
         "readiness": {
@@ -1028,13 +1029,14 @@
           "change_source": "derived_domain_invariants",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "0faa9d909ed4effe",
+          "semantic_hash": "10237eaa6ca821d7",
           "semantic_version": 1,
           "supersedes": []
         },
         "content_semantics": "normative",
         "description": "A System lifecycle state change requires approval for deprecation.",
         "id": "domain-invariant-2",
+        "invariant_clauses": [],
         "model_layer": "analysis",
         "name": "Rule 2",
         "readiness": {
@@ -1061,13 +1063,37 @@
           "change_source": "derived_domain_invariants",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "ae58a8512d9d5819",
+          "semantic_hash": "9595d29dc493d82e",
           "semantic_version": 1,
           "supersedes": []
         },
         "content_semantics": "normative",
         "description": "A System must record vendor and contract dates.",
         "id": "domain-invariant-3",
+        "invariant_clauses": [
+          {
+            "clause_kind": "obligation",
+            "derivation_basis": "shared_verb_objects",
+            "id": "domain-invariant-3-clause-1",
+            "order_index": 1,
+            "parent_invariant_id": "domain-invariant-3",
+            "parent_invariant_semantic_id": "domain-invariant-3",
+            "semantic_id": "domain-invariant-3-clause-obligation-record-vendor",
+            "text": "Record vendor.",
+            "title": "Record vendor"
+          },
+          {
+            "clause_kind": "obligation",
+            "derivation_basis": "shared_verb_objects",
+            "id": "domain-invariant-3-clause-2",
+            "order_index": 2,
+            "parent_invariant_id": "domain-invariant-3",
+            "parent_invariant_semantic_id": "domain-invariant-3",
+            "semantic_id": "domain-invariant-3-clause-obligation-record-contract-dates",
+            "text": "Record contract dates.",
+            "title": "Record contract dates"
+          }
+        ],
         "model_layer": "analysis",
         "name": "Rule 3",
         "readiness": {
@@ -1849,13 +1875,14 @@
           "change_source": "derived_state_invariants",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "e99d374908167c66",
+          "semantic_hash": "6cd13106207f8897",
           "semantic_version": 1,
           "supersedes": []
         },
         "content_semantics": "normative",
         "description": "A System must have a business owner before it becomes Active.",
         "id": "state-invariant-1",
+        "invariant_clauses": [],
         "model_layer": "analysis",
         "name": "Rule 1",
         "readiness": {
@@ -1882,13 +1909,14 @@
           "change_source": "derived_state_invariants",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "d3f0734ba4f5d238",
+          "semantic_hash": "04bf083cf9ba66fd",
           "semantic_version": 1,
           "supersedes": []
         },
         "content_semantics": "normative",
         "description": "A System lifecycle state change requires approval for deprecation.",
         "id": "state-invariant-2",
+        "invariant_clauses": [],
         "model_layer": "analysis",
         "name": "Rule 2",
         "readiness": {
@@ -1915,13 +1943,37 @@
           "change_source": "derived_state_invariants",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "86c22df4bc630d1b",
+          "semantic_hash": "3fac42f8e26890a5",
           "semantic_version": 1,
           "supersedes": []
         },
         "content_semantics": "normative",
         "description": "A System must record vendor and contract dates.",
         "id": "state-invariant-3",
+        "invariant_clauses": [
+          {
+            "clause_kind": "obligation",
+            "derivation_basis": "shared_verb_objects",
+            "id": "state-invariant-3-clause-1",
+            "order_index": 1,
+            "parent_invariant_id": "state-invariant-3",
+            "parent_invariant_semantic_id": "state-invariant-3",
+            "semantic_id": "state-invariant-3-clause-obligation-record-vendor",
+            "text": "Record vendor.",
+            "title": "Record vendor"
+          },
+          {
+            "clause_kind": "obligation",
+            "derivation_basis": "shared_verb_objects",
+            "id": "state-invariant-3-clause-2",
+            "order_index": 2,
+            "parent_invariant_id": "state-invariant-3",
+            "parent_invariant_semantic_id": "state-invariant-3",
+            "semantic_id": "state-invariant-3-clause-obligation-record-contract-dates",
+            "text": "Record contract dates.",
+            "title": "Record contract dates"
+          }
+        ],
         "model_layer": "analysis",
         "name": "Rule 3",
         "readiness": {
@@ -3842,13 +3894,14 @@
           "change_source": "derived_domain_invariants",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "a0838e2d92556587",
+          "semantic_hash": "f86b8e56c059947a",
           "semantic_version": 1,
           "supersedes": []
         },
         "content_semantics": "normative",
         "description": "A System must have a business owner before it becomes Active.",
         "id": "domain-invariant-1",
+        "invariant_clauses": [],
         "model_layer": "analysis",
         "name": "Rule 1",
         "readiness": {
@@ -3875,13 +3928,14 @@
           "change_source": "derived_domain_invariants",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "0faa9d909ed4effe",
+          "semantic_hash": "10237eaa6ca821d7",
           "semantic_version": 1,
           "supersedes": []
         },
         "content_semantics": "normative",
         "description": "A System lifecycle state change requires approval for deprecation.",
         "id": "domain-invariant-2",
+        "invariant_clauses": [],
         "model_layer": "analysis",
         "name": "Rule 2",
         "readiness": {
@@ -3908,13 +3962,37 @@
           "change_source": "derived_domain_invariants",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "ae58a8512d9d5819",
+          "semantic_hash": "9595d29dc493d82e",
           "semantic_version": 1,
           "supersedes": []
         },
         "content_semantics": "normative",
         "description": "A System must record vendor and contract dates.",
         "id": "domain-invariant-3",
+        "invariant_clauses": [
+          {
+            "clause_kind": "obligation",
+            "derivation_basis": "shared_verb_objects",
+            "id": "domain-invariant-3-clause-1",
+            "order_index": 1,
+            "parent_invariant_id": "domain-invariant-3",
+            "parent_invariant_semantic_id": "domain-invariant-3",
+            "semantic_id": "domain-invariant-3-clause-obligation-record-vendor",
+            "text": "Record vendor.",
+            "title": "Record vendor"
+          },
+          {
+            "clause_kind": "obligation",
+            "derivation_basis": "shared_verb_objects",
+            "id": "domain-invariant-3-clause-2",
+            "order_index": 2,
+            "parent_invariant_id": "domain-invariant-3",
+            "parent_invariant_semantic_id": "domain-invariant-3",
+            "semantic_id": "domain-invariant-3-clause-obligation-record-contract-dates",
+            "text": "Record contract dates.",
+            "title": "Record contract dates"
+          }
+        ],
         "model_layer": "analysis",
         "name": "Rule 3",
         "readiness": {
@@ -4171,7 +4249,7 @@
       "change_source": "normalize_replay_to_model",
       "last_changed_at": "",
       "regenerated_from_version": "",
-      "semantic_hash": "e436559f48487608",
+      "semantic_hash": "50298153f054adc9",
       "semantic_version": 1,
       "supersedes": []
     },
@@ -4351,13 +4429,14 @@
           "change_source": "derived_state_invariants",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "e99d374908167c66",
+          "semantic_hash": "6cd13106207f8897",
           "semantic_version": 1,
           "supersedes": []
         },
         "content_semantics": "normative",
         "description": "A System must have a business owner before it becomes Active.",
         "id": "state-invariant-1",
+        "invariant_clauses": [],
         "model_layer": "analysis",
         "name": "Rule 1",
         "readiness": {
@@ -4384,13 +4463,14 @@
           "change_source": "derived_state_invariants",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "d3f0734ba4f5d238",
+          "semantic_hash": "04bf083cf9ba66fd",
           "semantic_version": 1,
           "supersedes": []
         },
         "content_semantics": "normative",
         "description": "A System lifecycle state change requires approval for deprecation.",
         "id": "state-invariant-2",
+        "invariant_clauses": [],
         "model_layer": "analysis",
         "name": "Rule 2",
         "readiness": {
@@ -4417,13 +4497,37 @@
           "change_source": "derived_state_invariants",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "86c22df4bc630d1b",
+          "semantic_hash": "3fac42f8e26890a5",
           "semantic_version": 1,
           "supersedes": []
         },
         "content_semantics": "normative",
         "description": "A System must record vendor and contract dates.",
         "id": "state-invariant-3",
+        "invariant_clauses": [
+          {
+            "clause_kind": "obligation",
+            "derivation_basis": "shared_verb_objects",
+            "id": "state-invariant-3-clause-1",
+            "order_index": 1,
+            "parent_invariant_id": "state-invariant-3",
+            "parent_invariant_semantic_id": "state-invariant-3",
+            "semantic_id": "state-invariant-3-clause-obligation-record-vendor",
+            "text": "Record vendor.",
+            "title": "Record vendor"
+          },
+          {
+            "clause_kind": "obligation",
+            "derivation_basis": "shared_verb_objects",
+            "id": "state-invariant-3-clause-2",
+            "order_index": 2,
+            "parent_invariant_id": "state-invariant-3",
+            "parent_invariant_semantic_id": "state-invariant-3",
+            "semantic_id": "state-invariant-3-clause-obligation-record-contract-dates",
+            "text": "Record contract dates.",
+            "title": "Record contract dates"
+          }
+        ],
         "model_layer": "analysis",
         "name": "Rule 3",
         "readiness": {

--- a/examples/loyalty-platform-v2/README.md
+++ b/examples/loyalty-platform-v2/README.md
@@ -52,7 +52,7 @@ This V2 export currently shows:
 - 0 blocking ambiguities
 - 0 duplicate exported element IDs
 - 0 unresolved trace references
-- explicit requirement obligations, step sub-actions, and guard parts where the upstream normalization can derive them safely
+- explicit requirement obligations, step sub-actions, guard parts, and invariant clauses where the upstream normalization can derive them safely
 
 ## Notes
 

--- a/examples/loyalty-platform-v2/bundle-manifest.json
+++ b/examples/loyalty-platform-v2/bundle-manifest.json
@@ -15,7 +15,7 @@
       "change_source": "normalize_replay_to_model",
       "last_changed_at": "",
       "regenerated_from_version": "",
-      "semantic_hash": "1e4a32ec4521ade8",
+      "semantic_hash": "90756bcad0c547de",
       "semantic_version": 1,
       "supersedes": []
     },

--- a/examples/loyalty-platform-v2/exports/speckify-planning-export.json
+++ b/examples/loyalty-platform-v2/exports/speckify-planning-export.json
@@ -701,13 +701,37 @@
         "change_source": "derived_domain_invariants",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "9bdd873c55f95c20",
+        "semantic_hash": "2afc06d3e2758687",
         "semantic_version": 1,
         "supersedes": []
       },
       "content_semantics": "normative",
       "family": "domain_invariants",
       "id": "domain-invariant-1",
+      "invariant_clauses": [
+        {
+          "clause_kind": "condition",
+          "derivation_basis": "unless_confirmed_clause",
+          "id": "domain-invariant-1-clause-1",
+          "order_index": 1,
+          "parent_invariant_id": "domain-invariant-1",
+          "parent_invariant_semantic_id": "domain-invariant-1",
+          "semantic_id": "domain-invariant-1-clause-condition-confirm-reward-eligibility",
+          "text": "Confirm reward eligibility before be fulfilled.",
+          "title": "Confirm reward eligibility"
+        },
+        {
+          "clause_kind": "condition",
+          "derivation_basis": "unless_confirmed_clause",
+          "id": "domain-invariant-1-clause-2",
+          "order_index": 2,
+          "parent_invariant_id": "domain-invariant-1",
+          "parent_invariant_semantic_id": "domain-invariant-1",
+          "semantic_id": "domain-invariant-1-clause-condition-confirm-available-points",
+          "text": "Confirm available points before be fulfilled.",
+          "title": "Confirm available points"
+        }
+      ],
       "missing_fields": [],
       "name": "Rule 1",
       "normative_ready": true,
@@ -730,7 +754,7 @@
         "change_source": "derived_domain_invariants",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "a637b3e22f50cdd4",
+        "semantic_hash": "276954ae842992f6",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -758,13 +782,37 @@
         "change_source": "derived_domain_invariants",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "c2cf041e428bfa76",
+        "semantic_hash": "0e3e986abe6be808",
         "semantic_version": 1,
         "supersedes": []
       },
       "content_semantics": "normative",
       "family": "domain_invariants",
       "id": "domain-invariant-3",
+      "invariant_clauses": [
+        {
+          "clause_kind": "obligation",
+          "derivation_basis": "shared_verb_objects",
+          "id": "domain-invariant-3-clause-1",
+          "order_index": 1,
+          "parent_invariant_id": "domain-invariant-3",
+          "parent_invariant_semantic_id": "domain-invariant-3",
+          "semantic_id": "domain-invariant-3-clause-obligation-provide-the-required-details",
+          "text": "Provide the required details before enrollment completes.",
+          "title": "Provide the required details"
+        },
+        {
+          "clause_kind": "obligation",
+          "derivation_basis": "shared_verb_objects",
+          "id": "domain-invariant-3-clause-2",
+          "order_index": 2,
+          "parent_invariant_id": "domain-invariant-3",
+          "parent_invariant_semantic_id": "domain-invariant-3",
+          "semantic_id": "domain-invariant-3-clause-obligation-provide-consents",
+          "text": "Provide consents before enrollment completes.",
+          "title": "Provide consents"
+        }
+      ],
       "missing_fields": [],
       "name": "Rule 3",
       "normative_ready": true,
@@ -2020,13 +2068,37 @@
         "change_source": "derived_state_invariants",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "1001f94a08fd8f05",
+        "semantic_hash": "3b43928758af0059",
         "semantic_version": 1,
         "supersedes": []
       },
       "content_semantics": "normative",
       "family": "state_invariants",
       "id": "state-invariant-1",
+      "invariant_clauses": [
+        {
+          "clause_kind": "condition",
+          "derivation_basis": "unless_confirmed_clause",
+          "id": "state-invariant-1-clause-1",
+          "order_index": 1,
+          "parent_invariant_id": "state-invariant-1",
+          "parent_invariant_semantic_id": "state-invariant-1",
+          "semantic_id": "state-invariant-1-clause-condition-confirm-reward-eligibility",
+          "text": "Confirm reward eligibility before be fulfilled.",
+          "title": "Confirm reward eligibility"
+        },
+        {
+          "clause_kind": "condition",
+          "derivation_basis": "unless_confirmed_clause",
+          "id": "state-invariant-1-clause-2",
+          "order_index": 2,
+          "parent_invariant_id": "state-invariant-1",
+          "parent_invariant_semantic_id": "state-invariant-1",
+          "semantic_id": "state-invariant-1-clause-condition-confirm-available-points",
+          "text": "Confirm available points before be fulfilled.",
+          "title": "Confirm available points"
+        }
+      ],
       "missing_fields": [],
       "name": "Rule 1",
       "normative_ready": true,
@@ -2048,7 +2120,7 @@
         "change_source": "derived_state_invariants",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "da255172f2fcc35e",
+        "semantic_hash": "df72932140694e3f",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -3245,7 +3317,7 @@
       "change_source": "normalize_replay_to_model",
       "last_changed_at": "",
       "regenerated_from_version": "",
-      "semantic_hash": "1e4a32ec4521ade8",
+      "semantic_hash": "90756bcad0c547de",
       "semantic_version": 1,
       "supersedes": []
     },
@@ -3522,13 +3594,37 @@
         "change_source": "derived_domain_invariants",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "9bdd873c55f95c20",
+        "semantic_hash": "2afc06d3e2758687",
         "semantic_version": 1,
         "supersedes": []
       },
       "content_semantics": "normative",
       "family": "domain_invariants",
       "id": "domain-invariant-1",
+      "invariant_clauses": [
+        {
+          "clause_kind": "condition",
+          "derivation_basis": "unless_confirmed_clause",
+          "id": "domain-invariant-1-clause-1",
+          "order_index": 1,
+          "parent_invariant_id": "domain-invariant-1",
+          "parent_invariant_semantic_id": "domain-invariant-1",
+          "semantic_id": "domain-invariant-1-clause-condition-confirm-reward-eligibility",
+          "text": "Confirm reward eligibility before be fulfilled.",
+          "title": "Confirm reward eligibility"
+        },
+        {
+          "clause_kind": "condition",
+          "derivation_basis": "unless_confirmed_clause",
+          "id": "domain-invariant-1-clause-2",
+          "order_index": 2,
+          "parent_invariant_id": "domain-invariant-1",
+          "parent_invariant_semantic_id": "domain-invariant-1",
+          "semantic_id": "domain-invariant-1-clause-condition-confirm-available-points",
+          "text": "Confirm available points before be fulfilled.",
+          "title": "Confirm available points"
+        }
+      ],
       "missing_fields": [],
       "name": "Rule 1",
       "normative_ready": true,
@@ -3551,7 +3647,7 @@
         "change_source": "derived_domain_invariants",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "a637b3e22f50cdd4",
+        "semantic_hash": "276954ae842992f6",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -3579,13 +3675,37 @@
         "change_source": "derived_domain_invariants",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "c2cf041e428bfa76",
+        "semantic_hash": "0e3e986abe6be808",
         "semantic_version": 1,
         "supersedes": []
       },
       "content_semantics": "normative",
       "family": "domain_invariants",
       "id": "domain-invariant-3",
+      "invariant_clauses": [
+        {
+          "clause_kind": "obligation",
+          "derivation_basis": "shared_verb_objects",
+          "id": "domain-invariant-3-clause-1",
+          "order_index": 1,
+          "parent_invariant_id": "domain-invariant-3",
+          "parent_invariant_semantic_id": "domain-invariant-3",
+          "semantic_id": "domain-invariant-3-clause-obligation-provide-the-required-details",
+          "text": "Provide the required details before enrollment completes.",
+          "title": "Provide the required details"
+        },
+        {
+          "clause_kind": "obligation",
+          "derivation_basis": "shared_verb_objects",
+          "id": "domain-invariant-3-clause-2",
+          "order_index": 2,
+          "parent_invariant_id": "domain-invariant-3",
+          "parent_invariant_semantic_id": "domain-invariant-3",
+          "semantic_id": "domain-invariant-3-clause-obligation-provide-consents",
+          "text": "Provide consents before enrollment completes.",
+          "title": "Provide consents"
+        }
+      ],
       "missing_fields": [],
       "name": "Rule 3",
       "normative_ready": true,
@@ -4160,13 +4280,37 @@
         "change_source": "derived_state_invariants",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "1001f94a08fd8f05",
+        "semantic_hash": "3b43928758af0059",
         "semantic_version": 1,
         "supersedes": []
       },
       "content_semantics": "normative",
       "family": "state_invariants",
       "id": "state-invariant-1",
+      "invariant_clauses": [
+        {
+          "clause_kind": "condition",
+          "derivation_basis": "unless_confirmed_clause",
+          "id": "state-invariant-1-clause-1",
+          "order_index": 1,
+          "parent_invariant_id": "state-invariant-1",
+          "parent_invariant_semantic_id": "state-invariant-1",
+          "semantic_id": "state-invariant-1-clause-condition-confirm-reward-eligibility",
+          "text": "Confirm reward eligibility before be fulfilled.",
+          "title": "Confirm reward eligibility"
+        },
+        {
+          "clause_kind": "condition",
+          "derivation_basis": "unless_confirmed_clause",
+          "id": "state-invariant-1-clause-2",
+          "order_index": 2,
+          "parent_invariant_id": "state-invariant-1",
+          "parent_invariant_semantic_id": "state-invariant-1",
+          "semantic_id": "state-invariant-1-clause-condition-confirm-available-points",
+          "text": "Confirm available points before be fulfilled.",
+          "title": "Confirm available points"
+        }
+      ],
       "missing_fields": [],
       "name": "Rule 1",
       "normative_ready": true,
@@ -4188,7 +4332,7 @@
         "change_source": "derived_state_invariants",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "da255172f2fcc35e",
+        "semantic_hash": "df72932140694e3f",
         "semantic_version": 1,
         "supersedes": []
       },

--- a/examples/loyalty-platform-v2/model/rupify-model.json
+++ b/examples/loyalty-platform-v2/model/rupify-model.json
@@ -767,13 +767,37 @@
           "change_source": "derived_domain_invariants",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "9bdd873c55f95c20",
+          "semantic_hash": "2afc06d3e2758687",
           "semantic_version": 1,
           "supersedes": []
         },
         "content_semantics": "normative",
         "description": "A Redemption must not be fulfilled unless reward eligibility and available points are confirmed.",
         "id": "domain-invariant-1",
+        "invariant_clauses": [
+          {
+            "clause_kind": "condition",
+            "derivation_basis": "unless_confirmed_clause",
+            "id": "domain-invariant-1-clause-1",
+            "order_index": 1,
+            "parent_invariant_id": "domain-invariant-1",
+            "parent_invariant_semantic_id": "domain-invariant-1",
+            "semantic_id": "domain-invariant-1-clause-condition-confirm-reward-eligibility",
+            "text": "Confirm reward eligibility before be fulfilled.",
+            "title": "Confirm reward eligibility"
+          },
+          {
+            "clause_kind": "condition",
+            "derivation_basis": "unless_confirmed_clause",
+            "id": "domain-invariant-1-clause-2",
+            "order_index": 2,
+            "parent_invariant_id": "domain-invariant-1",
+            "parent_invariant_semantic_id": "domain-invariant-1",
+            "semantic_id": "domain-invariant-1-clause-condition-confirm-available-points",
+            "text": "Confirm available points before be fulfilled.",
+            "title": "Confirm available points"
+          }
+        ],
         "model_layer": "analysis",
         "name": "Rule 1",
         "readiness": {
@@ -801,13 +825,14 @@
           "change_source": "derived_domain_invariants",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "a637b3e22f50cdd4",
+          "semantic_hash": "276954ae842992f6",
           "semantic_version": 1,
           "supersedes": []
         },
         "content_semantics": "normative",
         "description": "A Reward Catalog Entry must be validated before it becomes Published.",
         "id": "domain-invariant-2",
+        "invariant_clauses": [],
         "model_layer": "analysis",
         "name": "Rule 2",
         "readiness": {
@@ -835,13 +860,37 @@
           "change_source": "derived_domain_invariants",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "c2cf041e428bfa76",
+          "semantic_hash": "0e3e986abe6be808",
           "semantic_version": 1,
           "supersedes": []
         },
         "content_semantics": "normative",
         "description": "A Member must provide the required details and consents before enrollment completes.",
         "id": "domain-invariant-3",
+        "invariant_clauses": [
+          {
+            "clause_kind": "obligation",
+            "derivation_basis": "shared_verb_objects",
+            "id": "domain-invariant-3-clause-1",
+            "order_index": 1,
+            "parent_invariant_id": "domain-invariant-3",
+            "parent_invariant_semantic_id": "domain-invariant-3",
+            "semantic_id": "domain-invariant-3-clause-obligation-provide-the-required-details",
+            "text": "Provide the required details before enrollment completes.",
+            "title": "Provide the required details"
+          },
+          {
+            "clause_kind": "obligation",
+            "derivation_basis": "shared_verb_objects",
+            "id": "domain-invariant-3-clause-2",
+            "order_index": 2,
+            "parent_invariant_id": "domain-invariant-3",
+            "parent_invariant_semantic_id": "domain-invariant-3",
+            "semantic_id": "domain-invariant-3-clause-obligation-provide-consents",
+            "text": "Provide consents before enrollment completes.",
+            "title": "Provide consents"
+          }
+        ],
         "model_layer": "analysis",
         "name": "Rule 3",
         "readiness": {
@@ -1936,13 +1985,37 @@
           "change_source": "derived_state_invariants",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "1001f94a08fd8f05",
+          "semantic_hash": "3b43928758af0059",
           "semantic_version": 1,
           "supersedes": []
         },
         "content_semantics": "normative",
         "description": "A Redemption must not be fulfilled unless reward eligibility and available points are confirmed.",
         "id": "state-invariant-1",
+        "invariant_clauses": [
+          {
+            "clause_kind": "condition",
+            "derivation_basis": "unless_confirmed_clause",
+            "id": "state-invariant-1-clause-1",
+            "order_index": 1,
+            "parent_invariant_id": "state-invariant-1",
+            "parent_invariant_semantic_id": "state-invariant-1",
+            "semantic_id": "state-invariant-1-clause-condition-confirm-reward-eligibility",
+            "text": "Confirm reward eligibility before be fulfilled.",
+            "title": "Confirm reward eligibility"
+          },
+          {
+            "clause_kind": "condition",
+            "derivation_basis": "unless_confirmed_clause",
+            "id": "state-invariant-1-clause-2",
+            "order_index": 2,
+            "parent_invariant_id": "state-invariant-1",
+            "parent_invariant_semantic_id": "state-invariant-1",
+            "semantic_id": "state-invariant-1-clause-condition-confirm-available-points",
+            "text": "Confirm available points before be fulfilled.",
+            "title": "Confirm available points"
+          }
+        ],
         "model_layer": "analysis",
         "name": "Rule 1",
         "readiness": {
@@ -1969,13 +2042,14 @@
           "change_source": "derived_state_invariants",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "da255172f2fcc35e",
+          "semantic_hash": "df72932140694e3f",
           "semantic_version": 1,
           "supersedes": []
         },
         "content_semantics": "normative",
         "description": "A Reward Catalog Entry must be validated before it becomes Published.",
         "id": "state-invariant-2",
+        "invariant_clauses": [],
         "model_layer": "analysis",
         "name": "Rule 2",
         "readiness": {
@@ -5572,13 +5646,37 @@
           "change_source": "derived_domain_invariants",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "9bdd873c55f95c20",
+          "semantic_hash": "2afc06d3e2758687",
           "semantic_version": 1,
           "supersedes": []
         },
         "content_semantics": "normative",
         "description": "A Redemption must not be fulfilled unless reward eligibility and available points are confirmed.",
         "id": "domain-invariant-1",
+        "invariant_clauses": [
+          {
+            "clause_kind": "condition",
+            "derivation_basis": "unless_confirmed_clause",
+            "id": "domain-invariant-1-clause-1",
+            "order_index": 1,
+            "parent_invariant_id": "domain-invariant-1",
+            "parent_invariant_semantic_id": "domain-invariant-1",
+            "semantic_id": "domain-invariant-1-clause-condition-confirm-reward-eligibility",
+            "text": "Confirm reward eligibility before be fulfilled.",
+            "title": "Confirm reward eligibility"
+          },
+          {
+            "clause_kind": "condition",
+            "derivation_basis": "unless_confirmed_clause",
+            "id": "domain-invariant-1-clause-2",
+            "order_index": 2,
+            "parent_invariant_id": "domain-invariant-1",
+            "parent_invariant_semantic_id": "domain-invariant-1",
+            "semantic_id": "domain-invariant-1-clause-condition-confirm-available-points",
+            "text": "Confirm available points before be fulfilled.",
+            "title": "Confirm available points"
+          }
+        ],
         "model_layer": "analysis",
         "name": "Rule 1",
         "readiness": {
@@ -5606,13 +5704,14 @@
           "change_source": "derived_domain_invariants",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "a637b3e22f50cdd4",
+          "semantic_hash": "276954ae842992f6",
           "semantic_version": 1,
           "supersedes": []
         },
         "content_semantics": "normative",
         "description": "A Reward Catalog Entry must be validated before it becomes Published.",
         "id": "domain-invariant-2",
+        "invariant_clauses": [],
         "model_layer": "analysis",
         "name": "Rule 2",
         "readiness": {
@@ -5640,13 +5739,37 @@
           "change_source": "derived_domain_invariants",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "c2cf041e428bfa76",
+          "semantic_hash": "0e3e986abe6be808",
           "semantic_version": 1,
           "supersedes": []
         },
         "content_semantics": "normative",
         "description": "A Member must provide the required details and consents before enrollment completes.",
         "id": "domain-invariant-3",
+        "invariant_clauses": [
+          {
+            "clause_kind": "obligation",
+            "derivation_basis": "shared_verb_objects",
+            "id": "domain-invariant-3-clause-1",
+            "order_index": 1,
+            "parent_invariant_id": "domain-invariant-3",
+            "parent_invariant_semantic_id": "domain-invariant-3",
+            "semantic_id": "domain-invariant-3-clause-obligation-provide-the-required-details",
+            "text": "Provide the required details before enrollment completes.",
+            "title": "Provide the required details"
+          },
+          {
+            "clause_kind": "obligation",
+            "derivation_basis": "shared_verb_objects",
+            "id": "domain-invariant-3-clause-2",
+            "order_index": 2,
+            "parent_invariant_id": "domain-invariant-3",
+            "parent_invariant_semantic_id": "domain-invariant-3",
+            "semantic_id": "domain-invariant-3-clause-obligation-provide-consents",
+            "text": "Provide consents before enrollment completes.",
+            "title": "Provide consents"
+          }
+        ],
         "model_layer": "analysis",
         "name": "Rule 3",
         "readiness": {
@@ -5838,7 +5961,7 @@
       "change_source": "normalize_replay_to_model",
       "last_changed_at": "",
       "regenerated_from_version": "",
-      "semantic_hash": "1e4a32ec4521ade8",
+      "semantic_hash": "90756bcad0c547de",
       "semantic_version": 1,
       "supersedes": []
     },
@@ -6087,13 +6210,37 @@
           "change_source": "derived_state_invariants",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "1001f94a08fd8f05",
+          "semantic_hash": "3b43928758af0059",
           "semantic_version": 1,
           "supersedes": []
         },
         "content_semantics": "normative",
         "description": "A Redemption must not be fulfilled unless reward eligibility and available points are confirmed.",
         "id": "state-invariant-1",
+        "invariant_clauses": [
+          {
+            "clause_kind": "condition",
+            "derivation_basis": "unless_confirmed_clause",
+            "id": "state-invariant-1-clause-1",
+            "order_index": 1,
+            "parent_invariant_id": "state-invariant-1",
+            "parent_invariant_semantic_id": "state-invariant-1",
+            "semantic_id": "state-invariant-1-clause-condition-confirm-reward-eligibility",
+            "text": "Confirm reward eligibility before be fulfilled.",
+            "title": "Confirm reward eligibility"
+          },
+          {
+            "clause_kind": "condition",
+            "derivation_basis": "unless_confirmed_clause",
+            "id": "state-invariant-1-clause-2",
+            "order_index": 2,
+            "parent_invariant_id": "state-invariant-1",
+            "parent_invariant_semantic_id": "state-invariant-1",
+            "semantic_id": "state-invariant-1-clause-condition-confirm-available-points",
+            "text": "Confirm available points before be fulfilled.",
+            "title": "Confirm available points"
+          }
+        ],
         "model_layer": "analysis",
         "name": "Rule 1",
         "readiness": {
@@ -6120,13 +6267,14 @@
           "change_source": "derived_state_invariants",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "da255172f2fcc35e",
+          "semantic_hash": "df72932140694e3f",
           "semantic_version": 1,
           "supersedes": []
         },
         "content_semantics": "normative",
         "description": "A Reward Catalog Entry must be validated before it becomes Published.",
         "id": "state-invariant-2",
+        "invariant_clauses": [],
         "model_layer": "analysis",
         "name": "Rule 2",
         "readiness": {

--- a/skills/rupify/references/rupify-model.md
+++ b/skills/rupify/references/rupify-model.md
@@ -274,6 +274,16 @@ The canonical project model is `rupify-model.yaml`.
     - `id`
     - `name`
     - `description`
+    - `invariant_clauses`
+      - `id`
+      - `semantic_id`
+      - `clause_kind`
+      - `title`
+      - `text`
+      - `order_index`
+      - `parent_invariant_id`
+      - `parent_invariant_semantic_id`
+      - `derivation_basis`
     - `scope_entity_ids`
     - `source_business_rule_id`
     - `model_layer`: `analysis`
@@ -282,6 +292,16 @@ The canonical project model is `rupify-model.yaml`.
     - `id`
     - `name`
     - `description`
+    - `invariant_clauses`
+      - `id`
+      - `semantic_id`
+      - `clause_kind`
+      - `title`
+      - `text`
+      - `order_index`
+      - `parent_invariant_id`
+      - `parent_invariant_semantic_id`
+      - `derivation_basis`
     - `state_entity_ids`
     - `source_business_rule_id`
     - `model_layer`: `analysis`

--- a/src/rupify_tools/discovery.py
+++ b/src/rupify_tools/discovery.py
@@ -1138,6 +1138,99 @@ def _bind_guard_parts(guard_objects: list[dict[str, Any]]) -> None:
             guard_part["parent_guard_semantic_id"] = parent_semantic_id
 
 
+def _build_invariant_clause(
+    *,
+    clause_kind: str,
+    title: str,
+    text: str,
+    derivation_basis: str,
+) -> dict[str, Any]:
+    """Build one normalized invariant clause record."""
+    return {
+        "id": "",
+        "semantic_id": "",
+        "clause_kind": clause_kind,
+        "title": title,
+        "text": text.strip(),
+        "order_index": 0,
+        "parent_invariant_id": "",
+        "parent_invariant_semantic_id": "",
+        "derivation_basis": derivation_basis,
+    }
+
+
+def _derive_invariant_clauses(description: str) -> list[dict[str, Any]]:
+    """Derive conservative structured invariant clauses from explicit invariant patterns."""
+    cleaned = _clean_sentence(description)
+    if not cleaned or " and " not in cleaned:
+        return []
+
+    unless_match = re.match(
+        r"^(?P<subject>.+?) must not (?P<outcome>.+?) unless (?P<objects>.+?) are confirmed$",
+        cleaned,
+        flags=re.IGNORECASE,
+    )
+    if unless_match:
+        outcome = unless_match.group("outcome").strip()
+        objects, _ = _split_conjoined_objects(unless_match.group("objects"))
+        if len(objects) < 2:
+            return []
+        return [
+            _build_invariant_clause(
+                clause_kind="condition",
+                title=f"Confirm {item}",
+                text=f"Confirm {item} before {outcome}.",
+                derivation_basis="unless_confirmed_clause",
+            )
+            for item in objects
+        ]
+
+    direct_match = re.match(
+        r"^(?P<subject>.+?) must (?P<action>.+)$",
+        cleaned,
+        flags=re.IGNORECASE,
+    )
+    if not direct_match:
+        return []
+
+    action = direct_match.group("action").strip()
+    for prefix in ("record", "provide"):
+        prefix_with_space = f"{prefix} "
+        if not action.lower().startswith(prefix_with_space):
+            continue
+        objects, suffix = _split_conjoined_objects(action[len(prefix_with_space) :])
+        if len(objects) < 2:
+            continue
+        return [
+            _build_invariant_clause(
+                clause_kind="obligation",
+                title=f"{prefix.capitalize()} {item}",
+                text=f"{prefix.capitalize()} {item}{suffix}.",
+                derivation_basis="shared_verb_objects",
+            )
+            for item in objects
+        ]
+
+    return []
+
+
+def _bind_invariant_clauses(invariant_objects: list[dict[str, Any]]) -> None:
+    """Bind ids, semantic ids, lineage, and ordering onto nested invariant clauses."""
+    for invariant in invariant_objects:
+        parent_id = invariant.get("id", "")
+        parent_semantic_id = invariant.get("semantic_id", parent_id)
+        for index, clause in enumerate(invariant.get("invariant_clauses", []), 1):
+            clause_kind = clause.get("clause_kind", f"clause-{index}")
+            title = clause.get("title", f"Clause {index}")
+            clause["id"] = f"{parent_id}-clause-{index}"
+            clause["semantic_id"] = (
+                f"{parent_semantic_id}-clause-{clause_kind}-{_slugify(title)}"
+            )
+            clause["order_index"] = index
+            clause["parent_invariant_id"] = parent_id
+            clause["parent_invariant_semantic_id"] = parent_semantic_id
+
+
 def _split_structured_parts(item: str) -> list[str]:
     """Split a pipe-delimited structured answer into trimmed parts."""
     return [part.strip() for part in item.split("|") if part.strip()]
@@ -1402,6 +1495,7 @@ def _build_domain_invariant_objects(
                 "id": f"domain-invariant-{index}",
                 "name": rule.get("name", f"Domain Invariant {index}"),
                 "description": rule_text,
+                "invariant_clauses": _derive_invariant_clauses(rule_text),
                 "scope_entity_ids": _matched_object_ids(
                     " ".join(part for part in (rule.get("scope", ""), rule_text) if part),
                     domain_entities,
@@ -1433,6 +1527,7 @@ def _build_state_invariant_objects(
                 "id": f"state-invariant-{index}",
                 "name": rule.get("name", f"State Invariant {index}"),
                 "description": rule_text,
+                "invariant_clauses": _derive_invariant_clauses(rule_text),
                 "state_entity_ids": matched_state_ids,
                 "source_business_rule_id": rule.get("id", ""),
                 "model_layer": "analysis",
@@ -2515,6 +2610,8 @@ def normalize_replay_to_model(replay: dict[str, Any]) -> dict[str, Any]:
     _stamp_semantic_identity(business_rule_objects, change_source="round_5")
     _stamp_semantic_identity(domain_invariant_objects, change_source="derived_domain_invariants")
     _stamp_semantic_identity(state_invariant_objects, change_source="derived_state_invariants")
+    _bind_invariant_clauses(domain_invariant_objects)
+    _bind_invariant_clauses(state_invariant_objects)
     _stamp_semantic_identity(state_entity_objects, change_source="round_6")
     _stamp_semantic_identity(state_transition_objects, change_source="round_6")
     _stamp_semantic_identity(trigger_objects, change_source="round_6")

--- a/src/rupify_tools/planning_export.py
+++ b/src/rupify_tools/planning_export.py
@@ -184,6 +184,25 @@ def _export_guard_parts(item: dict[str, Any]) -> list[dict[str, Any]]:
     ]
 
 
+def _export_invariant_clauses(item: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return exported invariant-clause records for one canonical element."""
+    return [
+        {
+            "id": clause.get("id", ""),
+            "semantic_id": clause.get("semantic_id", clause.get("id", "")),
+            "clause_kind": clause.get("clause_kind", ""),
+            "title": clause.get("title", ""),
+            "text": clause.get("text", ""),
+            "order_index": clause.get("order_index", 0),
+            "parent_invariant_id": clause.get("parent_invariant_id", ""),
+            "parent_invariant_semantic_id": clause.get("parent_invariant_semantic_id", ""),
+            "derivation_basis": clause.get("derivation_basis", ""),
+        }
+        for clause in item.get("invariant_clauses", [])
+        if isinstance(clause, dict)
+    ]
+
+
 def _export_element(item: dict[str, Any], family: str) -> dict[str, Any]:
     """Convert one canonical element into the planning export shape."""
     readiness = item.get("readiness", {})
@@ -213,6 +232,9 @@ def _export_element(item: dict[str, Any], family: str) -> dict[str, Any]:
     guard_parts = _export_guard_parts(item)
     if guard_parts:
         exported["guard_parts"] = guard_parts
+    invariant_clauses = _export_invariant_clauses(item)
+    if invariant_clauses:
+        exported["invariant_clauses"] = invariant_clauses
     return exported
 
 

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1205,3 +1205,59 @@ class DiscoveryTests(unittest.TestCase):
             [item["part_kind"] for item in guard_objects[2]["guard_parts"]],
             ["context", "condition", "block_outcome"],
         )
+
+    def test_normalize_replay_to_model_derives_invariant_clauses(self) -> None:
+        """Invariant objects should expose explicit clauses for safe conjunctive patterns."""
+        replay = replay_session(
+            [
+                {
+                    "round": 5,
+                    "responses": [
+                        {"key": "domain_entities", "answer": ["System", "Member", "Redemption"]},
+                        {
+                            "key": "business_rules",
+                            "answer": [
+                                "A System must record vendor and contract dates.",
+                                "A Member must provide the required details and consents before enrollment completes.",
+                                "A Redemption must not be fulfilled unless reward eligibility and available points are confirmed.",
+                            ],
+                        },
+                    ],
+                },
+                {
+                    "round": 6,
+                    "responses": [
+                        {"key": "state_entities", "answer": ["Redemption"]},
+                        {
+                            "key": "states_and_transitions",
+                            "answer": ["Redemption: Requested -> Validated -> Fulfilled"],
+                        },
+                    ],
+                },
+            ]
+        )
+
+        model = normalize_replay_to_model(replay)
+        domain_invariants = model["logical_view"]["domain_invariant_objects"]
+        state_invariants = model["process_view"]["state_invariant_objects"]
+
+        self.assertEqual(
+            [item["title"] for item in domain_invariants[0]["invariant_clauses"]],
+            ["Record vendor", "Record contract dates"],
+        )
+        self.assertEqual(
+            [item["title"] for item in domain_invariants[1]["invariant_clauses"]],
+            ["Provide the required details", "Provide consents"],
+        )
+        self.assertEqual(
+            [item["title"] for item in domain_invariants[2]["invariant_clauses"]],
+            ["Confirm reward eligibility", "Confirm available points"],
+        )
+        self.assertEqual(
+            domain_invariants[2]["invariant_clauses"][0]["parent_invariant_id"],
+            "domain-invariant-3",
+        )
+        self.assertEqual(
+            [item["title"] for item in state_invariants[0]["invariant_clauses"]],
+            ["Confirm reward eligibility", "Confirm available points"],
+        )

--- a/tests/test_planning_export.py
+++ b/tests/test_planning_export.py
@@ -152,13 +152,74 @@ class PlanningExportTests(unittest.TestCase):
             "domain_entity_objects": [],
             "relationship_objects": [],
             "business_rule_objects": [],
-            "domain_invariant_objects": [],
+            "domain_invariant_objects": [
+                {
+                    "id": "domain-invariant-1",
+                    "semantic_id": "domain-invariant-1",
+                    "name": "Domain Invariant 1",
+                    "description": "A System must record vendor and contract dates.",
+                    "invariant_clauses": [
+                        {
+                            "id": "domain-invariant-1-clause-1",
+                            "semantic_id": "domain-invariant-1-clause-obligation-record-vendor",
+                            "clause_kind": "obligation",
+                            "title": "Record vendor",
+                            "text": "Record vendor.",
+                            "order_index": 1,
+                            "parent_invariant_id": "domain-invariant-1",
+                            "parent_invariant_semantic_id": "domain-invariant-1",
+                            "derivation_basis": "shared_verb_objects",
+                        }
+                    ],
+                    "content_semantics": "normative",
+                    "readiness": {
+                        "status": "ready",
+                        "normative_ready": True,
+                        "missing_fields": [],
+                        "blocking_ambiguity_ids": [],
+                    },
+                    "change_metadata": {"semantic_hash": "domaininvhash"},
+                    "trace": {"source_round": 5, "source_key": "business_rules"},
+                }
+            ],
         }
         model["process_view"] = {
             "state_entity_objects": [],
             "state_transition_objects": [],
             "trigger_objects": [],
-            "state_invariant_objects": [],
+            "state_invariant_objects": [
+                {
+                    "id": "state-invariant-1",
+                    "semantic_id": "state-invariant-1",
+                    "name": "State Invariant 1",
+                    "description": (
+                        "A Redemption must not be fulfilled unless reward eligibility and "
+                        "available points are confirmed."
+                    ),
+                    "invariant_clauses": [
+                        {
+                            "id": "state-invariant-1-clause-1",
+                            "semantic_id": "state-invariant-1-clause-condition-confirm-reward-eligibility",
+                            "clause_kind": "condition",
+                            "title": "Confirm reward eligibility",
+                            "text": "Confirm reward eligibility before be fulfilled.",
+                            "order_index": 1,
+                            "parent_invariant_id": "state-invariant-1",
+                            "parent_invariant_semantic_id": "state-invariant-1",
+                            "derivation_basis": "unless_confirmed_clause",
+                        }
+                    ],
+                    "content_semantics": "normative",
+                    "readiness": {
+                        "status": "ready",
+                        "normative_ready": True,
+                        "missing_fields": [],
+                        "blocking_ambiguity_ids": [],
+                    },
+                    "change_metadata": {"semantic_hash": "stateinvhash"},
+                    "trace": {"source_round": 5, "source_key": "business_rules"},
+                }
+            ],
             "guard_condition_objects": [
                 {
                     "id": "guard-condition-1",
@@ -287,7 +348,14 @@ class PlanningExportTests(unittest.TestCase):
         self.assertEqual(export["export_metadata"]["export_kind"], "speckify_planning_export")
         self.assertEqual(
             export["summary"]["ready_normative_ids"],
-            ["functional-requirement-1", "guard-condition-1", "uc-redeem-step-1", "uc-redeem"],
+            [
+                "domain-invariant-1",
+                "functional-requirement-1",
+                "guard-condition-1",
+                "state-invariant-1",
+                "uc-redeem-step-1",
+                "uc-redeem",
+            ],
         )
         self.assertEqual(export["summary"]["blocking_ambiguity_ids"], ["ambiguity-open-question-1"])
         self.assertEqual(
@@ -317,6 +385,12 @@ class PlanningExportTests(unittest.TestCase):
                 item for item in export["elements"] if item["id"] == "guard-condition-1"
             )["guard_parts"][0]["part_kind"],
             "context",
+        )
+        self.assertEqual(
+            next(
+                item for item in export["elements"] if item["id"] == "domain-invariant-1"
+            )["invariant_clauses"][0]["title"],
+            "Record vendor",
         )
         self.assertEqual(
             next(item for item in export["elements"] if item["id"] == "acceptance-constraint-1")["attributes"]["linked_use_case_ids"],
@@ -514,6 +588,29 @@ class PlanningExportTests(unittest.TestCase):
                 "Support integration with external systems with payment confirmation",
                 "Support integration with external systems with reporting sources",
             ],
+        )
+
+    def test_checked_in_loyalty_v2_export_includes_invariant_clauses(self) -> None:
+        """The checked-in loyalty V2 export should surface explicit invariant clauses."""
+        repo_root = Path(__file__).resolve().parents[1]
+        export_path = (
+            repo_root
+            / "examples"
+            / "loyalty-platform-v2"
+            / "exports"
+            / "speckify-planning-export.json"
+        )
+        payload = json.loads(export_path.read_text(encoding="utf-8"))
+        invariant = next(
+            item for item in payload["elements"] if item["id"] == "domain-invariant-1"
+        )
+        self.assertEqual(
+            [item["title"] for item in invariant["invariant_clauses"]],
+            ["Confirm reward eligibility", "Confirm available points"],
+        )
+        self.assertEqual(
+            invariant["invariant_clauses"][0]["derivation_basis"],
+            "unless_confirmed_clause",
         )
 
 


### PR DESCRIPTION
Closes #161

## Summary
- add canonical `invariant_clauses` to domain and state invariant objects for safe explicit invariant patterns
- bind stable ids, semantic ids, parent lineage, derivation basis, and ordering on those nested invariant clauses
- expose `invariant_clauses` in the Speckify planning export and refresh the checked-in V2 bundles

## Verification
- uv run python -m unittest tests.test_discovery tests.test_planning_export
- uv run python -m unittest
