### PR TITLE
Tighten readiness semantics for constraint shorthand

### DIFF
--- a/examples/it-systems-inventory-v2/artifacts/formal/requirements-spec.md
+++ b/examples/it-systems-inventory-v2/artifacts/formal/requirements-spec.md
@@ -37,14 +37,14 @@ We have many IT Systems and some overlap, some are free, some are expensive, all
 ## Acceptance Constraints
 
 - `acceptance-constraint-requirement-1` UI must be web based (semantics: normative; kind: non_functional_requirement; requirement: non_functional-requirement-1; readiness: ready; source: round 2 constraints)
-- `acceptance-constraint-requirement-2` SSO (semantics: normative; kind: non_functional_requirement; requirement: non_functional-requirement-2; readiness: ready; source: round 4 non_functional_requirements)
-- `acceptance-constraint-requirement-3` role-based access (semantics: normative; kind: non_functional_requirement; requirement: non_functional-requirement-3; readiness: ready; source: round 4 non_functional_requirements)
-- `acceptance-constraint-requirement-4` audit trail (semantics: normative; kind: non_functional_requirement; requirement: non_functional-requirement-4; readiness: ready; source: round 4 non_functional_requirements)
-- `acceptance-constraint-requirement-5` search (semantics: normative; kind: non_functional_requirement; requirement: non_functional-requirement-5; readiness: ready; source: round 4 non_functional_requirements)
-- `acceptance-constraint-requirement-6` filtering (semantics: normative; kind: non_functional_requirement; requirement: non_functional-requirement-6; readiness: ready; source: round 4 non_functional_requirements)
+- `acceptance-constraint-requirement-2` SSO (semantics: normative; kind: non_functional_requirement; requirement: non_functional-requirement-2; readiness: blocked; source: round 4 non_functional_requirements)
+- `acceptance-constraint-requirement-3` role-based access (semantics: normative; kind: non_functional_requirement; requirement: non_functional-requirement-3; readiness: blocked; source: round 4 non_functional_requirements)
+- `acceptance-constraint-requirement-4` audit trail (semantics: normative; kind: non_functional_requirement; requirement: non_functional-requirement-4; readiness: blocked; source: round 4 non_functional_requirements)
+- `acceptance-constraint-requirement-5` search (semantics: normative; kind: non_functional_requirement; requirement: non_functional-requirement-5; readiness: blocked; source: round 4 non_functional_requirements)
+- `acceptance-constraint-requirement-6` filtering (semantics: normative; kind: non_functional_requirement; requirement: non_functional-requirement-6; readiness: blocked; source: round 4 non_functional_requirements)
 - `acceptance-constraint-requirement-7` performance (regular >1s for web page rendering) (semantics: normative; kind: non_functional_requirement; requirement: non_functional-requirement-7; readiness: ready; source: round 4 non_functional_requirements)
 - `acceptance-constraint-requirement-8` availability >=99% (semantics: normative; kind: non_functional_requirement; requirement: non_functional-requirement-8; readiness: ready; source: round 4 non_functional_requirements)
-- `acceptance-constraint-success-1` Better planning of IT systems purchasing and life cycle (semantics: normative; kind: success_criterion; readiness: ready; source: round 2 success_criteria)
+- `acceptance-constraint-success-1` Better planning of IT systems purchasing and life cycle (semantics: normative; kind: success_criterion; readiness: blocked; source: round 2 success_criteria)
 
 
 ## Logical View

--- a/examples/it-systems-inventory-v2/bundle-manifest.json
+++ b/examples/it-systems-inventory-v2/bundle-manifest.json
@@ -15,7 +15,7 @@
       "change_source": "normalize_replay_to_model",
       "last_changed_at": "",
       "regenerated_from_version": "",
-      "semantic_hash": "51dcbc3465b3e466",
+      "semantic_hash": "a66d5f97f4bdfe16",
       "semantic_version": 1,
       "supersedes": []
     },

--- a/examples/it-systems-inventory-v2/exports/speckify-planning-export.json
+++ b/examples/it-systems-inventory-v2/exports/speckify-planning-export.json
@@ -44,10 +44,12 @@
       "content_semantics": "normative",
       "family": "acceptance_constraints",
       "id": "acceptance-constraint-requirement-2",
-      "missing_fields": [],
+      "missing_fields": [
+        "behavioral_semantics"
+      ],
       "name": "Acceptance Constraint 2",
-      "normative_ready": true,
-      "readiness_status": "ready",
+      "normative_ready": false,
+      "readiness_status": "blocked",
       "semantic_id": "acceptance-constraint-requirement-2",
       "source_key": "non_functional_requirements",
       "source_round": 4,
@@ -70,10 +72,12 @@
       "content_semantics": "normative",
       "family": "acceptance_constraints",
       "id": "acceptance-constraint-requirement-3",
-      "missing_fields": [],
+      "missing_fields": [
+        "behavioral_semantics"
+      ],
       "name": "Acceptance Constraint 3",
-      "normative_ready": true,
-      "readiness_status": "ready",
+      "normative_ready": false,
+      "readiness_status": "blocked",
       "semantic_id": "acceptance-constraint-requirement-3",
       "source_key": "non_functional_requirements",
       "source_round": 4,
@@ -96,10 +100,12 @@
       "content_semantics": "normative",
       "family": "acceptance_constraints",
       "id": "acceptance-constraint-requirement-4",
-      "missing_fields": [],
+      "missing_fields": [
+        "behavioral_semantics"
+      ],
       "name": "Acceptance Constraint 4",
-      "normative_ready": true,
-      "readiness_status": "ready",
+      "normative_ready": false,
+      "readiness_status": "blocked",
       "semantic_id": "acceptance-constraint-requirement-4",
       "source_key": "non_functional_requirements",
       "source_round": 4,
@@ -122,10 +128,12 @@
       "content_semantics": "normative",
       "family": "acceptance_constraints",
       "id": "acceptance-constraint-requirement-5",
-      "missing_fields": [],
+      "missing_fields": [
+        "behavioral_semantics"
+      ],
       "name": "Acceptance Constraint 5",
-      "normative_ready": true,
-      "readiness_status": "ready",
+      "normative_ready": false,
+      "readiness_status": "blocked",
       "semantic_id": "acceptance-constraint-requirement-5",
       "source_key": "non_functional_requirements",
       "source_round": 4,
@@ -148,10 +156,12 @@
       "content_semantics": "normative",
       "family": "acceptance_constraints",
       "id": "acceptance-constraint-requirement-6",
-      "missing_fields": [],
+      "missing_fields": [
+        "behavioral_semantics"
+      ],
       "name": "Acceptance Constraint 6",
-      "normative_ready": true,
-      "readiness_status": "ready",
+      "normative_ready": false,
+      "readiness_status": "blocked",
       "semantic_id": "acceptance-constraint-requirement-6",
       "source_key": "non_functional_requirements",
       "source_round": 4,
@@ -225,10 +235,12 @@
       "content_semantics": "normative",
       "family": "acceptance_constraints",
       "id": "acceptance-constraint-success-1",
-      "missing_fields": [],
+      "missing_fields": [
+        "behavioral_semantics"
+      ],
       "name": "Success Criterion 1",
-      "normative_ready": true,
-      "readiness_status": "ready",
+      "normative_ready": false,
+      "readiness_status": "blocked",
       "semantic_id": "acceptance-constraint-success-1",
       "source_key": "success_criteria",
       "source_round": 2,
@@ -1352,10 +1364,12 @@
       "content_semantics": "normative",
       "family": "non_functional_requirements",
       "id": "non_functional-requirement-2",
-      "missing_fields": [],
+      "missing_fields": [
+        "behavioral_semantics"
+      ],
       "name": "",
-      "normative_ready": true,
-      "readiness_status": "ready",
+      "normative_ready": false,
+      "readiness_status": "blocked",
       "semantic_id": "non_functional-requirement-2",
       "source_key": "non_functional_requirements",
       "source_round": 4,
@@ -1377,10 +1391,12 @@
       "content_semantics": "normative",
       "family": "non_functional_requirements",
       "id": "non_functional-requirement-3",
-      "missing_fields": [],
+      "missing_fields": [
+        "behavioral_semantics"
+      ],
       "name": "",
-      "normative_ready": true,
-      "readiness_status": "ready",
+      "normative_ready": false,
+      "readiness_status": "blocked",
       "semantic_id": "non_functional-requirement-3",
       "source_key": "non_functional_requirements",
       "source_round": 4,
@@ -1402,10 +1418,12 @@
       "content_semantics": "normative",
       "family": "non_functional_requirements",
       "id": "non_functional-requirement-4",
-      "missing_fields": [],
+      "missing_fields": [
+        "behavioral_semantics"
+      ],
       "name": "",
-      "normative_ready": true,
-      "readiness_status": "ready",
+      "normative_ready": false,
+      "readiness_status": "blocked",
       "semantic_id": "non_functional-requirement-4",
       "source_key": "non_functional_requirements",
       "source_round": 4,
@@ -1427,10 +1445,12 @@
       "content_semantics": "normative",
       "family": "non_functional_requirements",
       "id": "non_functional-requirement-5",
-      "missing_fields": [],
+      "missing_fields": [
+        "behavioral_semantics"
+      ],
       "name": "",
-      "normative_ready": true,
-      "readiness_status": "ready",
+      "normative_ready": false,
+      "readiness_status": "blocked",
       "semantic_id": "non_functional-requirement-5",
       "source_key": "non_functional_requirements",
       "source_round": 4,
@@ -1452,10 +1472,12 @@
       "content_semantics": "normative",
       "family": "non_functional_requirements",
       "id": "non_functional-requirement-6",
-      "missing_fields": [],
+      "missing_fields": [
+        "behavioral_semantics"
+      ],
       "name": "",
-      "normative_ready": true,
-      "readiness_status": "ready",
+      "normative_ready": false,
+      "readiness_status": "blocked",
       "semantic_id": "non_functional-requirement-6",
       "source_key": "non_functional_requirements",
       "source_round": 4,
@@ -2217,7 +2239,7 @@
       "change_source": "normalize_replay_to_model",
       "last_changed_at": "",
       "regenerated_from_version": "",
-      "semantic_hash": "51dcbc3465b3e466",
+      "semantic_hash": "a66d5f97f4bdfe16",
       "semantic_version": 1,
       "supersedes": []
     },
@@ -2249,136 +2271,6 @@
       "source_key": "constraints",
       "source_round": 2,
       "text": "UI must be web based"
-    },
-    {
-      "attributes": {
-        "constraint_kind": "non_functional_requirement",
-        "source_requirement_id": "non_functional-requirement-2"
-      },
-      "blocking_ambiguity_ids": [],
-      "change_metadata": {
-        "change_source": "derived_acceptance_constraints",
-        "last_changed_at": "",
-        "regenerated_from_version": "",
-        "semantic_hash": "cc8fa5e4dd1589f3",
-        "semantic_version": 1,
-        "supersedes": []
-      },
-      "content_semantics": "normative",
-      "family": "acceptance_constraints",
-      "id": "acceptance-constraint-requirement-2",
-      "missing_fields": [],
-      "name": "Acceptance Constraint 2",
-      "normative_ready": true,
-      "readiness_status": "ready",
-      "semantic_id": "acceptance-constraint-requirement-2",
-      "source_key": "non_functional_requirements",
-      "source_round": 4,
-      "text": "SSO"
-    },
-    {
-      "attributes": {
-        "constraint_kind": "non_functional_requirement",
-        "source_requirement_id": "non_functional-requirement-3"
-      },
-      "blocking_ambiguity_ids": [],
-      "change_metadata": {
-        "change_source": "derived_acceptance_constraints",
-        "last_changed_at": "",
-        "regenerated_from_version": "",
-        "semantic_hash": "b9a15e23c0db7d29",
-        "semantic_version": 1,
-        "supersedes": []
-      },
-      "content_semantics": "normative",
-      "family": "acceptance_constraints",
-      "id": "acceptance-constraint-requirement-3",
-      "missing_fields": [],
-      "name": "Acceptance Constraint 3",
-      "normative_ready": true,
-      "readiness_status": "ready",
-      "semantic_id": "acceptance-constraint-requirement-3",
-      "source_key": "non_functional_requirements",
-      "source_round": 4,
-      "text": "role-based access"
-    },
-    {
-      "attributes": {
-        "constraint_kind": "non_functional_requirement",
-        "source_requirement_id": "non_functional-requirement-4"
-      },
-      "blocking_ambiguity_ids": [],
-      "change_metadata": {
-        "change_source": "derived_acceptance_constraints",
-        "last_changed_at": "",
-        "regenerated_from_version": "",
-        "semantic_hash": "c27d4311ee7676d4",
-        "semantic_version": 1,
-        "supersedes": []
-      },
-      "content_semantics": "normative",
-      "family": "acceptance_constraints",
-      "id": "acceptance-constraint-requirement-4",
-      "missing_fields": [],
-      "name": "Acceptance Constraint 4",
-      "normative_ready": true,
-      "readiness_status": "ready",
-      "semantic_id": "acceptance-constraint-requirement-4",
-      "source_key": "non_functional_requirements",
-      "source_round": 4,
-      "text": "audit trail"
-    },
-    {
-      "attributes": {
-        "constraint_kind": "non_functional_requirement",
-        "source_requirement_id": "non_functional-requirement-5"
-      },
-      "blocking_ambiguity_ids": [],
-      "change_metadata": {
-        "change_source": "derived_acceptance_constraints",
-        "last_changed_at": "",
-        "regenerated_from_version": "",
-        "semantic_hash": "07c609485342104d",
-        "semantic_version": 1,
-        "supersedes": []
-      },
-      "content_semantics": "normative",
-      "family": "acceptance_constraints",
-      "id": "acceptance-constraint-requirement-5",
-      "missing_fields": [],
-      "name": "Acceptance Constraint 5",
-      "normative_ready": true,
-      "readiness_status": "ready",
-      "semantic_id": "acceptance-constraint-requirement-5",
-      "source_key": "non_functional_requirements",
-      "source_round": 4,
-      "text": "search"
-    },
-    {
-      "attributes": {
-        "constraint_kind": "non_functional_requirement",
-        "source_requirement_id": "non_functional-requirement-6"
-      },
-      "blocking_ambiguity_ids": [],
-      "change_metadata": {
-        "change_source": "derived_acceptance_constraints",
-        "last_changed_at": "",
-        "regenerated_from_version": "",
-        "semantic_hash": "ed67c4ace2e59e49",
-        "semantic_version": 1,
-        "supersedes": []
-      },
-      "content_semantics": "normative",
-      "family": "acceptance_constraints",
-      "id": "acceptance-constraint-requirement-6",
-      "missing_fields": [],
-      "name": "Acceptance Constraint 6",
-      "normative_ready": true,
-      "readiness_status": "ready",
-      "semantic_id": "acceptance-constraint-requirement-6",
-      "source_key": "non_functional_requirements",
-      "source_round": 4,
-      "text": "filtering"
     },
     {
       "attributes": {
@@ -2431,31 +2323,6 @@
       "source_key": "non_functional_requirements",
       "source_round": 4,
       "text": "availability >=99%"
-    },
-    {
-      "attributes": {
-        "constraint_kind": "success_criterion"
-      },
-      "blocking_ambiguity_ids": [],
-      "change_metadata": {
-        "change_source": "derived_acceptance_constraints",
-        "last_changed_at": "",
-        "regenerated_from_version": "",
-        "semantic_hash": "f58f7d91234137ac",
-        "semantic_version": 1,
-        "supersedes": []
-      },
-      "content_semantics": "normative",
-      "family": "acceptance_constraints",
-      "id": "acceptance-constraint-success-1",
-      "missing_fields": [],
-      "name": "Success Criterion 1",
-      "normative_ready": true,
-      "readiness_status": "ready",
-      "semantic_id": "acceptance-constraint-success-1",
-      "source_key": "success_criteria",
-      "source_round": 2,
-      "text": "Better planning of IT systems purchasing and life cycle"
     },
     {
       "attributes": {
@@ -2664,131 +2531,6 @@
       "source_key": "constraints",
       "source_round": 2,
       "text": "UI must be web based"
-    },
-    {
-      "attributes": {
-        "requirement_kind": "non_functional"
-      },
-      "blocking_ambiguity_ids": [],
-      "change_metadata": {
-        "change_source": "requirements",
-        "last_changed_at": "",
-        "regenerated_from_version": "",
-        "semantic_hash": "4777a0dcede17d97",
-        "semantic_version": 1,
-        "supersedes": []
-      },
-      "content_semantics": "normative",
-      "family": "non_functional_requirements",
-      "id": "non_functional-requirement-2",
-      "missing_fields": [],
-      "name": "",
-      "normative_ready": true,
-      "readiness_status": "ready",
-      "semantic_id": "non_functional-requirement-2",
-      "source_key": "non_functional_requirements",
-      "source_round": 4,
-      "text": "SSO"
-    },
-    {
-      "attributes": {
-        "requirement_kind": "non_functional"
-      },
-      "blocking_ambiguity_ids": [],
-      "change_metadata": {
-        "change_source": "requirements",
-        "last_changed_at": "",
-        "regenerated_from_version": "",
-        "semantic_hash": "5ce87fea5d01eec6",
-        "semantic_version": 1,
-        "supersedes": []
-      },
-      "content_semantics": "normative",
-      "family": "non_functional_requirements",
-      "id": "non_functional-requirement-3",
-      "missing_fields": [],
-      "name": "",
-      "normative_ready": true,
-      "readiness_status": "ready",
-      "semantic_id": "non_functional-requirement-3",
-      "source_key": "non_functional_requirements",
-      "source_round": 4,
-      "text": "role-based access"
-    },
-    {
-      "attributes": {
-        "requirement_kind": "non_functional"
-      },
-      "blocking_ambiguity_ids": [],
-      "change_metadata": {
-        "change_source": "requirements",
-        "last_changed_at": "",
-        "regenerated_from_version": "",
-        "semantic_hash": "1301748bdf90f823",
-        "semantic_version": 1,
-        "supersedes": []
-      },
-      "content_semantics": "normative",
-      "family": "non_functional_requirements",
-      "id": "non_functional-requirement-4",
-      "missing_fields": [],
-      "name": "",
-      "normative_ready": true,
-      "readiness_status": "ready",
-      "semantic_id": "non_functional-requirement-4",
-      "source_key": "non_functional_requirements",
-      "source_round": 4,
-      "text": "audit trail"
-    },
-    {
-      "attributes": {
-        "requirement_kind": "non_functional"
-      },
-      "blocking_ambiguity_ids": [],
-      "change_metadata": {
-        "change_source": "requirements",
-        "last_changed_at": "",
-        "regenerated_from_version": "",
-        "semantic_hash": "124f23d7f07094d7",
-        "semantic_version": 1,
-        "supersedes": []
-      },
-      "content_semantics": "normative",
-      "family": "non_functional_requirements",
-      "id": "non_functional-requirement-5",
-      "missing_fields": [],
-      "name": "",
-      "normative_ready": true,
-      "readiness_status": "ready",
-      "semantic_id": "non_functional-requirement-5",
-      "source_key": "non_functional_requirements",
-      "source_round": 4,
-      "text": "search"
-    },
-    {
-      "attributes": {
-        "requirement_kind": "non_functional"
-      },
-      "blocking_ambiguity_ids": [],
-      "change_metadata": {
-        "change_source": "requirements",
-        "last_changed_at": "",
-        "regenerated_from_version": "",
-        "semantic_hash": "cefdf9f48c729e40",
-        "semantic_version": 1,
-        "supersedes": []
-      },
-      "content_semantics": "normative",
-      "family": "non_functional_requirements",
-      "id": "non_functional-requirement-6",
-      "missing_fields": [],
-      "name": "",
-      "normative_ready": true,
-      "readiness_status": "ready",
-      "semantic_id": "non_functional-requirement-6",
-      "source_key": "non_functional_requirements",
-      "source_round": 4,
-      "text": "filtering"
     },
     {
       "attributes": {
@@ -3062,6 +2804,12 @@
     "blocking_ambiguity_ids": [],
     "element_count": 82,
     "partial_or_blocked_normative_ids": [
+      "acceptance-constraint-requirement-2",
+      "acceptance-constraint-requirement-3",
+      "acceptance-constraint-requirement-4",
+      "acceptance-constraint-requirement-5",
+      "acceptance-constraint-requirement-6",
+      "acceptance-constraint-success-1",
       "business-rule-1",
       "business-rule-2",
       "business-rule-3",
@@ -3073,6 +2821,11 @@
       "entity-system",
       "guard-condition-1",
       "guard-condition-2",
+      "non_functional-requirement-2",
+      "non_functional-requirement-3",
+      "non_functional-requirement-4",
+      "non_functional-requirement-5",
+      "non_functional-requirement-6",
       "relationship-1",
       "relationship-2",
       "relationship-3",
@@ -3092,28 +2845,17 @@
       "see-costs",
       "track-lifecycle-state"
     ],
-    "ready_normative_count": 29,
+    "ready_normative_count": 18,
     "ready_normative_ids": [
       "acceptance-constraint-requirement-1",
-      "acceptance-constraint-requirement-2",
-      "acceptance-constraint-requirement-3",
-      "acceptance-constraint-requirement-4",
-      "acceptance-constraint-requirement-5",
-      "acceptance-constraint-requirement-6",
       "acceptance-constraint-requirement-7",
       "acceptance-constraint-requirement-8",
-      "acceptance-constraint-success-1",
       "domain-invariant-1",
       "domain-invariant-2",
       "domain-invariant-3",
       "functional-requirement-1",
       "functional-requirement-2",
       "non_functional-requirement-1",
-      "non_functional-requirement-2",
-      "non_functional-requirement-3",
-      "non_functional-requirement-4",
-      "non_functional-requirement-5",
-      "non_functional-requirement-6",
       "non_functional-requirement-7",
       "non_functional-requirement-8",
       "state-invariant-1",

--- a/examples/it-systems-inventory-v2/model/rupify-model.json
+++ b/examples/it-systems-inventory-v2/model/rupify-model.json
@@ -292,9 +292,11 @@
           "content_semantics": "normative",
           "family": "acceptance_constraints",
           "id": "acceptance-constraint-requirement-2",
-          "missing_fields": [],
-          "normative_ready": true,
-          "status": "ready"
+          "missing_fields": [
+            "behavioral_semantics"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
         },
         "semantic_id": "acceptance-constraint-requirement-2",
         "source_requirement_id": "non_functional-requirement-2",
@@ -324,9 +326,11 @@
           "content_semantics": "normative",
           "family": "acceptance_constraints",
           "id": "acceptance-constraint-requirement-3",
-          "missing_fields": [],
-          "normative_ready": true,
-          "status": "ready"
+          "missing_fields": [
+            "behavioral_semantics"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
         },
         "semantic_id": "acceptance-constraint-requirement-3",
         "source_requirement_id": "non_functional-requirement-3",
@@ -356,9 +360,11 @@
           "content_semantics": "normative",
           "family": "acceptance_constraints",
           "id": "acceptance-constraint-requirement-4",
-          "missing_fields": [],
-          "normative_ready": true,
-          "status": "ready"
+          "missing_fields": [
+            "behavioral_semantics"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
         },
         "semantic_id": "acceptance-constraint-requirement-4",
         "source_requirement_id": "non_functional-requirement-4",
@@ -388,9 +394,11 @@
           "content_semantics": "normative",
           "family": "acceptance_constraints",
           "id": "acceptance-constraint-requirement-5",
-          "missing_fields": [],
-          "normative_ready": true,
-          "status": "ready"
+          "missing_fields": [
+            "behavioral_semantics"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
         },
         "semantic_id": "acceptance-constraint-requirement-5",
         "source_requirement_id": "non_functional-requirement-5",
@@ -420,9 +428,11 @@
           "content_semantics": "normative",
           "family": "acceptance_constraints",
           "id": "acceptance-constraint-requirement-6",
-          "missing_fields": [],
-          "normative_ready": true,
-          "status": "ready"
+          "missing_fields": [
+            "behavioral_semantics"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
         },
         "semantic_id": "acceptance-constraint-requirement-6",
         "source_requirement_id": "non_functional-requirement-6",
@@ -516,9 +526,11 @@
           "content_semantics": "normative",
           "family": "acceptance_constraints",
           "id": "acceptance-constraint-success-1",
-          "missing_fields": [],
-          "normative_ready": true,
-          "status": "ready"
+          "missing_fields": [
+            "behavioral_semantics"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
         },
         "semantic_id": "acceptance-constraint-success-1",
         "source_requirement_id": "",
@@ -1615,9 +1627,11 @@
           "content_semantics": "normative",
           "family": "requirements",
           "id": "non_functional-requirement-2",
-          "missing_fields": [],
-          "normative_ready": true,
-          "status": "ready"
+          "missing_fields": [
+            "behavioral_semantics"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
         },
         "requirement_kind": "non_functional",
         "semantic_id": "non_functional-requirement-2",
@@ -1649,9 +1663,11 @@
           "content_semantics": "normative",
           "family": "requirements",
           "id": "non_functional-requirement-3",
-          "missing_fields": [],
-          "normative_ready": true,
-          "status": "ready"
+          "missing_fields": [
+            "behavioral_semantics"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
         },
         "requirement_kind": "non_functional",
         "semantic_id": "non_functional-requirement-3",
@@ -1683,9 +1699,11 @@
           "content_semantics": "normative",
           "family": "requirements",
           "id": "non_functional-requirement-4",
-          "missing_fields": [],
-          "normative_ready": true,
-          "status": "ready"
+          "missing_fields": [
+            "behavioral_semantics"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
         },
         "requirement_kind": "non_functional",
         "semantic_id": "non_functional-requirement-4",
@@ -1717,9 +1735,11 @@
           "content_semantics": "normative",
           "family": "requirements",
           "id": "non_functional-requirement-5",
-          "missing_fields": [],
-          "normative_ready": true,
-          "status": "ready"
+          "missing_fields": [
+            "behavioral_semantics"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
         },
         "requirement_kind": "non_functional",
         "semantic_id": "non_functional-requirement-5",
@@ -1751,9 +1771,11 @@
           "content_semantics": "normative",
           "family": "requirements",
           "id": "non_functional-requirement-6",
-          "missing_fields": [],
-          "normative_ready": true,
-          "status": "ready"
+          "missing_fields": [
+            "behavioral_semantics"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
         },
         "requirement_kind": "non_functional",
         "semantic_id": "non_functional-requirement-6",
@@ -2998,45 +3020,55 @@
           "content_semantics": "normative",
           "family": "acceptance_constraints",
           "id": "acceptance-constraint-requirement-2",
-          "missing_fields": [],
-          "normative_ready": true,
-          "status": "ready"
+          "missing_fields": [
+            "behavioral_semantics"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
         },
         {
           "blocking_ambiguity_ids": [],
           "content_semantics": "normative",
           "family": "acceptance_constraints",
           "id": "acceptance-constraint-requirement-3",
-          "missing_fields": [],
-          "normative_ready": true,
-          "status": "ready"
+          "missing_fields": [
+            "behavioral_semantics"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
         },
         {
           "blocking_ambiguity_ids": [],
           "content_semantics": "normative",
           "family": "acceptance_constraints",
           "id": "acceptance-constraint-requirement-4",
-          "missing_fields": [],
-          "normative_ready": true,
-          "status": "ready"
+          "missing_fields": [
+            "behavioral_semantics"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
         },
         {
           "blocking_ambiguity_ids": [],
           "content_semantics": "normative",
           "family": "acceptance_constraints",
           "id": "acceptance-constraint-requirement-5",
-          "missing_fields": [],
-          "normative_ready": true,
-          "status": "ready"
+          "missing_fields": [
+            "behavioral_semantics"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
         },
         {
           "blocking_ambiguity_ids": [],
           "content_semantics": "normative",
           "family": "acceptance_constraints",
           "id": "acceptance-constraint-requirement-6",
-          "missing_fields": [],
-          "normative_ready": true,
-          "status": "ready"
+          "missing_fields": [
+            "behavioral_semantics"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
         },
         {
           "blocking_ambiguity_ids": [],
@@ -3061,9 +3093,11 @@
           "content_semantics": "normative",
           "family": "acceptance_constraints",
           "id": "acceptance-constraint-success-1",
-          "missing_fields": [],
-          "normative_ready": true,
-          "status": "ready"
+          "missing_fields": [
+            "behavioral_semantics"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
         }
       ],
       "ambiguities": [],
@@ -3154,45 +3188,55 @@
           "content_semantics": "normative",
           "family": "requirements",
           "id": "non_functional-requirement-2",
-          "missing_fields": [],
-          "normative_ready": true,
-          "status": "ready"
+          "missing_fields": [
+            "behavioral_semantics"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
         },
         {
           "blocking_ambiguity_ids": [],
           "content_semantics": "normative",
           "family": "requirements",
           "id": "non_functional-requirement-3",
-          "missing_fields": [],
-          "normative_ready": true,
-          "status": "ready"
+          "missing_fields": [
+            "behavioral_semantics"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
         },
         {
           "blocking_ambiguity_ids": [],
           "content_semantics": "normative",
           "family": "requirements",
           "id": "non_functional-requirement-4",
-          "missing_fields": [],
-          "normative_ready": true,
-          "status": "ready"
+          "missing_fields": [
+            "behavioral_semantics"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
         },
         {
           "blocking_ambiguity_ids": [],
           "content_semantics": "normative",
           "family": "requirements",
           "id": "non_functional-requirement-5",
-          "missing_fields": [],
-          "normative_ready": true,
-          "status": "ready"
+          "missing_fields": [
+            "behavioral_semantics"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
         },
         {
           "blocking_ambiguity_ids": [],
           "content_semantics": "normative",
           "family": "requirements",
           "id": "non_functional-requirement-6",
-          "missing_fields": [],
-          "normative_ready": true,
-          "status": "ready"
+          "missing_fields": [
+            "behavioral_semantics"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
         },
         {
           "blocking_ambiguity_ids": [],
@@ -3375,6 +3419,17 @@
     },
     "summary": {
       "blocked_normative_ids": [
+        "non_functional-requirement-2",
+        "non_functional-requirement-3",
+        "non_functional-requirement-4",
+        "non_functional-requirement-5",
+        "non_functional-requirement-6",
+        "acceptance-constraint-requirement-2",
+        "acceptance-constraint-requirement-3",
+        "acceptance-constraint-requirement-4",
+        "acceptance-constraint-requirement-5",
+        "acceptance-constraint-requirement-6",
+        "acceptance-constraint-success-1",
         "register-a-system",
         "edit-metadata",
         "compare-overlapping-systems",
@@ -3392,22 +3447,11 @@
         "functional-requirement-1",
         "functional-requirement-2",
         "non_functional-requirement-1",
-        "non_functional-requirement-2",
-        "non_functional-requirement-3",
-        "non_functional-requirement-4",
-        "non_functional-requirement-5",
-        "non_functional-requirement-6",
         "non_functional-requirement-7",
         "non_functional-requirement-8",
         "acceptance-constraint-requirement-1",
-        "acceptance-constraint-requirement-2",
-        "acceptance-constraint-requirement-3",
-        "acceptance-constraint-requirement-4",
-        "acceptance-constraint-requirement-5",
-        "acceptance-constraint-requirement-6",
         "acceptance-constraint-requirement-7",
         "acceptance-constraint-requirement-8",
-        "acceptance-constraint-success-1",
         "state-transition-1",
         "state-transition-2",
         "state-transition-3",
@@ -4255,7 +4299,7 @@
       "change_source": "normalize_replay_to_model",
       "last_changed_at": "",
       "regenerated_from_version": "",
-      "semantic_hash": "51dcbc3465b3e466",
+      "semantic_hash": "a66d5f97f4bdfe16",
       "semantic_version": 1,
       "supersedes": []
     },
@@ -4829,9 +4873,11 @@
           "content_semantics": "normative",
           "family": "acceptance_constraints",
           "id": "acceptance-constraint-requirement-2",
-          "missing_fields": [],
-          "normative_ready": true,
-          "status": "ready"
+          "missing_fields": [
+            "behavioral_semantics"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
         },
         "semantic_id": "acceptance-constraint-requirement-2",
         "source_requirement_id": "non_functional-requirement-2",
@@ -4861,9 +4907,11 @@
           "content_semantics": "normative",
           "family": "acceptance_constraints",
           "id": "acceptance-constraint-requirement-3",
-          "missing_fields": [],
-          "normative_ready": true,
-          "status": "ready"
+          "missing_fields": [
+            "behavioral_semantics"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
         },
         "semantic_id": "acceptance-constraint-requirement-3",
         "source_requirement_id": "non_functional-requirement-3",
@@ -4893,9 +4941,11 @@
           "content_semantics": "normative",
           "family": "acceptance_constraints",
           "id": "acceptance-constraint-requirement-4",
-          "missing_fields": [],
-          "normative_ready": true,
-          "status": "ready"
+          "missing_fields": [
+            "behavioral_semantics"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
         },
         "semantic_id": "acceptance-constraint-requirement-4",
         "source_requirement_id": "non_functional-requirement-4",
@@ -4925,9 +4975,11 @@
           "content_semantics": "normative",
           "family": "acceptance_constraints",
           "id": "acceptance-constraint-requirement-5",
-          "missing_fields": [],
-          "normative_ready": true,
-          "status": "ready"
+          "missing_fields": [
+            "behavioral_semantics"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
         },
         "semantic_id": "acceptance-constraint-requirement-5",
         "source_requirement_id": "non_functional-requirement-5",
@@ -4957,9 +5009,11 @@
           "content_semantics": "normative",
           "family": "acceptance_constraints",
           "id": "acceptance-constraint-requirement-6",
-          "missing_fields": [],
-          "normative_ready": true,
-          "status": "ready"
+          "missing_fields": [
+            "behavioral_semantics"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
         },
         "semantic_id": "acceptance-constraint-requirement-6",
         "source_requirement_id": "non_functional-requirement-6",
@@ -5053,9 +5107,11 @@
           "content_semantics": "normative",
           "family": "acceptance_constraints",
           "id": "acceptance-constraint-success-1",
-          "missing_fields": [],
-          "normative_ready": true,
-          "status": "ready"
+          "missing_fields": [
+            "behavioral_semantics"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
         },
         "semantic_id": "acceptance-constraint-success-1",
         "source_requirement_id": "",
@@ -5239,9 +5295,11 @@
           "content_semantics": "normative",
           "family": "requirements",
           "id": "non_functional-requirement-2",
-          "missing_fields": [],
-          "normative_ready": true,
-          "status": "ready"
+          "missing_fields": [
+            "behavioral_semantics"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
         },
         "requirement_kind": "non_functional",
         "semantic_id": "non_functional-requirement-2",
@@ -5273,9 +5331,11 @@
           "content_semantics": "normative",
           "family": "requirements",
           "id": "non_functional-requirement-3",
-          "missing_fields": [],
-          "normative_ready": true,
-          "status": "ready"
+          "missing_fields": [
+            "behavioral_semantics"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
         },
         "requirement_kind": "non_functional",
         "semantic_id": "non_functional-requirement-3",
@@ -5307,9 +5367,11 @@
           "content_semantics": "normative",
           "family": "requirements",
           "id": "non_functional-requirement-4",
-          "missing_fields": [],
-          "normative_ready": true,
-          "status": "ready"
+          "missing_fields": [
+            "behavioral_semantics"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
         },
         "requirement_kind": "non_functional",
         "semantic_id": "non_functional-requirement-4",
@@ -5341,9 +5403,11 @@
           "content_semantics": "normative",
           "family": "requirements",
           "id": "non_functional-requirement-5",
-          "missing_fields": [],
-          "normative_ready": true,
-          "status": "ready"
+          "missing_fields": [
+            "behavioral_semantics"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
         },
         "requirement_kind": "non_functional",
         "semantic_id": "non_functional-requirement-5",
@@ -5375,9 +5439,11 @@
           "content_semantics": "normative",
           "family": "requirements",
           "id": "non_functional-requirement-6",
-          "missing_fields": [],
-          "normative_ready": true,
-          "status": "ready"
+          "missing_fields": [
+            "behavioral_semantics"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
         },
         "requirement_kind": "non_functional",
         "semantic_id": "non_functional-requirement-6",

--- a/examples/loyalty-platform-v2/artifacts/formal/requirements-spec.md
+++ b/examples/loyalty-platform-v2/artifacts/formal/requirements-spec.md
@@ -46,9 +46,9 @@ Legacy loyalty operations are fragmented across channels and teams, causing inco
 - `acceptance-constraint-requirement-5` The system must show point balance and available rewards to eligible members. (semantics: normative; kind: non_functional_requirement; requirement: non_functional-requirement-5; readiness: ready; source: round 4 non_functional_requirements)
 - `acceptance-constraint-requirement-6` The system must allow members to redeem rewards when eligibility conditions are satisfied. (semantics: normative; kind: non_functional_requirement; requirement: non_functional-requirement-6; readiness: ready; source: round 4 non_functional_requirements)
 - `acceptance-constraint-requirement-7` The system must provide reporting on redemptions and campaign performance. (semantics: normative; kind: non_functional_requirement; requirement: non_functional-requirement-7; readiness: ready; source: round 4 non_functional_requirements)
-- `acceptance-constraint-success-1` Members can enroll and redeem rewards through one coherent digital journey. (semantics: normative; kind: success_criterion; readiness: ready; source: round 2 success_criteria)
+- `acceptance-constraint-success-1` Members can enroll and redeem rewards through one coherent digital journey. (semantics: normative; kind: success_criterion; readiness: blocked; source: round 2 success_criteria)
 - `acceptance-constraint-success-2` Operations managers can update the reward catalog without engineering support for routine changes. (semantics: normative; kind: success_criterion; readiness: ready; source: round 2 success_criteria)
-- `acceptance-constraint-success-3` The business can review redemption and campaign performance in one reporting workflow. (semantics: normative; kind: success_criterion; readiness: ready; source: round 2 success_criteria)
+- `acceptance-constraint-success-3` The business can review redemption and campaign performance in one reporting workflow. (semantics: normative; kind: success_criterion; readiness: blocked; source: round 2 success_criteria)
 
 
 ## Logical View

--- a/examples/loyalty-platform-v2/bundle-manifest.json
+++ b/examples/loyalty-platform-v2/bundle-manifest.json
@@ -15,7 +15,7 @@
       "change_source": "normalize_replay_to_model",
       "last_changed_at": "",
       "regenerated_from_version": "",
-      "semantic_hash": "fa990c5b15c56d66",
+      "semantic_hash": "dc346a5a027d9c30",
       "semantic_version": 1,
       "supersedes": []
     },

--- a/examples/loyalty-platform-v2/exports/speckify-planning-export.json
+++ b/examples/loyalty-platform-v2/exports/speckify-planning-export.json
@@ -199,10 +199,12 @@
       "content_semantics": "normative",
       "family": "acceptance_constraints",
       "id": "acceptance-constraint-success-1",
-      "missing_fields": [],
+      "missing_fields": [
+        "behavioral_semantics"
+      ],
       "name": "Success Criterion 1",
-      "normative_ready": true,
-      "readiness_status": "ready",
+      "normative_ready": false,
+      "readiness_status": "blocked",
       "semantic_id": "acceptance-constraint-success-1",
       "source_key": "success_criteria",
       "source_round": 2,
@@ -249,10 +251,12 @@
       "content_semantics": "normative",
       "family": "acceptance_constraints",
       "id": "acceptance-constraint-success-3",
-      "missing_fields": [],
+      "missing_fields": [
+        "behavioral_semantics"
+      ],
       "name": "Success Criterion 3",
-      "normative_ready": true,
-      "readiness_status": "ready",
+      "normative_ready": false,
+      "readiness_status": "blocked",
       "semantic_id": "acceptance-constraint-success-3",
       "source_key": "success_criteria",
       "source_round": 2,
@@ -3353,7 +3357,7 @@
       "change_source": "normalize_replay_to_model",
       "last_changed_at": "",
       "regenerated_from_version": "",
-      "semantic_hash": "fa990c5b15c56d66",
+      "semantic_hash": "dc346a5a027d9c30",
       "semantic_version": 1,
       "supersedes": []
     },
@@ -3551,31 +3555,6 @@
         "change_source": "derived_acceptance_constraints",
         "last_changed_at": "",
         "regenerated_from_version": "",
-        "semantic_hash": "50e151c1183f5872",
-        "semantic_version": 1,
-        "supersedes": []
-      },
-      "content_semantics": "normative",
-      "family": "acceptance_constraints",
-      "id": "acceptance-constraint-success-1",
-      "missing_fields": [],
-      "name": "Success Criterion 1",
-      "normative_ready": true,
-      "readiness_status": "ready",
-      "semantic_id": "acceptance-constraint-success-1",
-      "source_key": "success_criteria",
-      "source_round": 2,
-      "text": "Members can enroll and redeem rewards through one coherent digital journey."
-    },
-    {
-      "attributes": {
-        "constraint_kind": "success_criterion"
-      },
-      "blocking_ambiguity_ids": [],
-      "change_metadata": {
-        "change_source": "derived_acceptance_constraints",
-        "last_changed_at": "",
-        "regenerated_from_version": "",
         "semantic_hash": "2abb9a2aa9983c0a",
         "semantic_version": 1,
         "supersedes": []
@@ -3591,31 +3570,6 @@
       "source_key": "success_criteria",
       "source_round": 2,
       "text": "Operations managers can update the reward catalog without engineering support for routine changes."
-    },
-    {
-      "attributes": {
-        "constraint_kind": "success_criterion"
-      },
-      "blocking_ambiguity_ids": [],
-      "change_metadata": {
-        "change_source": "derived_acceptance_constraints",
-        "last_changed_at": "",
-        "regenerated_from_version": "",
-        "semantic_hash": "489ea823b5173325",
-        "semantic_version": 1,
-        "supersedes": []
-      },
-      "content_semantics": "normative",
-      "family": "acceptance_constraints",
-      "id": "acceptance-constraint-success-3",
-      "missing_fields": [],
-      "name": "Success Criterion 3",
-      "normative_ready": true,
-      "readiness_status": "ready",
-      "semantic_id": "acceptance-constraint-success-3",
-      "source_key": "success_criteria",
-      "source_round": 2,
-      "text": "The business can review redemption and campaign performance in one reporting workflow."
     },
     {
       "attributes": {
@@ -5553,6 +5507,8 @@
     "blocking_ambiguity_ids": [],
     "element_count": 108,
     "partial_or_blocked_normative_ids": [
+      "acceptance-constraint-success-1",
+      "acceptance-constraint-success-3",
       "business-rule-1",
       "business-rule-2",
       "business-rule-3",
@@ -5574,7 +5530,7 @@
       "trigger-1",
       "trigger-2"
     ],
-    "ready_normative_count": 62,
+    "ready_normative_count": 60,
     "ready_normative_ids": [
       "acceptance-constraint-requirement-1",
       "acceptance-constraint-requirement-2",
@@ -5583,9 +5539,7 @@
       "acceptance-constraint-requirement-5",
       "acceptance-constraint-requirement-6",
       "acceptance-constraint-requirement-7",
-      "acceptance-constraint-success-1",
       "acceptance-constraint-success-2",
-      "acceptance-constraint-success-3",
       "domain-invariant-1",
       "domain-invariant-2",
       "domain-invariant-3",

--- a/examples/loyalty-platform-v2/model/rupify-model.json
+++ b/examples/loyalty-platform-v2/model/rupify-model.json
@@ -345,9 +345,11 @@
           "content_semantics": "normative",
           "family": "acceptance_constraints",
           "id": "acceptance-constraint-success-1",
-          "missing_fields": [],
-          "normative_ready": true,
-          "status": "ready"
+          "missing_fields": [
+            "behavioral_semantics"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
         },
         "semantic_id": "acceptance-constraint-success-1",
         "source_requirement_id": "",
@@ -409,9 +411,11 @@
           "content_semantics": "normative",
           "family": "acceptance_constraints",
           "id": "acceptance-constraint-success-3",
-          "missing_fields": [],
-          "normative_ready": true,
-          "status": "ready"
+          "missing_fields": [
+            "behavioral_semantics"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
         },
         "semantic_id": "acceptance-constraint-success-3",
         "source_requirement_id": "",
@@ -4269,9 +4273,11 @@
           "content_semantics": "normative",
           "family": "acceptance_constraints",
           "id": "acceptance-constraint-success-1",
-          "missing_fields": [],
-          "normative_ready": true,
-          "status": "ready"
+          "missing_fields": [
+            "behavioral_semantics"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
         },
         {
           "blocking_ambiguity_ids": [],
@@ -4287,9 +4293,11 @@
           "content_semantics": "normative",
           "family": "acceptance_constraints",
           "id": "acceptance-constraint-success-3",
-          "missing_fields": [],
-          "normative_ready": true,
-          "status": "ready"
+          "missing_fields": [
+            "behavioral_semantics"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
         }
       ],
       "ambiguities": [],
@@ -4793,6 +4801,8 @@
     },
     "summary": {
       "blocked_normative_ids": [
+        "acceptance-constraint-success-1",
+        "acceptance-constraint-success-3",
         "guard-condition-1"
       ],
       "informative_ids": [],
@@ -4814,9 +4824,7 @@
         "acceptance-constraint-requirement-5",
         "acceptance-constraint-requirement-6",
         "acceptance-constraint-requirement-7",
-        "acceptance-constraint-success-1",
         "acceptance-constraint-success-2",
-        "acceptance-constraint-success-3",
         "enroll-member",
         "browse-rewards",
         "redeem-reward",
@@ -5997,7 +6005,7 @@
       "change_source": "normalize_replay_to_model",
       "last_changed_at": "",
       "regenerated_from_version": "",
-      "semantic_hash": "fa990c5b15c56d66",
+      "semantic_hash": "dc346a5a027d9c30",
       "semantic_version": 1,
       "supersedes": []
     },
@@ -6834,9 +6842,11 @@
           "content_semantics": "normative",
           "family": "acceptance_constraints",
           "id": "acceptance-constraint-success-1",
-          "missing_fields": [],
-          "normative_ready": true,
-          "status": "ready"
+          "missing_fields": [
+            "behavioral_semantics"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
         },
         "semantic_id": "acceptance-constraint-success-1",
         "source_requirement_id": "",
@@ -6898,9 +6908,11 @@
           "content_semantics": "normative",
           "family": "acceptance_constraints",
           "id": "acceptance-constraint-success-3",
-          "missing_fields": [],
-          "normative_ready": true,
-          "status": "ready"
+          "missing_fields": [
+            "behavioral_semantics"
+          ],
+          "normative_ready": false,
+          "status": "blocked"
         },
         "semantic_id": "acceptance-constraint-success-3",
         "source_requirement_id": "",

--- a/src/rupify_tools/readiness.py
+++ b/src/rupify_tools/readiness.py
@@ -392,11 +392,93 @@ def _base_element_result(
     }
 
 
+def _has_normalized_substructure(item: dict[str, Any]) -> bool:
+    """Return whether an element already carries explicit normalized semantic detail."""
+    for key in ("sub_obligations", "sub_actions", "guard_parts", "invariant_clauses"):
+        value = item.get(key, [])
+        if isinstance(value, list) and value:
+            return True
+    return False
+
+
+def _text_is_behaviorally_explicit(text: str) -> bool:
+    """Return whether a constraint text is explicit enough for downstream implementation."""
+    cleaned = str(text).strip().lower()
+    if not cleaned:
+        return False
+    if any(operator in cleaned for operator in (">=", "<=", "==", "!=", ">", "<")):
+        return True
+    if len(cleaned.split()) < 3:
+        return False
+    return any(
+        marker in cleaned
+        for marker in (
+            " must ",
+            " shall ",
+            " should ",
+            " cannot ",
+            " may not ",
+            " remain ",
+            " remains ",
+            " ensure ",
+            " ensures ",
+            " provide ",
+            " provides ",
+            " protect ",
+            " protects ",
+            " support ",
+            " supports ",
+            " allow ",
+            " allows ",
+            " integrate ",
+            " integrates ",
+            " show ",
+            " shows ",
+            " record ",
+            " records ",
+        )
+    )
+
+
+def _constraint_like_semantics_ready(
+    item: dict[str, Any],
+    family: str,
+    requirement_lookup: dict[str, dict[str, Any]],
+) -> bool:
+    """Return whether a constraint-like normative element carries enough explicit semantics."""
+    if family == "requirements" and item.get("requirement_kind") != "non_functional":
+        return True
+    if family not in {"requirements", "acceptance_constraints"}:
+        return True
+
+    text = str(item.get("statement") or item.get("description") or "").strip()
+    if _has_normalized_substructure(item) or _text_is_behaviorally_explicit(text):
+        return True
+
+    source_requirement_id = str(item.get("source_requirement_id", "")).strip()
+    source_requirement = requirement_lookup.get(source_requirement_id, {})
+    if source_requirement and (
+        _has_normalized_substructure(source_requirement)
+        or _text_is_behaviorally_explicit(source_requirement.get("statement", ""))
+    ):
+        return True
+
+    return False
+
+
 def evaluate_element_readiness(model: dict[str, Any]) -> dict[str, Any]:
     """Evaluate readiness on individual canonical elements that downstream tools consume."""
     analysis_view = model.get("analysis_view", {})
     process_view = model.get("process_view", {})
     unresolved_ambiguities = _unresolved_ambiguity_ids_by_element(model)
+    requirement_lookup = {
+        str(item.get("id", "")).strip(): item
+        for item in (
+            model.get("requirements", {}).get("functional_objects", [])
+            + model.get("requirements", {}).get("non_functional_objects", [])
+        )
+        if str(item.get("id", "")).strip()
+    }
 
     family_specs = {
         "requirements": (
@@ -466,10 +548,18 @@ def evaluate_element_readiness(model: dict[str, Any]) -> dict[str, Any]:
     by_family: dict[str, list[dict[str, Any]]] = {}
     all_items = []
     for family, (items, requirement_builder) in family_specs.items():
-        family_results = [
-            _base_element_result(item, family, requirement_builder(item), unresolved_ambiguities)
-            for item in items
-        ]
+        family_results = []
+        for item in items:
+            result = _base_element_result(item, family, requirement_builder(item), unresolved_ambiguities)
+            if (
+                item.get("content_semantics") == "normative"
+                and result["status"] == "ready"
+                and not _constraint_like_semantics_ready(item, family, requirement_lookup)
+            ):
+                result["missing_fields"].append("behavioral_semantics")
+                result["status"] = "blocked"
+                result["normative_ready"] = False
+            family_results.append(result)
         by_family[family] = family_results
         all_items.extend(family_results)
 

--- a/tests/test_interview.py
+++ b/tests/test_interview.py
@@ -75,6 +75,10 @@ class InterviewHarnessTests(unittest.TestCase):
         self.assertEqual(replay["traceability_validation"]["requirement_to_use_case"]["status"], "blocked")
         self.assertEqual(
             replay["element_readiness_validation"]["summary"]["ready_normative_ids"],
+            [],
+        )
+        self.assertEqual(
+            replay["element_readiness_validation"]["summary"]["blocked_normative_ids"],
             [
                 "non_functional-requirement-1",
                 "acceptance-constraint-requirement-1",

--- a/tests/test_readiness.py
+++ b/tests/test_readiness.py
@@ -411,14 +411,48 @@ class ReadinessTests(unittest.TestCase):
                         "id": "functional-requirement-1",
                         "statement": "Approve system changes",
                         "content_semantics": "normative",
+                    },
+                    {
+                        "id": "functional-requirement-2",
+                        "statement": "Support approvals such as manager approval and security approval",
+                        "content_semantics": "normative",
+                        "sub_obligations": [
+                            {"id": "functional-requirement-2-obligation-1"},
+                            {"id": "functional-requirement-2-obligation-2"},
+                        ],
                     }
                 ],
-                "non_functional_objects": [],
+                "non_functional_objects": [
+                    {
+                        "id": "non-functional-requirement-1",
+                        "statement": "SSO",
+                        "requirement_kind": "non_functional",
+                        "content_semantics": "normative",
+                    },
+                    {
+                        "id": "non-functional-requirement-2",
+                        "statement": "The system must retain an audit trail for approval changes",
+                        "requirement_kind": "non_functional",
+                        "content_semantics": "normative",
+                    },
+                ],
                 "acceptance_constraint_objects": [
                     {
                         "id": "acceptance-constraint-1",
-                        "description": "SSO is required",
+                        "description": "SSO",
                         "content_semantics": "normative",
+                        "source_requirement_id": "non-functional-requirement-1",
+                    },
+                    {
+                        "id": "acceptance-constraint-2",
+                        "description": "Audit trail retention must be enforced for approval changes",
+                        "content_semantics": "normative",
+                    },
+                    {
+                        "id": "acceptance-constraint-3",
+                        "description": "Audit trail retention",
+                        "content_semantics": "normative",
+                        "source_requirement_id": "non-functional-requirement-2",
                     }
                 ],
             },
@@ -493,7 +527,12 @@ class ReadinessTests(unittest.TestCase):
         validation = evaluate_element_readiness(model)
 
         self.assertIn("functional-requirement-1", validation["summary"]["ready_normative_ids"])
-        self.assertIn("acceptance-constraint-1", validation["summary"]["ready_normative_ids"])
+        self.assertIn("functional-requirement-2", validation["summary"]["ready_normative_ids"])
+        self.assertIn("non-functional-requirement-2", validation["summary"]["ready_normative_ids"])
+        self.assertIn("acceptance-constraint-2", validation["summary"]["ready_normative_ids"])
+        self.assertIn("acceptance-constraint-3", validation["summary"]["ready_normative_ids"])
+        self.assertIn("non-functional-requirement-1", validation["summary"]["blocked_normative_ids"])
+        self.assertIn("acceptance-constraint-1", validation["summary"]["blocked_normative_ids"])
         self.assertIn("approve-system", validation["summary"]["partial_normative_ids"])
         self.assertIn("scenario-approval", validation["summary"]["blocked_normative_ids"])
         self.assertIn("ambiguity-open-question-1", validation["summary"]["informative_ids"])
@@ -503,3 +542,21 @@ class ReadinessTests(unittest.TestCase):
             ["ambiguity-open-question-1"],
         )
         self.assertEqual(validation["by_family"]["scenarios"][0]["missing_fields"], ["flow_of_events"])
+        requirements_by_id = {
+            item["id"]: item for item in validation["by_family"]["requirements"]
+        }
+        self.assertIn(
+            "behavioral_semantics",
+            requirements_by_id["non-functional-requirement-1"]["missing_fields"],
+        )
+        acceptance_constraints_by_id = {
+            item["id"]: item for item in validation["by_family"]["acceptance_constraints"]
+        }
+        self.assertIn(
+            "behavioral_semantics",
+            acceptance_constraints_by_id["acceptance-constraint-1"]["missing_fields"],
+        )
+        self.assertNotIn(
+            "behavioral_semantics",
+            acceptance_constraints_by_id["acceptance-constraint-3"]["missing_fields"],
+        )


### PR DESCRIPTION
Closes #168

## Summary
- tighten the generic readiness gate for constraint-like normative elements in the canonical readiness layer
- block terse shorthand from becoming `normative_ready` unless it carries explicit behavioral semantics or normalized substructure
- refresh the checked-in CMDB and loyalty V2 bundles so their model snapshots and Speckify exports reflect the new readiness contract

## Verification
- uv run python -m unittest tests.test_readiness tests.test_interview
- uv run python -m unittest