### PR TITLE
Harden shared nested sub-part contract

### DIFF
--- a/docs/speckify-planning-export.md
+++ b/docs/speckify-planning-export.md
@@ -52,14 +52,23 @@ uv run rupify-export-planning \
     - `source_key`
     - `change_metadata`
     - `attributes`
+    - shared nested sub-part contract when present
+      - `id`
+      - `semantic_id`
+      - `order_index`
+      - parent lineage fields ending in `_id` and `_semantic_id`
+      - `derivation_basis`
     - optional `obligations` for requirement elements where Rupify has explicit normalized
       requirement sub-obligations
       - `id`
+      - `semantic_id`
       - `title`
       - `summary`
       - `acceptance`
+      - `order_index`
       - `parent_requirement_id`
       - `parent_requirement_semantic_id`
+      - `derivation_basis`
     - optional `sub_actions` for use-case step elements where Rupify has explicit normalized
       step sub-actions
       - `id`

--- a/examples/it-systems-inventory-v2/bundle-manifest.json
+++ b/examples/it-systems-inventory-v2/bundle-manifest.json
@@ -15,7 +15,7 @@
       "change_source": "normalize_replay_to_model",
       "last_changed_at": "",
       "regenerated_from_version": "",
-      "semantic_hash": "50298153f054adc9",
+      "semantic_hash": "51dcbc3465b3e466",
       "semantic_version": 1,
       "supersedes": []
     },

--- a/examples/it-systems-inventory-v2/exports/speckify-planning-export.json
+++ b/examples/it-systems-inventory-v2/exports/speckify-planning-export.json
@@ -834,7 +834,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "a3ef6c1c703ff787",
+        "semantic_hash": "2eb4641a951863cc",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -847,17 +847,23 @@
       "obligations": [
         {
           "acceptance": "Stage gates is supported.",
+          "derivation_basis": "supported_like_objects",
           "id": "support-stage-gates",
+          "order_index": 1,
           "parent_requirement_id": "functional-requirement-1",
           "parent_requirement_semantic_id": "functional-requirement-1",
+          "semantic_id": "functional-requirement-1-obligation-support-stage-gates",
           "summary": "Support stage gates.",
           "title": "Support stage gates"
         },
         {
           "acceptance": "Approval states is supported.",
+          "derivation_basis": "supported_like_objects",
           "id": "support-approval-states",
+          "order_index": 2,
           "parent_requirement_id": "functional-requirement-1",
           "parent_requirement_semantic_id": "functional-requirement-1",
+          "semantic_id": "functional-requirement-1-obligation-support-approval-states",
           "summary": "Support approval states.",
           "title": "Support approval states"
         }
@@ -2211,7 +2217,7 @@
       "change_source": "normalize_replay_to_model",
       "last_changed_at": "",
       "regenerated_from_version": "",
-      "semantic_hash": "50298153f054adc9",
+      "semantic_hash": "51dcbc3465b3e466",
       "semantic_version": 1,
       "supersedes": []
     },
@@ -2569,7 +2575,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "a3ef6c1c703ff787",
+        "semantic_hash": "2eb4641a951863cc",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -2582,17 +2588,23 @@
       "obligations": [
         {
           "acceptance": "Stage gates is supported.",
+          "derivation_basis": "supported_like_objects",
           "id": "support-stage-gates",
+          "order_index": 1,
           "parent_requirement_id": "functional-requirement-1",
           "parent_requirement_semantic_id": "functional-requirement-1",
+          "semantic_id": "functional-requirement-1-obligation-support-stage-gates",
           "summary": "Support stage gates.",
           "title": "Support stage gates"
         },
         {
           "acceptance": "Approval states is supported.",
+          "derivation_basis": "supported_like_objects",
           "id": "support-approval-states",
+          "order_index": 2,
           "parent_requirement_id": "functional-requirement-1",
           "parent_requirement_semantic_id": "functional-requirement-1",
+          "semantic_id": "functional-requirement-1-obligation-support-approval-states",
           "summary": "Support approval states.",
           "title": "Support approval states"
         }

--- a/examples/it-systems-inventory-v2/model/rupify-model.json
+++ b/examples/it-systems-inventory-v2/model/rupify-model.json
@@ -1474,7 +1474,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "a3ef6c1c703ff787",
+          "semantic_hash": "2eb4641a951863cc",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -1500,17 +1500,23 @@
         "sub_obligations": [
           {
             "acceptance": "Stage gates is supported.",
+            "derivation_basis": "supported_like_objects",
             "id": "support-stage-gates",
+            "order_index": 1,
             "parent_requirement_id": "functional-requirement-1",
             "parent_requirement_semantic_id": "functional-requirement-1",
+            "semantic_id": "functional-requirement-1-obligation-support-stage-gates",
             "summary": "Support stage gates.",
             "title": "Support stage gates"
           },
           {
             "acceptance": "Approval states is supported.",
+            "derivation_basis": "supported_like_objects",
             "id": "support-approval-states",
+            "order_index": 2,
             "parent_requirement_id": "functional-requirement-1",
             "parent_requirement_semantic_id": "functional-requirement-1",
+            "semantic_id": "functional-requirement-1-obligation-support-approval-states",
             "summary": "Support approval states.",
             "title": "Support approval states"
           }
@@ -4249,7 +4255,7 @@
       "change_source": "normalize_replay_to_model",
       "last_changed_at": "",
       "regenerated_from_version": "",
-      "semantic_hash": "50298153f054adc9",
+      "semantic_hash": "51dcbc3465b3e466",
       "semantic_version": 1,
       "supersedes": []
     },
@@ -5080,7 +5086,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "a3ef6c1c703ff787",
+          "semantic_hash": "2eb4641a951863cc",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -5106,17 +5112,23 @@
         "sub_obligations": [
           {
             "acceptance": "Stage gates is supported.",
+            "derivation_basis": "supported_like_objects",
             "id": "support-stage-gates",
+            "order_index": 1,
             "parent_requirement_id": "functional-requirement-1",
             "parent_requirement_semantic_id": "functional-requirement-1",
+            "semantic_id": "functional-requirement-1-obligation-support-stage-gates",
             "summary": "Support stage gates.",
             "title": "Support stage gates"
           },
           {
             "acceptance": "Approval states is supported.",
+            "derivation_basis": "supported_like_objects",
             "id": "support-approval-states",
+            "order_index": 2,
             "parent_requirement_id": "functional-requirement-1",
             "parent_requirement_semantic_id": "functional-requirement-1",
+            "semantic_id": "functional-requirement-1-obligation-support-approval-states",
             "summary": "Support approval states.",
             "title": "Support approval states"
           }

--- a/examples/loyalty-platform-v2/bundle-manifest.json
+++ b/examples/loyalty-platform-v2/bundle-manifest.json
@@ -15,7 +15,7 @@
       "change_source": "normalize_replay_to_model",
       "last_changed_at": "",
       "regenerated_from_version": "",
-      "semantic_hash": "90756bcad0c547de",
+      "semantic_hash": "fa990c5b15c56d66",
       "semantic_version": 1,
       "supersedes": []
     },

--- a/examples/loyalty-platform-v2/exports/speckify-planning-export.json
+++ b/examples/loyalty-platform-v2/exports/speckify-planning-export.json
@@ -856,7 +856,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "2e8b905f864b8055",
+        "semantic_hash": "5198864ebbe8f9c4",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -869,17 +869,23 @@
       "obligations": [
         {
           "acceptance": "Operations managers can maintain reward catalog entries.",
+          "derivation_basis": "allow_shared_verb_objects",
           "id": "maintain-reward-catalog-entries",
+          "order_index": 1,
           "parent_requirement_id": "functional-requirement-1",
           "parent_requirement_semantic_id": "functional-requirement-1",
+          "semantic_id": "functional-requirement-1-obligation-maintain-reward-catalog-entries",
           "summary": "Allow operations managers to maintain reward catalog entries.",
           "title": "Maintain reward catalog entries"
         },
         {
           "acceptance": "Operations managers can maintain campaign rules.",
+          "derivation_basis": "allow_shared_verb_objects",
           "id": "maintain-campaign-rules",
+          "order_index": 2,
           "parent_requirement_id": "functional-requirement-1",
           "parent_requirement_semantic_id": "functional-requirement-1",
+          "semantic_id": "functional-requirement-1-obligation-maintain-campaign-rules",
           "summary": "Allow operations managers to maintain campaign rules.",
           "title": "Maintain campaign rules"
         }
@@ -899,7 +905,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "dc3d2831f79f8c13",
+        "semantic_hash": "0921c4dc0a39584e",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -912,17 +918,23 @@
       "obligations": [
         {
           "acceptance": "Payment confirmation is supported.",
+          "derivation_basis": "direct_shared_verb_objects",
           "id": "integrate-with-payment-confirmation",
+          "order_index": 1,
           "parent_requirement_id": "functional-requirement-2",
           "parent_requirement_semantic_id": "functional-requirement-2",
+          "semantic_id": "functional-requirement-2-obligation-integrate-with-payment-confirmation",
           "summary": "Integrate with payment confirmation.",
           "title": "Integrate with payment confirmation"
         },
         {
           "acceptance": "Downstream reporting sources is supported.",
+          "derivation_basis": "direct_shared_verb_objects",
           "id": "integrate-with-downstream-reporting-sources",
+          "order_index": 2,
           "parent_requirement_id": "functional-requirement-2",
           "parent_requirement_semantic_id": "functional-requirement-2",
+          "semantic_id": "functional-requirement-2-obligation-integrate-with-downstream-reporting-sources",
           "summary": "Integrate with downstream reporting sources.",
           "title": "Integrate with downstream reporting sources"
         }
@@ -1391,7 +1403,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "9fce780019db01af",
+        "semantic_hash": "353a9e38972ecd9e",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -1404,17 +1416,23 @@
       "obligations": [
         {
           "acceptance": "Member with appropriate security controls is supported.",
+          "derivation_basis": "direct_shared_verb_objects",
           "id": "protect-member",
+          "order_index": 1,
           "parent_requirement_id": "non_functional-requirement-1",
           "parent_requirement_semantic_id": "non_functional-requirement-1",
+          "semantic_id": "non_functional-requirement-1-obligation-protect-member",
           "summary": "Protect member with appropriate security controls.",
           "title": "Protect member"
         },
         {
           "acceptance": "Reward transactions with appropriate security controls is supported.",
+          "derivation_basis": "direct_shared_verb_objects",
           "id": "protect-reward-transactions",
+          "order_index": 2,
           "parent_requirement_id": "non_functional-requirement-1",
           "parent_requirement_semantic_id": "non_functional-requirement-1",
+          "semantic_id": "non_functional-requirement-1-obligation-protect-reward-transactions",
           "summary": "Protect reward transactions with appropriate security controls.",
           "title": "Protect reward transactions"
         }
@@ -1459,7 +1477,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "6343566b4bf3c59c",
+        "semantic_hash": "6f01186e3c266a34",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -1472,17 +1490,23 @@
       "obligations": [
         {
           "acceptance": "Integration with external systems with payment confirmation is supported.",
+          "derivation_basis": "support_such_as_objects",
           "id": "support-integration-with-external-systems-with-payment-confirmation",
+          "order_index": 1,
           "parent_requirement_id": "non_functional-requirement-3",
           "parent_requirement_semantic_id": "non_functional-requirement-3",
+          "semantic_id": "non_functional-requirement-3-obligation-support-integration-with-external-systems-with-payment-confirmation",
           "summary": "Support integration with external systems with payment confirmation.",
           "title": "Support integration with external systems with payment confirmation"
         },
         {
           "acceptance": "Integration with external systems with reporting sources is supported.",
+          "derivation_basis": "support_such_as_objects",
           "id": "support-integration-with-external-systems-with-reporting-sources",
+          "order_index": 2,
           "parent_requirement_id": "non_functional-requirement-3",
           "parent_requirement_semantic_id": "non_functional-requirement-3",
+          "semantic_id": "non_functional-requirement-3-obligation-support-integration-with-external-systems-with-reporting-sources",
           "summary": "Support integration with external systems with reporting sources.",
           "title": "Support integration with external systems with reporting sources"
         }
@@ -1527,7 +1551,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "dd40814a68e5ea4c",
+        "semantic_hash": "99aaa1b6ee3250ee",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -1540,17 +1564,23 @@
       "obligations": [
         {
           "acceptance": "Point balance to eligible members is supported.",
+          "derivation_basis": "direct_shared_verb_objects",
           "id": "show-point-balance",
+          "order_index": 1,
           "parent_requirement_id": "non_functional-requirement-5",
           "parent_requirement_semantic_id": "non_functional-requirement-5",
+          "semantic_id": "non_functional-requirement-5-obligation-show-point-balance",
           "summary": "Show point balance to eligible members.",
           "title": "Show point balance"
         },
         {
           "acceptance": "Available rewards to eligible members is supported.",
+          "derivation_basis": "direct_shared_verb_objects",
           "id": "show-available-rewards",
+          "order_index": 2,
           "parent_requirement_id": "non_functional-requirement-5",
           "parent_requirement_semantic_id": "non_functional-requirement-5",
+          "semantic_id": "non_functional-requirement-5-obligation-show-available-rewards",
           "summary": "Show available rewards to eligible members.",
           "title": "Show available rewards"
         }
@@ -1598,7 +1628,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "0812eed1d3237b95",
+        "semantic_hash": "1aeb704af808832a",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -1611,17 +1641,23 @@
       "obligations": [
         {
           "acceptance": "Reporting on redemptions is supported.",
+          "derivation_basis": "direct_shared_verb_objects",
           "id": "provide-reporting-on-redemptions",
+          "order_index": 1,
           "parent_requirement_id": "non_functional-requirement-7",
           "parent_requirement_semantic_id": "non_functional-requirement-7",
+          "semantic_id": "non_functional-requirement-7-obligation-provide-reporting-on-redemptions",
           "summary": "Provide reporting on redemptions.",
           "title": "Provide reporting on redemptions"
         },
         {
           "acceptance": "Campaign performance is supported.",
+          "derivation_basis": "direct_shared_verb_objects",
           "id": "provide-campaign-performance",
+          "order_index": 2,
           "parent_requirement_id": "non_functional-requirement-7",
           "parent_requirement_semantic_id": "non_functional-requirement-7",
+          "semantic_id": "non_functional-requirement-7-obligation-provide-campaign-performance",
           "summary": "Provide campaign performance.",
           "title": "Provide campaign performance"
         }
@@ -3317,7 +3353,7 @@
       "change_source": "normalize_replay_to_model",
       "last_changed_at": "",
       "regenerated_from_version": "",
-      "semantic_hash": "90756bcad0c547de",
+      "semantic_hash": "fa990c5b15c56d66",
       "semantic_version": 1,
       "supersedes": []
     },
@@ -3749,7 +3785,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "2e8b905f864b8055",
+        "semantic_hash": "5198864ebbe8f9c4",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -3762,17 +3798,23 @@
       "obligations": [
         {
           "acceptance": "Operations managers can maintain reward catalog entries.",
+          "derivation_basis": "allow_shared_verb_objects",
           "id": "maintain-reward-catalog-entries",
+          "order_index": 1,
           "parent_requirement_id": "functional-requirement-1",
           "parent_requirement_semantic_id": "functional-requirement-1",
+          "semantic_id": "functional-requirement-1-obligation-maintain-reward-catalog-entries",
           "summary": "Allow operations managers to maintain reward catalog entries.",
           "title": "Maintain reward catalog entries"
         },
         {
           "acceptance": "Operations managers can maintain campaign rules.",
+          "derivation_basis": "allow_shared_verb_objects",
           "id": "maintain-campaign-rules",
+          "order_index": 2,
           "parent_requirement_id": "functional-requirement-1",
           "parent_requirement_semantic_id": "functional-requirement-1",
+          "semantic_id": "functional-requirement-1-obligation-maintain-campaign-rules",
           "summary": "Allow operations managers to maintain campaign rules.",
           "title": "Maintain campaign rules"
         }
@@ -3792,7 +3834,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "dc3d2831f79f8c13",
+        "semantic_hash": "0921c4dc0a39584e",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -3805,17 +3847,23 @@
       "obligations": [
         {
           "acceptance": "Payment confirmation is supported.",
+          "derivation_basis": "direct_shared_verb_objects",
           "id": "integrate-with-payment-confirmation",
+          "order_index": 1,
           "parent_requirement_id": "functional-requirement-2",
           "parent_requirement_semantic_id": "functional-requirement-2",
+          "semantic_id": "functional-requirement-2-obligation-integrate-with-payment-confirmation",
           "summary": "Integrate with payment confirmation.",
           "title": "Integrate with payment confirmation"
         },
         {
           "acceptance": "Downstream reporting sources is supported.",
+          "derivation_basis": "direct_shared_verb_objects",
           "id": "integrate-with-downstream-reporting-sources",
+          "order_index": 2,
           "parent_requirement_id": "functional-requirement-2",
           "parent_requirement_semantic_id": "functional-requirement-2",
+          "semantic_id": "functional-requirement-2-obligation-integrate-with-downstream-reporting-sources",
           "summary": "Integrate with downstream reporting sources.",
           "title": "Integrate with downstream reporting sources"
         }
@@ -3899,7 +3947,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "9fce780019db01af",
+        "semantic_hash": "353a9e38972ecd9e",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -3912,17 +3960,23 @@
       "obligations": [
         {
           "acceptance": "Member with appropriate security controls is supported.",
+          "derivation_basis": "direct_shared_verb_objects",
           "id": "protect-member",
+          "order_index": 1,
           "parent_requirement_id": "non_functional-requirement-1",
           "parent_requirement_semantic_id": "non_functional-requirement-1",
+          "semantic_id": "non_functional-requirement-1-obligation-protect-member",
           "summary": "Protect member with appropriate security controls.",
           "title": "Protect member"
         },
         {
           "acceptance": "Reward transactions with appropriate security controls is supported.",
+          "derivation_basis": "direct_shared_verb_objects",
           "id": "protect-reward-transactions",
+          "order_index": 2,
           "parent_requirement_id": "non_functional-requirement-1",
           "parent_requirement_semantic_id": "non_functional-requirement-1",
+          "semantic_id": "non_functional-requirement-1-obligation-protect-reward-transactions",
           "summary": "Protect reward transactions with appropriate security controls.",
           "title": "Protect reward transactions"
         }
@@ -3967,7 +4021,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "6343566b4bf3c59c",
+        "semantic_hash": "6f01186e3c266a34",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -3980,17 +4034,23 @@
       "obligations": [
         {
           "acceptance": "Integration with external systems with payment confirmation is supported.",
+          "derivation_basis": "support_such_as_objects",
           "id": "support-integration-with-external-systems-with-payment-confirmation",
+          "order_index": 1,
           "parent_requirement_id": "non_functional-requirement-3",
           "parent_requirement_semantic_id": "non_functional-requirement-3",
+          "semantic_id": "non_functional-requirement-3-obligation-support-integration-with-external-systems-with-payment-confirmation",
           "summary": "Support integration with external systems with payment confirmation.",
           "title": "Support integration with external systems with payment confirmation"
         },
         {
           "acceptance": "Integration with external systems with reporting sources is supported.",
+          "derivation_basis": "support_such_as_objects",
           "id": "support-integration-with-external-systems-with-reporting-sources",
+          "order_index": 2,
           "parent_requirement_id": "non_functional-requirement-3",
           "parent_requirement_semantic_id": "non_functional-requirement-3",
+          "semantic_id": "non_functional-requirement-3-obligation-support-integration-with-external-systems-with-reporting-sources",
           "summary": "Support integration with external systems with reporting sources.",
           "title": "Support integration with external systems with reporting sources"
         }
@@ -4035,7 +4095,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "dd40814a68e5ea4c",
+        "semantic_hash": "99aaa1b6ee3250ee",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -4048,17 +4108,23 @@
       "obligations": [
         {
           "acceptance": "Point balance to eligible members is supported.",
+          "derivation_basis": "direct_shared_verb_objects",
           "id": "show-point-balance",
+          "order_index": 1,
           "parent_requirement_id": "non_functional-requirement-5",
           "parent_requirement_semantic_id": "non_functional-requirement-5",
+          "semantic_id": "non_functional-requirement-5-obligation-show-point-balance",
           "summary": "Show point balance to eligible members.",
           "title": "Show point balance"
         },
         {
           "acceptance": "Available rewards to eligible members is supported.",
+          "derivation_basis": "direct_shared_verb_objects",
           "id": "show-available-rewards",
+          "order_index": 2,
           "parent_requirement_id": "non_functional-requirement-5",
           "parent_requirement_semantic_id": "non_functional-requirement-5",
+          "semantic_id": "non_functional-requirement-5-obligation-show-available-rewards",
           "summary": "Show available rewards to eligible members.",
           "title": "Show available rewards"
         }
@@ -4106,7 +4172,7 @@
         "change_source": "requirements",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "0812eed1d3237b95",
+        "semantic_hash": "1aeb704af808832a",
         "semantic_version": 1,
         "supersedes": []
       },
@@ -4119,17 +4185,23 @@
       "obligations": [
         {
           "acceptance": "Reporting on redemptions is supported.",
+          "derivation_basis": "direct_shared_verb_objects",
           "id": "provide-reporting-on-redemptions",
+          "order_index": 1,
           "parent_requirement_id": "non_functional-requirement-7",
           "parent_requirement_semantic_id": "non_functional-requirement-7",
+          "semantic_id": "non_functional-requirement-7-obligation-provide-reporting-on-redemptions",
           "summary": "Provide reporting on redemptions.",
           "title": "Provide reporting on redemptions"
         },
         {
           "acceptance": "Campaign performance is supported.",
+          "derivation_basis": "direct_shared_verb_objects",
           "id": "provide-campaign-performance",
+          "order_index": 2,
           "parent_requirement_id": "non_functional-requirement-7",
           "parent_requirement_semantic_id": "non_functional-requirement-7",
+          "semantic_id": "non_functional-requirement-7-obligation-provide-campaign-performance",
           "summary": "Provide campaign performance.",
           "title": "Provide campaign performance"
         }

--- a/examples/loyalty-platform-v2/model/rupify-model.json
+++ b/examples/loyalty-platform-v2/model/rupify-model.json
@@ -1254,7 +1254,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "2e8b905f864b8055",
+          "semantic_hash": "5198864ebbe8f9c4",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -1280,17 +1280,23 @@
         "sub_obligations": [
           {
             "acceptance": "Operations managers can maintain reward catalog entries.",
+            "derivation_basis": "allow_shared_verb_objects",
             "id": "maintain-reward-catalog-entries",
+            "order_index": 1,
             "parent_requirement_id": "functional-requirement-1",
             "parent_requirement_semantic_id": "functional-requirement-1",
+            "semantic_id": "functional-requirement-1-obligation-maintain-reward-catalog-entries",
             "summary": "Allow operations managers to maintain reward catalog entries.",
             "title": "Maintain reward catalog entries"
           },
           {
             "acceptance": "Operations managers can maintain campaign rules.",
+            "derivation_basis": "allow_shared_verb_objects",
             "id": "maintain-campaign-rules",
+            "order_index": 2,
             "parent_requirement_id": "functional-requirement-1",
             "parent_requirement_semantic_id": "functional-requirement-1",
+            "semantic_id": "functional-requirement-1-obligation-maintain-campaign-rules",
             "summary": "Allow operations managers to maintain campaign rules.",
             "title": "Maintain campaign rules"
           }
@@ -1305,7 +1311,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "dc3d2831f79f8c13",
+          "semantic_hash": "0921c4dc0a39584e",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -1331,17 +1337,23 @@
         "sub_obligations": [
           {
             "acceptance": "Payment confirmation is supported.",
+            "derivation_basis": "direct_shared_verb_objects",
             "id": "integrate-with-payment-confirmation",
+            "order_index": 1,
             "parent_requirement_id": "functional-requirement-2",
             "parent_requirement_semantic_id": "functional-requirement-2",
+            "semantic_id": "functional-requirement-2-obligation-integrate-with-payment-confirmation",
             "summary": "Integrate with payment confirmation.",
             "title": "Integrate with payment confirmation"
           },
           {
             "acceptance": "Downstream reporting sources is supported.",
+            "derivation_basis": "direct_shared_verb_objects",
             "id": "integrate-with-downstream-reporting-sources",
+            "order_index": 2,
             "parent_requirement_id": "functional-requirement-2",
             "parent_requirement_semantic_id": "functional-requirement-2",
+            "semantic_id": "functional-requirement-2-obligation-integrate-with-downstream-reporting-sources",
             "summary": "Integrate with downstream reporting sources.",
             "title": "Integrate with downstream reporting sources"
           }
@@ -1356,7 +1368,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "9fce780019db01af",
+          "semantic_hash": "353a9e38972ecd9e",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -1382,17 +1394,23 @@
         "sub_obligations": [
           {
             "acceptance": "Member with appropriate security controls is supported.",
+            "derivation_basis": "direct_shared_verb_objects",
             "id": "protect-member",
+            "order_index": 1,
             "parent_requirement_id": "non_functional-requirement-1",
             "parent_requirement_semantic_id": "non_functional-requirement-1",
+            "semantic_id": "non_functional-requirement-1-obligation-protect-member",
             "summary": "Protect member with appropriate security controls.",
             "title": "Protect member"
           },
           {
             "acceptance": "Reward transactions with appropriate security controls is supported.",
+            "derivation_basis": "direct_shared_verb_objects",
             "id": "protect-reward-transactions",
+            "order_index": 2,
             "parent_requirement_id": "non_functional-requirement-1",
             "parent_requirement_semantic_id": "non_functional-requirement-1",
+            "semantic_id": "non_functional-requirement-1-obligation-protect-reward-transactions",
             "summary": "Protect reward transactions with appropriate security controls.",
             "title": "Protect reward transactions"
           }
@@ -1441,7 +1459,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "6343566b4bf3c59c",
+          "semantic_hash": "6f01186e3c266a34",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -1467,17 +1485,23 @@
         "sub_obligations": [
           {
             "acceptance": "Integration with external systems with payment confirmation is supported.",
+            "derivation_basis": "support_such_as_objects",
             "id": "support-integration-with-external-systems-with-payment-confirmation",
+            "order_index": 1,
             "parent_requirement_id": "non_functional-requirement-3",
             "parent_requirement_semantic_id": "non_functional-requirement-3",
+            "semantic_id": "non_functional-requirement-3-obligation-support-integration-with-external-systems-with-payment-confirmation",
             "summary": "Support integration with external systems with payment confirmation.",
             "title": "Support integration with external systems with payment confirmation"
           },
           {
             "acceptance": "Integration with external systems with reporting sources is supported.",
+            "derivation_basis": "support_such_as_objects",
             "id": "support-integration-with-external-systems-with-reporting-sources",
+            "order_index": 2,
             "parent_requirement_id": "non_functional-requirement-3",
             "parent_requirement_semantic_id": "non_functional-requirement-3",
+            "semantic_id": "non_functional-requirement-3-obligation-support-integration-with-external-systems-with-reporting-sources",
             "summary": "Support integration with external systems with reporting sources.",
             "title": "Support integration with external systems with reporting sources"
           }
@@ -1526,7 +1550,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "dd40814a68e5ea4c",
+          "semantic_hash": "99aaa1b6ee3250ee",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -1552,17 +1576,23 @@
         "sub_obligations": [
           {
             "acceptance": "Point balance to eligible members is supported.",
+            "derivation_basis": "direct_shared_verb_objects",
             "id": "show-point-balance",
+            "order_index": 1,
             "parent_requirement_id": "non_functional-requirement-5",
             "parent_requirement_semantic_id": "non_functional-requirement-5",
+            "semantic_id": "non_functional-requirement-5-obligation-show-point-balance",
             "summary": "Show point balance to eligible members.",
             "title": "Show point balance"
           },
           {
             "acceptance": "Available rewards to eligible members is supported.",
+            "derivation_basis": "direct_shared_verb_objects",
             "id": "show-available-rewards",
+            "order_index": 2,
             "parent_requirement_id": "non_functional-requirement-5",
             "parent_requirement_semantic_id": "non_functional-requirement-5",
+            "semantic_id": "non_functional-requirement-5-obligation-show-available-rewards",
             "summary": "Show available rewards to eligible members.",
             "title": "Show available rewards"
           }
@@ -1613,7 +1643,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "0812eed1d3237b95",
+          "semantic_hash": "1aeb704af808832a",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -1639,17 +1669,23 @@
         "sub_obligations": [
           {
             "acceptance": "Reporting on redemptions is supported.",
+            "derivation_basis": "direct_shared_verb_objects",
             "id": "provide-reporting-on-redemptions",
+            "order_index": 1,
             "parent_requirement_id": "non_functional-requirement-7",
             "parent_requirement_semantic_id": "non_functional-requirement-7",
+            "semantic_id": "non_functional-requirement-7-obligation-provide-reporting-on-redemptions",
             "summary": "Provide reporting on redemptions.",
             "title": "Provide reporting on redemptions"
           },
           {
             "acceptance": "Campaign performance is supported.",
+            "derivation_basis": "direct_shared_verb_objects",
             "id": "provide-campaign-performance",
+            "order_index": 2,
             "parent_requirement_id": "non_functional-requirement-7",
             "parent_requirement_semantic_id": "non_functional-requirement-7",
+            "semantic_id": "non_functional-requirement-7-obligation-provide-campaign-performance",
             "summary": "Provide campaign performance.",
             "title": "Provide campaign performance"
           }
@@ -5961,7 +5997,7 @@
       "change_source": "normalize_replay_to_model",
       "last_changed_at": "",
       "regenerated_from_version": "",
-      "semantic_hash": "90756bcad0c547de",
+      "semantic_hash": "fa990c5b15c56d66",
       "semantic_version": 1,
       "supersedes": []
     },
@@ -6896,7 +6932,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "2e8b905f864b8055",
+          "semantic_hash": "5198864ebbe8f9c4",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -6922,17 +6958,23 @@
         "sub_obligations": [
           {
             "acceptance": "Operations managers can maintain reward catalog entries.",
+            "derivation_basis": "allow_shared_verb_objects",
             "id": "maintain-reward-catalog-entries",
+            "order_index": 1,
             "parent_requirement_id": "functional-requirement-1",
             "parent_requirement_semantic_id": "functional-requirement-1",
+            "semantic_id": "functional-requirement-1-obligation-maintain-reward-catalog-entries",
             "summary": "Allow operations managers to maintain reward catalog entries.",
             "title": "Maintain reward catalog entries"
           },
           {
             "acceptance": "Operations managers can maintain campaign rules.",
+            "derivation_basis": "allow_shared_verb_objects",
             "id": "maintain-campaign-rules",
+            "order_index": 2,
             "parent_requirement_id": "functional-requirement-1",
             "parent_requirement_semantic_id": "functional-requirement-1",
+            "semantic_id": "functional-requirement-1-obligation-maintain-campaign-rules",
             "summary": "Allow operations managers to maintain campaign rules.",
             "title": "Maintain campaign rules"
           }
@@ -6947,7 +6989,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "dc3d2831f79f8c13",
+          "semantic_hash": "0921c4dc0a39584e",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -6973,17 +7015,23 @@
         "sub_obligations": [
           {
             "acceptance": "Payment confirmation is supported.",
+            "derivation_basis": "direct_shared_verb_objects",
             "id": "integrate-with-payment-confirmation",
+            "order_index": 1,
             "parent_requirement_id": "functional-requirement-2",
             "parent_requirement_semantic_id": "functional-requirement-2",
+            "semantic_id": "functional-requirement-2-obligation-integrate-with-payment-confirmation",
             "summary": "Integrate with payment confirmation.",
             "title": "Integrate with payment confirmation"
           },
           {
             "acceptance": "Downstream reporting sources is supported.",
+            "derivation_basis": "direct_shared_verb_objects",
             "id": "integrate-with-downstream-reporting-sources",
+            "order_index": 2,
             "parent_requirement_id": "functional-requirement-2",
             "parent_requirement_semantic_id": "functional-requirement-2",
+            "semantic_id": "functional-requirement-2-obligation-integrate-with-downstream-reporting-sources",
             "summary": "Integrate with downstream reporting sources.",
             "title": "Integrate with downstream reporting sources"
           }
@@ -7009,7 +7057,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "9fce780019db01af",
+          "semantic_hash": "353a9e38972ecd9e",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -7035,17 +7083,23 @@
         "sub_obligations": [
           {
             "acceptance": "Member with appropriate security controls is supported.",
+            "derivation_basis": "direct_shared_verb_objects",
             "id": "protect-member",
+            "order_index": 1,
             "parent_requirement_id": "non_functional-requirement-1",
             "parent_requirement_semantic_id": "non_functional-requirement-1",
+            "semantic_id": "non_functional-requirement-1-obligation-protect-member",
             "summary": "Protect member with appropriate security controls.",
             "title": "Protect member"
           },
           {
             "acceptance": "Reward transactions with appropriate security controls is supported.",
+            "derivation_basis": "direct_shared_verb_objects",
             "id": "protect-reward-transactions",
+            "order_index": 2,
             "parent_requirement_id": "non_functional-requirement-1",
             "parent_requirement_semantic_id": "non_functional-requirement-1",
+            "semantic_id": "non_functional-requirement-1-obligation-protect-reward-transactions",
             "summary": "Protect reward transactions with appropriate security controls.",
             "title": "Protect reward transactions"
           }
@@ -7094,7 +7148,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "6343566b4bf3c59c",
+          "semantic_hash": "6f01186e3c266a34",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -7120,17 +7174,23 @@
         "sub_obligations": [
           {
             "acceptance": "Integration with external systems with payment confirmation is supported.",
+            "derivation_basis": "support_such_as_objects",
             "id": "support-integration-with-external-systems-with-payment-confirmation",
+            "order_index": 1,
             "parent_requirement_id": "non_functional-requirement-3",
             "parent_requirement_semantic_id": "non_functional-requirement-3",
+            "semantic_id": "non_functional-requirement-3-obligation-support-integration-with-external-systems-with-payment-confirmation",
             "summary": "Support integration with external systems with payment confirmation.",
             "title": "Support integration with external systems with payment confirmation"
           },
           {
             "acceptance": "Integration with external systems with reporting sources is supported.",
+            "derivation_basis": "support_such_as_objects",
             "id": "support-integration-with-external-systems-with-reporting-sources",
+            "order_index": 2,
             "parent_requirement_id": "non_functional-requirement-3",
             "parent_requirement_semantic_id": "non_functional-requirement-3",
+            "semantic_id": "non_functional-requirement-3-obligation-support-integration-with-external-systems-with-reporting-sources",
             "summary": "Support integration with external systems with reporting sources.",
             "title": "Support integration with external systems with reporting sources"
           }
@@ -7179,7 +7239,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "dd40814a68e5ea4c",
+          "semantic_hash": "99aaa1b6ee3250ee",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -7205,17 +7265,23 @@
         "sub_obligations": [
           {
             "acceptance": "Point balance to eligible members is supported.",
+            "derivation_basis": "direct_shared_verb_objects",
             "id": "show-point-balance",
+            "order_index": 1,
             "parent_requirement_id": "non_functional-requirement-5",
             "parent_requirement_semantic_id": "non_functional-requirement-5",
+            "semantic_id": "non_functional-requirement-5-obligation-show-point-balance",
             "summary": "Show point balance to eligible members.",
             "title": "Show point balance"
           },
           {
             "acceptance": "Available rewards to eligible members is supported.",
+            "derivation_basis": "direct_shared_verb_objects",
             "id": "show-available-rewards",
+            "order_index": 2,
             "parent_requirement_id": "non_functional-requirement-5",
             "parent_requirement_semantic_id": "non_functional-requirement-5",
+            "semantic_id": "non_functional-requirement-5-obligation-show-available-rewards",
             "summary": "Show available rewards to eligible members.",
             "title": "Show available rewards"
           }
@@ -7266,7 +7332,7 @@
           "change_source": "requirements",
           "last_changed_at": "",
           "regenerated_from_version": "",
-          "semantic_hash": "0812eed1d3237b95",
+          "semantic_hash": "1aeb704af808832a",
           "semantic_version": 1,
           "supersedes": []
         },
@@ -7292,17 +7358,23 @@
         "sub_obligations": [
           {
             "acceptance": "Reporting on redemptions is supported.",
+            "derivation_basis": "direct_shared_verb_objects",
             "id": "provide-reporting-on-redemptions",
+            "order_index": 1,
             "parent_requirement_id": "non_functional-requirement-7",
             "parent_requirement_semantic_id": "non_functional-requirement-7",
+            "semantic_id": "non_functional-requirement-7-obligation-provide-reporting-on-redemptions",
             "summary": "Provide reporting on redemptions.",
             "title": "Provide reporting on redemptions"
           },
           {
             "acceptance": "Campaign performance is supported.",
+            "derivation_basis": "direct_shared_verb_objects",
             "id": "provide-campaign-performance",
+            "order_index": 2,
             "parent_requirement_id": "non_functional-requirement-7",
             "parent_requirement_semantic_id": "non_functional-requirement-7",
+            "semantic_id": "non_functional-requirement-7-obligation-provide-campaign-performance",
             "summary": "Provide campaign performance.",
             "title": "Provide campaign performance"
           }

--- a/skills/rupify/references/rupify-model.md
+++ b/skills/rupify/references/rupify-model.md
@@ -14,6 +14,12 @@ The canonical project model is `rupify-model.yaml`.
     - `change_source`
     - `regenerated_from_version`
     - `supersedes`
+- shared sub-part contract for nested decomposition records
+  - `id`: stable local id within the parent element
+  - `semantic_id`: durable downstream identity derived from the parent semantic id plus the part slug
+  - `order_index`: explicit sequence position when multiple parts exist
+  - parent lineage fields ending in `_id` and `_semantic_id`
+  - `derivation_basis`: the deterministic normalization rule that created the part
 - `project`
   - `name`
   - `domain`
@@ -123,11 +129,14 @@ The canonical project model is `rupify-model.yaml`.
     - `fit_criterion`
     - `sub_obligations`
       - `id`
+      - `semantic_id`
       - `title`
       - `summary`
       - `acceptance`
+      - `order_index`
       - `parent_requirement_id`
       - `parent_requirement_semantic_id`
+      - `derivation_basis`
     - `trace`
     - `content_semantics`: `normative` or `informative`
     - `readiness`
@@ -143,11 +152,14 @@ The canonical project model is `rupify-model.yaml`.
     - `fit_criterion`
     - `sub_obligations`
       - `id`
+      - `semantic_id`
       - `title`
       - `summary`
       - `acceptance`
+      - `order_index`
       - `parent_requirement_id`
       - `parent_requirement_semantic_id`
+      - `derivation_basis`
     - `trace`
     - `content_semantics`: `normative` or `informative`
     - `readiness`

--- a/src/rupify_tools/discovery.py
+++ b/src/rupify_tools/discovery.py
@@ -751,15 +751,19 @@ def _build_sub_obligation(
     title: str,
     summary: str,
     acceptance: str,
-) -> dict[str, str]:
+    derivation_basis: str,
+) -> dict[str, Any]:
     """Build one normalized sub-obligation record."""
     return {
         "id": obligation_id,
+        "semantic_id": "",
         "title": title,
         "summary": summary,
         "acceptance": acceptance,
+        "order_index": 0,
         "parent_requirement_id": "",
         "parent_requirement_semantic_id": "",
+        "derivation_basis": derivation_basis,
     }
 
 
@@ -793,6 +797,7 @@ def _derive_requirement_sub_obligations(statement: str) -> list[dict[str, str]]:
                         title=title,
                         summary=f"Allow {actor} to {prefix} {item}{suffix}.",
                         acceptance=f"{_capitalize_phrase(actor)} can {prefix} {item}{suffix}.",
+                        derivation_basis="allow_shared_verb_objects",
                     )
                 )
             return obligations
@@ -820,6 +825,7 @@ def _derive_requirement_sub_obligations(statement: str) -> list[dict[str, str]]:
                         title=title,
                         summary=f"{prefix.capitalize()} {item}{suffix}.",
                         acceptance=f"{_capitalize_phrase(item)}{suffix} is supported.",
+                        derivation_basis="direct_shared_verb_objects",
                     )
                 )
             return obligations
@@ -842,6 +848,7 @@ def _derive_requirement_sub_obligations(statement: str) -> list[dict[str, str]]:
                     title=title,
                     summary=f"Support {item}.",
                     acceptance=f"{_capitalize_phrase(item)} is supported.",
+                    derivation_basis="supported_like_objects",
                 )
             )
         return obligations
@@ -869,6 +876,7 @@ def _derive_requirement_sub_obligations(statement: str) -> list[dict[str, str]]:
                     title=title,
                     summary=f"Support {singular_context} with {item}{suffix}.",
                     acceptance=f"{_capitalize_phrase(singular_context)} with {item}{suffix} is supported.",
+                    derivation_basis="support_such_as_objects",
                 )
             )
         return obligations
@@ -881,9 +889,14 @@ def _bind_requirement_sub_obligations(requirements: list[dict[str, Any]]) -> Non
     for requirement in requirements:
         parent_id = requirement.get("id", "")
         parent_semantic_id = requirement.get("semantic_id", parent_id)
-        for sub_obligation in requirement.get("sub_obligations", []):
+        for index, sub_obligation in enumerate(requirement.get("sub_obligations", []), 1):
+            obligation_id = sub_obligation.get("id", f"obligation-{index}")
             sub_obligation["parent_requirement_id"] = parent_id
             sub_obligation["parent_requirement_semantic_id"] = parent_semantic_id
+            sub_obligation["semantic_id"] = (
+                f"{parent_semantic_id}-obligation-{obligation_id}"
+            )
+            sub_obligation["order_index"] = index
 
 
 def _parse_step_clause(clause: str) -> tuple[str, str, str]:

--- a/src/rupify_tools/planning_export.py
+++ b/src/rupify_tools/planning_export.py
@@ -130,14 +130,17 @@ def _export_obligations(item: dict[str, Any]) -> list[dict[str, Any]]:
     return [
         {
             "id": obligation.get("id", ""),
+            "semantic_id": obligation.get("semantic_id", obligation.get("id", "")),
             "title": obligation.get("title", ""),
             "summary": obligation.get("summary", ""),
             "acceptance": obligation.get("acceptance", ""),
+            "order_index": obligation.get("order_index", 0),
             "parent_requirement_id": obligation.get("parent_requirement_id", ""),
             "parent_requirement_semantic_id": obligation.get(
                 "parent_requirement_semantic_id",
                 "",
             ),
+            "derivation_basis": obligation.get("derivation_basis", ""),
         }
         for obligation in item.get("sub_obligations", [])
         if isinstance(obligation, dict)

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -308,8 +308,17 @@ class DiscoveryTests(unittest.TestCase):
             ["Maintain reward catalog entries", "Maintain campaign rules"],
         )
         self.assertEqual(
+            functional_sub_obligations[0]["semantic_id"],
+            "functional-requirement-1-obligation-maintain-reward-catalog-entries",
+        )
+        self.assertEqual(
             functional_sub_obligations[0]["parent_requirement_id"],
             "functional-requirement-1",
+        )
+        self.assertEqual(functional_sub_obligations[0]["order_index"], 1)
+        self.assertEqual(
+            functional_sub_obligations[0]["derivation_basis"],
+            "allow_shared_verb_objects",
         )
         self.assertIn(
             "Operations managers can maintain reward catalog entries.",
@@ -364,6 +373,18 @@ class DiscoveryTests(unittest.TestCase):
                 "support-integration-with-external-systems-with-payment-confirmation",
                 "support-integration-with-external-systems-with-reporting-sources",
             ],
+        )
+        self.assertEqual(
+            sub_obligations[0]["semantic_id"],
+            (
+                "non_functional-requirement-1-obligation-"
+                "support-integration-with-external-systems-with-payment-confirmation"
+            ),
+        )
+        self.assertEqual(sub_obligations[1]["order_index"], 2)
+        self.assertEqual(
+            sub_obligations[0]["derivation_basis"],
+            "support_such_as_objects",
         )
 
     def test_normalize_replay_to_model_keeps_empty_sections_explicit(self) -> None:

--- a/tests/test_planning_export.py
+++ b/tests/test_planning_export.py
@@ -31,11 +31,14 @@ class PlanningExportTests(unittest.TestCase):
                     "sub_obligations": [
                         {
                             "id": "approve-system-changes",
+                            "semantic_id": "functional-requirement-1-obligation-approve-system-changes",
                             "title": "Approve system changes",
                             "summary": "Approve system changes.",
                             "acceptance": "System changes can be approved.",
+                            "order_index": 1,
                             "parent_requirement_id": "functional-requirement-1",
                             "parent_requirement_semantic_id": "functional-requirement-1",
+                            "derivation_basis": "test_fixture",
                         }
                     ],
                     "content_semantics": "normative",
@@ -376,6 +379,12 @@ class PlanningExportTests(unittest.TestCase):
         )
         self.assertEqual(
             next(
+                item for item in export["elements"] if item["id"] == "functional-requirement-1"
+            )["obligations"][0]["semantic_id"],
+            "functional-requirement-1-obligation-approve-system-changes",
+        )
+        self.assertEqual(
+            next(
                 item for item in export["elements"] if item["id"] == "uc-redeem-step-1"
             )["sub_actions"][0]["semantic_id"],
             "uc-redeem-step-1-action-select-reward",
@@ -514,6 +523,22 @@ class PlanningExportTests(unittest.TestCase):
             )["obligations"][1]["id"],
             "support-approval-states",
         )
+        self.assertEqual(
+            next(
+                item
+                for item in payload["elements"]
+                if item["id"] == "functional-requirement-1"
+            )["obligations"][0]["order_index"],
+            1,
+        )
+        self.assertEqual(
+            next(
+                item
+                for item in payload["elements"]
+                if item["id"] == "functional-requirement-1"
+            )["obligations"][0]["derivation_basis"],
+            "supported_like_objects",
+        )
 
     def test_checked_in_loyalty_v2_export_includes_step_sub_actions(self) -> None:
         """The checked-in loyalty V2 export should surface explicit step sub-actions."""
@@ -589,6 +614,14 @@ class PlanningExportTests(unittest.TestCase):
                 "Support integration with external systems with reporting sources",
             ],
         )
+        self.assertEqual(
+            requirement["obligations"][0]["semantic_id"],
+            (
+                "non_functional-requirement-3-obligation-"
+                "support-integration-with-external-systems-with-payment-confirmation"
+            ),
+        )
+        self.assertEqual(requirement["obligations"][1]["order_index"], 2)
 
     def test_checked_in_loyalty_v2_export_includes_invariant_clauses(self) -> None:
         """The checked-in loyalty V2 export should surface explicit invariant clauses."""


### PR DESCRIPTION
Closes #162

## Summary
- standardize requirement obligations onto the same identity, provenance, and ordering contract used by the other nested decomposition families
- refresh the checked-in V2 bundles so the published Speckify exports reflect the unified nested-part contract
- document the shared contract explicitly in the canonical model and planning-export docs

## Verification
- uv run python -m unittest tests.test_discovery tests.test_planning_export
- uv run python -m unittest
